### PR TITLE
Extract repeated fixtures

### DIFF
--- a/db/tests/types/fixtures.py
+++ b/db/tests/types/fixtures.py
@@ -1,3 +1,11 @@
+"""
+The fixtures defined here are specifically defined in a non-standard
+location in order to avoid them being automatically picked up by pytest
+and made available to all test files.  Specifically, we should not use
+these in testing either `db.types.base`, or `db.types.install`, since
+those are imports that are used in these fixtures.
+"""
+
 import pytest
 from sqlalchemy.schema import CreateSchema, DropSchema
 from db.engine import _add_custom_types_to_engine

--- a/db/tests/types/fixtures.py
+++ b/db/tests/types/fixtures.py
@@ -1,0 +1,31 @@
+import pytest
+from sqlalchemy.schema import CreateSchema, DropSchema
+from db.engine import _add_custom_types_to_engine
+from db.types import base, install
+
+TEST_SCHEMA = "test_schema"
+
+
+@pytest.fixture
+def engine_with_types(engine):
+    _add_custom_types_to_engine(engine)
+    return engine
+
+
+@pytest.fixture
+def temporary_testing_schema(engine_with_types):
+    schema = TEST_SCHEMA
+    with engine_with_types.begin() as conn:
+        conn.execute(CreateSchema(schema))
+    yield engine_with_types, schema
+    with engine_with_types.begin() as conn:
+        conn.execute(DropSchema(schema, cascade=True, if_exists=True))
+
+
+@pytest.fixture
+def engine_email_type(temporary_testing_schema):
+    engine, schema = temporary_testing_schema
+    install.install_mathesar_on_database(engine)
+    yield engine, schema
+    with engine.begin() as conn:
+        conn.execute(DropSchema(base.SCHEMA, cascade=True, if_exists=True))

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -3,37 +3,17 @@ from decimal import Decimal
 import pytest
 from sqlalchemy import Table, Column, MetaData
 from sqlalchemy import String, Numeric
-from sqlalchemy.schema import CreateSchema, DropSchema
 from db import types
-from db.engine import _add_custom_types_to_engine
-from db.types import alteration, base, install
-
-TEST_SCHEMA = "test_schema"
+from db.tests.types import fixtures
+from db.types import alteration
 
 
-@pytest.fixture
-def engine_with_types(engine):
-    _add_custom_types_to_engine(engine)
-    return engine
-
-
-@pytest.fixture
-def temporary_testing_schema(engine_with_types):
-    schema = TEST_SCHEMA
-    with engine_with_types.begin() as conn:
-        conn.execute(CreateSchema(schema))
-    yield engine_with_types, schema
-    with engine_with_types.begin() as conn:
-        conn.execute(DropSchema(schema, cascade=True, if_exists=True))
-
-
-@pytest.fixture
-def engine_email_type(temporary_testing_schema):
-    engine, schema = temporary_testing_schema
-    install.install_mathesar_on_database(engine)
-    yield engine, schema
-    with engine.begin() as conn:
-        conn.execute(DropSchema(base.SCHEMA, cascade=True, if_exists=True))
+# We need to set these variables when the file loads, or pytest can't
+# properly detect the fixtures.  Importing them directly results in a
+# flake8 unused import error.
+engine_with_types = fixtures.engine_with_types
+engine_email_type = fixtures.engine_email_type
+temporary_testing_schema = fixtures.temporary_testing_schema
 
 
 def test_get_alter_column_types_with_standard_engine(engine):

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -10,7 +10,7 @@ from db.types import alteration
 
 # We need to set these variables when the file loads, or pytest can't
 # properly detect the fixtures.  Importing them directly results in a
-# flake8 unused import error.
+# flake8 unused import error, and a bunch of flake8 F811 errors.
 engine_with_types = fixtures.engine_with_types
 engine_email_type = fixtures.engine_email_type
 temporary_testing_schema = fixtures.temporary_testing_schema

--- a/db/tests/types/test_email.py
+++ b/db/tests/types/test_email.py
@@ -9,7 +9,7 @@ from db.types import email
 
 # We need to set these variables when the file loads, or pytest can't
 # properly detect the fixtures.  Importing them directly results in a
-# flake8 unused import error.
+# flake8 unused import error, and a bunch of flake8 F811 errors.
 engine_with_types = fixtures.engine_with_types
 engine_email_type = fixtures.engine_email_type
 temporary_testing_schema = fixtures.temporary_testing_schema

--- a/db/tests/types/test_email.py
+++ b/db/tests/types/test_email.py
@@ -3,52 +3,36 @@ import pytest
 from sqlalchemy import text, select, func, Table, Column, MetaData
 from sqlalchemy.exc import IntegrityError
 from db.engine import _add_custom_types_to_engine
-from db.types import install
+from db.tests.types import fixtures
 from db.types import email
 
 
-@pytest.fixture
-def engine_type_schema(engine):
-    install.create_type_schema(engine)
-    yield engine
-    with engine.begin() as conn:
-        conn.execute(
-            text(f"DROP SCHEMA IF EXISTS {install.base.SCHEMA} CASCADE;")
-        )
-
-
-@pytest.fixture
-def engine_email_type(engine_type_schema):
-    email.create_email_type(engine_type_schema)
-    return engine_type_schema
-
-
-@pytest.fixture
-def engine_with_app(engine_email_type):
-    app_schema = "test_app"
-    with engine_email_type.begin() as conn:
-        conn.execute(text(f"CREATE SCHEMA {app_schema};"))
-    yield engine_email_type, app_schema
-    with engine_email_type.begin() as conn:
-        conn.execute(text(f"DROP SCHEMA {app_schema} CASCADE;"))
+# We need to set these variables when the file loads, or pytest can't
+# properly detect the fixtures.  Importing them directly results in a
+# flake8 unused import error.
+engine_with_types = fixtures.engine_with_types
+engine_email_type = fixtures.engine_email_type
+temporary_testing_schema = fixtures.temporary_testing_schema
 
 
 def test_domain_func_wrapper(engine_email_type):
+    engine, _ = engine_email_type
     sel = select(func.email_domain_name(text("'test@example.com'")))
-    with engine_email_type.begin() as conn:
+    with engine.begin() as conn:
         res = conn.execute(sel)
         assert res.fetchone()[0] == "example.com"
 
 
 def test_local_part_func_wrapper(engine_email_type):
+    engine, _ = engine_email_type
     sel = select(func.email_local_part(text("'test@example.com'")))
-    with engine_email_type.begin() as conn:
+    with engine.begin() as conn:
         res = conn.execute(sel)
         assert res.fetchone()[0] == "test"
 
 
-def test_email_type_column_creation(engine_with_app):
-    engine, app_schema = engine_with_app
+def test_email_type_column_creation(engine_email_type):
+    engine, app_schema = engine_email_type
     with engine.begin() as conn:
         conn.execute(text(f"SET search_path={app_schema}"))
         metadata = MetaData(bind=conn)
@@ -60,8 +44,8 @@ def test_email_type_column_creation(engine_with_app):
         test_table.create()
 
 
-def test_email_type_column_reflection(engine_with_app):
-    engine, app_schema = engine_with_app
+def test_email_type_column_reflection(engine_email_type):
+    engine, app_schema = engine_email_type
     with engine.begin() as conn:
         metadata = MetaData(bind=conn, schema=app_schema)
         test_table = Table(
@@ -81,9 +65,10 @@ def test_email_type_column_reflection(engine_with_app):
 
 
 def test_create_email_type_domain_passes_correct_emails(engine_email_type):
+    engine, _ = engine_email_type
     email_addresses_correct = ["alice@example.com", "alice@example"]
     for address in email_addresses_correct:
-        with engine_email_type.begin() as conn:
+        with engine.begin() as conn:
             res = conn.execute(
                 text(f"SELECT '{address}'::{email.QUALIFIED_EMAIL};")
             )
@@ -91,9 +76,10 @@ def test_create_email_type_domain_passes_correct_emails(engine_email_type):
 
 
 def test_create_email_type_domain_checks_broken_emails(engine_email_type):
+    engine, _ = engine_email_type
     address_incorrect = "aliceexample.com"
     with pytest.raises(IntegrityError) as e:
-        with engine_email_type.begin() as conn:
+        with engine.begin() as conn:
             conn.execute(
                 text(
                     f"SELECT '{address_incorrect}'::{email.QUALIFIED_EMAIL};"

--- a/db/tests/types/test_inference.py
+++ b/db/tests/types/test_inference.py
@@ -7,7 +7,7 @@ from db.types import inference
 
 # We need to set these variables when the file loads, or pytest can't
 # properly detect the fixtures.  Importing them directly results in a
-# flake8 unused import error.
+# flake8 unused import error, and a bunch of flake8 F811 errors
 engine_with_types = fixtures.engine_with_types
 engine_email_type = fixtures.engine_email_type
 temporary_testing_schema = fixtures.temporary_testing_schema

--- a/db/tests/types/test_inference.py
+++ b/db/tests/types/test_inference.py
@@ -1,36 +1,16 @@
 import pytest
 from sqlalchemy import Column, MetaData, Table
 from sqlalchemy import BOOLEAN, Numeric, NUMERIC, String, VARCHAR
-from sqlalchemy.schema import CreateSchema, DropSchema
-from db.engine import _add_custom_types_to_engine
-from db.types import base, inference, install
-
-TEST_SCHEMA = "test_schema"
+from db.tests.types import fixtures
+from db.types import inference
 
 
-@pytest.fixture
-def engine_with_types(engine):
-    _add_custom_types_to_engine(engine)
-    return engine
-
-
-@pytest.fixture
-def temporary_testing_schema(engine_with_types):
-    schema = TEST_SCHEMA
-    with engine_with_types.begin() as conn:
-        conn.execute(CreateSchema(schema))
-    yield engine_with_types, schema
-    with engine_with_types.begin() as conn:
-        conn.execute(DropSchema(schema, cascade=True, if_exists=True))
-
-
-@pytest.fixture
-def engine_email_type(temporary_testing_schema):
-    engine, schema = temporary_testing_schema
-    install.install_mathesar_on_database(engine)
-    yield engine, schema
-    with engine.begin() as conn:
-        conn.execute(DropSchema(base.SCHEMA, cascade=True, if_exists=True))
+# We need to set these variables when the file loads, or pytest can't
+# properly detect the fixtures.  Importing them directly results in a
+# flake8 unused import error.
+engine_with_types = fixtures.engine_with_types
+engine_email_type = fixtures.engine_email_type
+temporary_testing_schema = fixtures.temporary_testing_schema
 
 
 type_data_list = [


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #136 

<!-- Concisely describe what the pull request does. -->

This extracts some repeated (or similar) fixtures to their own file, `db/tests/types/fixtures.py`.  These are used in the test files:
- `db/tests/types/test_alteration.py`,
- `db/tests/types/test_inference.py`, and
- `db/tests/types/test_email.py`.
These should _not_ be used for testing `db/types/base.py` or `db/types/install.py`, since they use code from those modules.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
