### PR TITLE
API updates to unblock frontend work

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,11 @@ TEST_DB = "mathesar_db_test_database"
 
 
 @pytest.fixture(scope="session")
+def test_db_name():
+    return TEST_DB
+
+
+@pytest.fixture(scope="session")
 def test_db():
     superuser_engine = _get_superuser_engine()
     with superuser_engine.connect() as conn:

--- a/mathesar/serializers.py
+++ b/mathesar/serializers.py
@@ -4,7 +4,21 @@ from rest_framework import serializers
 from mathesar.models import Table, Schema
 
 
+class NestedTableSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Table
+        fields = ['id', 'name', 'url']
+
+    def get_url(self, obj):
+        request = self.context['request']
+        return request.build_absolute_uri(reverse('table-detail', kwargs={'pk': obj.pk}))
+
+
 class SchemaSerializer(serializers.HyperlinkedModelSerializer):
+    tables = NestedTableSerializer(many=True, read_only=True)
+
     class Meta:
         model = Schema
         fields = ['id', 'name', 'database', 'tables']

--- a/mathesar/templates/mathesar/index.html
+++ b/mathesar/templates/mathesar/index.html
@@ -42,3 +42,7 @@
     {% endif %}
   </div>
 {% endblock %}
+
+{% block scripts %}
+   {{ schema_data|json_script:"schema-data" }}
+{% endblock %}

--- a/mathesar/tests/imports/test_csv.py
+++ b/mathesar/tests/imports/test_csv.py
@@ -5,37 +5,37 @@ from sqlalchemy.exc import InvalidRequestError
 from mathesar.imports.csv import create_table_from_csv
 
 
-def test_csv_upload_with_all_required_parameters(engine, csv_filename):
+def test_csv_upload_with_all_required_parameters(engine, csv_filename, test_db_name):
     with open(csv_filename, 'rb') as csv_file:
         table = create_table_from_csv(
             name='NASA',
             schema='Patents',
-            database_key='mathesar_db_test_database',
+            database_key=test_db_name,
             csv_file=csv_file
         )
         assert table is not None
         assert table.name == 'NASA'
         assert table.schema.name == 'Patents'
-        assert table.schema.database == 'mathesar_db_test_database'
+        assert table.schema.database == test_db_name
         assert table.sa_num_records == 1393
 
 
-def test_csv_upload_with_parameters_positional(engine, csv_filename):
+def test_csv_upload_with_parameters_positional(engine, csv_filename, test_db_name):
     with open(csv_filename, 'rb') as csv_file:
         table = create_table_from_csv(
             'NASA 2',
             'Patents',
-            'mathesar_db_test_database',
+            test_db_name,
             csv_file
         )
         assert table is not None
         assert table.name == 'NASA 2'
         assert table.schema.name == 'Patents'
-        assert table.schema.database == 'mathesar_db_test_database'
+        assert table.schema.database == test_db_name
         assert table.sa_num_records == 1393
 
 
-def test_csv_upload_with_duplicate_table_name(engine, csv_filename):
+def test_csv_upload_with_duplicate_table_name(engine, csv_filename, test_db_name):
     schema_name = 'Patents'
     table_name = 'NASA 3'
     already_defined_str = (
@@ -46,32 +46,32 @@ def test_csv_upload_with_duplicate_table_name(engine, csv_filename):
         table = create_table_from_csv(
             table_name,
             schema_name,
-            'mathesar_db_test_database',
+            test_db_name,
             csv_file
         )
         assert table is not None
         assert table.name == table_name
         assert table.schema.name == schema_name
-        assert table.schema.database == 'mathesar_db_test_database'
+        assert table.schema.database == test_db_name
         assert table.sa_num_records == 1393
     with open(csv_filename, 'rb') as csv_file:
         with pytest.raises(InvalidRequestError) as excinfo:
             create_table_from_csv(
                 table_name,
                 schema_name,
-                'mathesar_db_test_database',
+                test_db_name,
                 csv_file
             )
             assert already_defined_str in str(excinfo)
 
 
-def test_csv_upload_with_wrong_parameter(engine, csv_filename):
+def test_csv_upload_with_wrong_parameter(engine, csv_filename, test_db_name):
     with pytest.raises(TypeError) as excinfo:
         with open(csv_filename, 'rb') as csv_file:
             create_table_from_csv(
                 name='NASA',
                 schema_name='Patents',
-                database_key='mathesar_db_test_database',
+                database_key=test_db_name,
                 csv_file=csv_file
             )
             assert 'unexpected keyword' in str(excinfo.value)

--- a/mathesar/tests/settings.py
+++ b/mathesar/tests/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from pathlib import Path
 
+from conftest import TEST_DB
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -84,9 +86,9 @@ DATABASES = {
         "HOST": "db",
         "PORT": 5432,
     },
-    "mathesar_db_test_database": {
+    TEST_DB: {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "mathesar_db_test_database",
+        "NAME": TEST_DB,
         "USER": "mathesar",
         "PASSWORD": "mathesar",
         "HOST": "db",

--- a/mathesar/tests/views/api/conftest.py
+++ b/mathesar/tests/views/api/conftest.py
@@ -10,13 +10,13 @@ def client():
 
 
 @pytest.fixture
-def create_table(engine, csv_filename):
+def create_table(engine, csv_filename, test_db_name):
     def _create_table(table_name):
         with open(csv_filename, 'rb') as csv_file:
             create_table_from_csv(
                 name=table_name,
                 schema='Patents',
-                database_key='mathesar_db_test_database',
+                database_key=test_db_name,
                 csv_file=csv_file
             )
 

--- a/mathesar/tests/views/api/test_database_key_api.py
+++ b/mathesar/tests/views/api/test_database_key_api.py
@@ -1,0 +1,10 @@
+def test_database_key_list(client, test_db_name):
+    """
+    Desired format:
+    ['mathesar_tables']
+    """
+    response = client.get('/api/v0/database_keys/')
+    response_data = response.json()
+    assert response.status_code == 200
+    assert len(response_data) == 1
+    assert response_data[0] == test_db_name

--- a/mathesar/tests/views/api/test_schema_api.py
+++ b/mathesar/tests/views/api/test_schema_api.py
@@ -1,10 +1,10 @@
 from mathesar.models import Schema
 
 
-def check_schema_response(response_schema, schema, schema_name):
+def check_schema_response(response_schema, schema, schema_name, test_db_name):
     assert response_schema['id'] == schema.id
     assert response_schema['name'] == schema_name
-    assert response_schema['database'] == 'mathesar_db_test_database'
+    assert response_schema['database'] == test_db_name
     assert len(response_schema['tables']) == 1
     response_table = response_schema['tables'][0]
     assert 'id' in response_table
@@ -14,7 +14,7 @@ def check_schema_response(response_schema, schema, schema_name):
     assert response_table['url'].endswith(f'/api/v0/tables/{response_table_id}/')
 
 
-def test_schema_list(create_table, client):
+def test_schema_list(create_table, client, test_db_name):
     """
     Desired format:
     {
@@ -45,10 +45,10 @@ def test_schema_list(create_table, client):
     assert response.status_code == 200
     assert response_data['count'] == 1
     assert len(response_data['results']) == 1
-    check_schema_response(response_schema, schema, 'Patents')
+    check_schema_response(response_schema, schema, 'Patents', test_db_name)
 
 
-def test_schema_detail(create_table, client):
+def test_schema_detail(create_table, client, test_db_name):
     """
     Desired format:
     One item in the results list in the schema list view, see above.
@@ -59,7 +59,7 @@ def test_schema_detail(create_table, client):
     response = client.get(f'/api/v0/schemas/{schema.id}/')
     response_schema = response.json()
     assert response.status_code == 200
-    check_schema_response(response_schema, schema, 'Patents')
+    check_schema_response(response_schema, schema, 'Patents', test_db_name)
 
 
 def test_schema_404(create_table, client):

--- a/mathesar/tests/views/api/test_schema_api.py
+++ b/mathesar/tests/views/api/test_schema_api.py
@@ -7,8 +7,11 @@ def check_schema_response(response_schema, schema, schema_name):
     assert response_schema['database'] == 'mathesar_db_test_database'
     assert len(response_schema['tables']) == 1
     response_table = response_schema['tables'][0]
-    assert response_table.startswith('http')
-    assert '/api/v0/tables/' in response_table
+    assert 'id' in response_table
+    response_table_id = response_table['id']
+    assert 'name' in response_table
+    assert response_table['url'].startswith('http')
+    assert response_table['url'].endswith(f'/api/v0/tables/{response_table_id}/')
 
 
 def test_schema_list(create_table, client):
@@ -22,7 +25,12 @@ def test_schema_list(create_table, client):
                 "name": "Patents",
                 "database": "mathesar_tables",
                 "tables": [
-                    "http://testserver/api/v0/tables/1/",
+                    {
+                        "id": 1,
+                        "name": "Fairfax County",
+                        "url": "http://testserver/api/v0/tables/1/",
+                    }
+
                 ]
             }
         ]

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -7,6 +7,7 @@ from mathesar.views import api, frontend
 router = routers.DefaultRouter()
 router.register(r'tables', api.TableViewSet)
 router.register(r'schemas', api.SchemaViewSet)
+router.register(r'database_keys', api.DatabaseKeyViewSet, basename='database_keys')
 
 records_router = routers.NestedSimpleRouter(router, r'tables', lookup='table')
 records_router.register(r'records', api.RecordViewSet, basename='table-records')

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -2,6 +2,7 @@ from rest_framework import status, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
+from mathesar.database.utils import get_non_default_database_keys
 from mathesar.models import Table, Schema
 from mathesar.pagination import DefaultLimitOffsetPagination, TableLimitOffsetPagination
 from mathesar.serializers import TableSerializer, SchemaSerializer, RecordSerializer
@@ -57,3 +58,8 @@ class RecordViewSet(viewsets.ViewSet):
         table = Table.objects.get(id=table_pk)
         table.delete_record(pk)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class DatabaseKeyViewSet(viewsets.ViewSet):
+    def list(self, request):
+        return Response(get_non_default_database_keys())

--- a/mathesar/views/frontend.py
+++ b/mathesar/views/frontend.py
@@ -5,7 +5,8 @@ from django.views.generic import DetailView
 
 from mathesar.forms.forms import UploadFileForm
 from mathesar.imports.csv import create_table_from_csv
-from mathesar.models import Table
+from mathesar.models import Table, Schema
+from mathesar.serializers import SchemaSerializer
 
 
 def index(request):
@@ -24,12 +25,14 @@ def index(request):
             )
     else:
         form = UploadFileForm()
+    schema_serializer = SchemaSerializer(Schema.objects.all(), many=True, context={'request': request})
     return render(
         request,
         "mathesar/index.html",
         {
             "form": form,
             "tables": sorted(tables, key=lambda x: x.schema.name),
+            "schema_data": schema_serializer.data
         },
     )
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #109

<!-- Concisely describe what the pull request does. -->
- Updates schema API to include ID and table names for all tables
- Adds database keys list API
- Pre-renders serialized schema data in the homepage, to provide example to @pavish 

**Technical details**
- I removed the repeated use of the test database name as a string, replacing it with a single source of truth (the root `conftest.py` file)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
