### PR TITLE
Ensure pytest-django doesn't make an extra database

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -74,6 +74,8 @@ DATABASES = {
     decouple_config('MATHESAR_DATABASE_KEY'): decouple_config('MATHESAR_DATABASE_URL', cast=db_url)
 }
 
+# pytest-django will create a new database named 'test_{DATABASES[table_db]['NAME']}'
+# and use it for our API tests if we don't specify DATABASES[table_db]['TEST']['NAME']
 if decouple_config('TEST', default=False, cast=bool):
     DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['TEST'] = {
         'NAME': DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['NAME']

--- a/config/settings.py
+++ b/config/settings.py
@@ -73,9 +73,11 @@ DATABASES = {
     decouple_config('DJANGO_DATABASE_KEY'): decouple_config('DJANGO_DATABASE_URL', cast=db_url),
     decouple_config('MATHESAR_DATABASE_KEY'): decouple_config('MATHESAR_DATABASE_URL', cast=db_url)
 }
-DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['TEST'] = {
-    'NAME': DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['NAME']
-}
+
+if decouple_config('TEST', default=False, cast=bool):
+    DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['TEST'] = {
+        'NAME': DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['NAME']
+    }
 
 
 # Quick-start development settings - unsuitable for production

--- a/config/settings.py
+++ b/config/settings.py
@@ -73,6 +73,9 @@ DATABASES = {
     decouple_config('DJANGO_DATABASE_KEY'): decouple_config('DJANGO_DATABASE_URL', cast=db_url),
     decouple_config('MATHESAR_DATABASE_KEY'): decouple_config('MATHESAR_DATABASE_URL', cast=db_url)
 }
+DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['TEST'] = {
+    'NAME': DATABASES[decouple_config('MATHESAR_DATABASE_KEY')]['NAME']
+}
 
 
 # Quick-start development settings - unsuitable for production

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,4 @@ env =
 	DJANGO_DATABASE_URL=postgres://mathesar:mathesar@db:5432/mathesar_django
 	MATHESAR_DATABASE_KEY=mathesar_db_test
 	MATHESAR_DATABASE_URL=postgres://mathesar:mathesar@db:5432/mathesar_db_test
+	TEST=True


### PR DESCRIPTION
Fixes #283 

Updates `settings.py` to ensure that `pytest-django` won't make an additional database.

**Technical details**
Adds a line to `settings.py` that sets `DATABASES[mathesar_db_name]['TEST']['NAME']` equal to `DATABASES[mathesar_db_name]['NAME']` at test time.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
