### PR TITLE
Related to #65 - Web service awaits db readiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,8 @@ COPY requirements-dev.txt /code/
 RUN pip install -r requirements.txt
 RUN pip install -r requirements-dev.txt
 COPY . /code/
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,16 +4,16 @@ services:
   db:
     image: postgres
     environment:
-      - POSTGRES_DB=mathesar_django
-      - POSTGRES_USER=mathesar
-      - POSTGRES_PASSWORD=mathesar
+      - POSTGRES_DB=${POSTGRES_DB-mathesar_django}
+      - POSTGRES_USER=${POSTGRES_USER-mathesar}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD-mathesar}
     ports:
       - "5432:5432"
     volumes:
       - ./.volumes:/var/lib/postgresql/data
   web:
     build: .
-    command: python manage.py runserver 0.0.0.0:8000
+    command: dockerize -wait tcp://db:5432 -timeout 30s python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/code
     ports:


### PR DESCRIPTION
## This PR:
* Waits for db to start accepting connections
* Accepts DB connection params as environment variables

## Approach
- This PR uses [dockerize](https://github.com/jwilder/dockerize), one of the recommended utils from [docker docs to control startup behaviour](https://docs.docker.com/compose/startup-order/)
- This PR avoids using service health checks, [an alternate approach](https://stackoverflow.com/a/55835081). Reason: Docker compose [version 3 no longer supports the condition form](https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on) of depends_on, and health checks are meant for monitoring, a overhead we don't need for this specific issue.   

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
