### PR TITLE
Add ignore directives for IDE configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,10 @@ ENV/
 env.bak/
 venv.bak/
 
+# IDE configs
+.idea/
+.vscode/
+
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
This PR adds `.gitignore` directives to ignore config files created by PyCharm (which I use) and VS Code (which is also quite popular).