### PR TITLE
Record sorting

### DIFF
--- a/db/records.py
+++ b/db/records.py
@@ -42,7 +42,7 @@ def get_records(
     """
     query = select(table)
     if order_by:
-        query = apply_sort(query, order_by, table)
+        query = apply_sort(query, order_by)
     query = (
         query
         .limit(limit)

--- a/db/records.py
+++ b/db/records.py
@@ -1,7 +1,7 @@
 import logging
 from sqlalchemy import delete, select, Column
 from sqlalchemy.inspection import inspect
-from sqlalchemy_filters import apply_filters
+from sqlalchemy_filters import apply_filters, apply_sort
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +40,11 @@ def get_records(
                   field, in addition to an 'value' field if appropriate.
                   See: https://github.com/centerofci/sqlalchemy-filters#filters-format
     """
+    query = select(table)
+    if order_by:
+        query = apply_sort(query, order_by, table)
     query = (
-        select(table)
-        .order_by(*order_by)
+        query
         .limit(limit)
         .offset(offset)
     )

--- a/db/records.py
+++ b/db/records.py
@@ -33,9 +33,9 @@ def get_records(
         engine:   SQLAlchemy engine object
         limit:    int, gives number of rows to return
         offset:   int, gives number of rows to skip
-        order_by: list of SQLAlchemy ColumnElements to order by.  Should
-                  usually be either a list of string column names, or a
-                  list of columns from the given table.
+        order_by: list of dictionaries, where each dictionary has a 'field' and
+                  'direction' field.
+                  See https://github.com/centerofci/sqlalchemy-filters for details.
         filters:  list of dictionaries, where each dictionary has a 'field' and 'op'
                   field, in addition to an 'value' field if appropriate.
                   See: https://github.com/centerofci/sqlalchemy-filters#filters-format

--- a/db/records.py
+++ b/db/records.py
@@ -35,7 +35,7 @@ def get_records(
         offset:   int, gives number of rows to skip
         order_by: list of dictionaries, where each dictionary has a 'field' and
                   'direction' field.
-                  See https://github.com/centerofci/sqlalchemy-filters for details.
+                  See: https://github.com/centerofci/sqlalchemy-filters#sort-format
         filters:  list of dictionaries, where each dictionary has a 'field' and 'op'
                   field, in addition to an 'value' field if appropriate.
                   See: https://github.com/centerofci/sqlalchemy-filters#filters-format

--- a/db/tests/records/test_records.py
+++ b/db/tests/records/test_records.py
@@ -43,51 +43,59 @@ def test_get_records_gets_limited_offset_records(roster_table_obj):
 
 def test_get_records_gets_ordered_records_str_col_name(roster_table_obj):
     roster, engine = roster_table_obj
-    record_list = records.get_records(roster, engine, order_by=["Teacher"])
+    order_list = [{"field": "Teacher", "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
     assert record_list[0][4] == "Amber Hudson"
 
 
 def test_get_records_gets_ordered_records_num_col(roster_table_obj):
     roster, engine = roster_table_obj
-    record_list = records.get_records(roster, engine, order_by=["Grade"])
+    order_list = [{"field": "Grade", "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
     assert record_list[0][7] == 25
 
 
 def test_get_records_gets_ordered_records_str_col_obj(roster_table_obj):
     roster, engine = roster_table_obj
-    teacher_col = roster.columns["Teacher"]
-    record_list = records.get_records(roster, engine, order_by=[teacher_col])
+    order_list = [{"field": roster.columns["Teacher"], "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
     assert record_list[0][4] == "Amber Hudson"
 
 
 def test_get_records_gets_ordered_records_num_col_obj(roster_table_obj):
     roster, engine = roster_table_obj
-    grade_col = roster.columns["Grade"]
-    record_list = records.get_records(roster, engine, order_by=[grade_col])
+    order_list = [{"field": roster.columns["Grade"], "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
     assert record_list[0][7] == 25
 
 
 def test_get_records_ordered_col_set(roster_table_obj):
     roster, engine = roster_table_obj
-    record_list = records.get_records(
-        roster, engine, order_by=["Student Name", "Grade"]
-    )
+    order_list = [
+        {"field": "Student Name", "direction": "asc"},
+        {"field": "Grade", "direction": "asc"}
+    ]
+    record_list = records.get_records(roster, engine, order_by=order_list)
     assert record_list[0][2] == "Alejandro Lam" and record_list[0][7] == 40
 
 
 def test_get_records_ordered_col_set_different_col_order(roster_table_obj):
     roster, engine = roster_table_obj
-    record_list = records.get_records(
-        roster, engine, order_by=["Grade", "Student Name"]
-    )
+    order_list = [
+        {"field": "Grade", "direction": "asc"},
+        {"field": "Student Name", "direction": "asc"}
+    ]
+    record_list = records.get_records(roster, engine, order_by=order_list)
     assert record_list[0][7] == 25 and record_list[0][2] == "Amy Gamble"
 
 
 def test_get_records_orders_before_limiting(roster_table_obj):
     roster, engine = roster_table_obj
-    record_list = records.get_records(
-        roster, engine, limit=1, order_by=["Grade", "Student Name"]
-    )
+    order_list = [
+        {"field": "Grade", "direction": "asc"},
+        {"field": "Student Name", "direction": "asc"}
+    ]
+    record_list = records.get_records(roster, engine, limit=1, order_by=order_list)
     assert record_list[0][7] == 25 and record_list[0][2] == "Amy Gamble"
 
 

--- a/db/tests/records/test_records.py
+++ b/db/tests/records/test_records.py
@@ -41,64 +41,6 @@ def test_get_records_gets_limited_offset_records(roster_table_obj):
     assert len(offset_records) == 10 and offset_records[0] == base_records[5]
 
 
-def test_get_records_gets_ordered_records_str_col_name(roster_table_obj):
-    roster, engine = roster_table_obj
-    order_list = [{"field": "Teacher", "direction": "asc"}]
-    record_list = records.get_records(roster, engine, order_by=order_list)
-    assert record_list[0][4] == "Amber Hudson"
-
-
-def test_get_records_gets_ordered_records_num_col(roster_table_obj):
-    roster, engine = roster_table_obj
-    order_list = [{"field": "Grade", "direction": "asc"}]
-    record_list = records.get_records(roster, engine, order_by=order_list)
-    assert record_list[0][7] == 25
-
-
-def test_get_records_gets_ordered_records_str_col_obj(roster_table_obj):
-    roster, engine = roster_table_obj
-    order_list = [{"field": roster.columns["Teacher"], "direction": "asc"}]
-    record_list = records.get_records(roster, engine, order_by=order_list)
-    assert record_list[0][4] == "Amber Hudson"
-
-
-def test_get_records_gets_ordered_records_num_col_obj(roster_table_obj):
-    roster, engine = roster_table_obj
-    order_list = [{"field": roster.columns["Grade"], "direction": "asc"}]
-    record_list = records.get_records(roster, engine, order_by=order_list)
-    assert record_list[0][7] == 25
-
-
-def test_get_records_ordered_col_set(roster_table_obj):
-    roster, engine = roster_table_obj
-    order_list = [
-        {"field": "Student Name", "direction": "asc"},
-        {"field": "Grade", "direction": "asc"}
-    ]
-    record_list = records.get_records(roster, engine, order_by=order_list)
-    assert record_list[0][2] == "Alejandro Lam" and record_list[0][7] == 40
-
-
-def test_get_records_ordered_col_set_different_col_order(roster_table_obj):
-    roster, engine = roster_table_obj
-    order_list = [
-        {"field": "Grade", "direction": "asc"},
-        {"field": "Student Name", "direction": "asc"}
-    ]
-    record_list = records.get_records(roster, engine, order_by=order_list)
-    assert record_list[0][7] == 25 and record_list[0][2] == "Amy Gamble"
-
-
-def test_get_records_orders_before_limiting(roster_table_obj):
-    roster, engine = roster_table_obj
-    order_list = [
-        {"field": "Grade", "direction": "asc"},
-        {"field": "Student Name", "direction": "asc"}
-    ]
-    record_list = records.get_records(roster, engine, limit=1, order_by=order_list)
-    assert record_list[0][7] == 25 and record_list[0][2] == "Amy Gamble"
-
-
 def test_get_distinct_tuple_values_length(roster_table_obj):
     roster, engine = roster_table_obj
     column_list = [

--- a/db/tests/records/test_sorting.py
+++ b/db/tests/records/test_sorting.py
@@ -1,0 +1,158 @@
+import re
+import pytest
+from datetime import datetime
+
+from sqlalchemy import MetaData, Table
+from sqlalchemy_filters.exceptions import BadFilterFormat, FilterFieldNotFound
+
+from db import records
+
+
+ROSTER = "Roster"
+FILTERSORT = "FilterSort"
+
+
+@pytest.fixture
+def roster_table_obj(engine_with_roster):
+    engine, schema = engine_with_roster
+    metadata = MetaData(bind=engine)
+    roster = Table(ROSTER, metadata, schema=schema, autoload_with=engine)
+    return roster, engine
+
+
+@pytest.fixture
+def filter_sort_table_obj(engine_with_filter_sort):
+    engine, schema = engine_with_filter_sort
+    metadata = MetaData(bind=engine)
+    roster = Table(FILTERSORT, metadata, schema=schema, autoload_with=engine)
+    return roster, engine
+
+
+def test_get_records_gets_ordered_records_str_col_name(roster_table_obj):
+    roster, engine = roster_table_obj
+    order_list = [{"field": "Teacher", "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
+    assert record_list[0][4] == "Amber Hudson"
+
+
+def test_get_records_gets_ordered_records_num_col(roster_table_obj):
+    roster, engine = roster_table_obj
+    order_list = [{"field": "Grade", "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
+    assert record_list[0][7] == 25
+
+
+def test_get_records_gets_ordered_records_str_col_obj(roster_table_obj):
+    roster, engine = roster_table_obj
+    order_list = [{"field": roster.columns["Teacher"], "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
+    assert record_list[0][4] == "Amber Hudson"
+
+
+def test_get_records_gets_ordered_records_num_col_obj(roster_table_obj):
+    roster, engine = roster_table_obj
+    order_list = [{"field": roster.columns["Grade"], "direction": "asc"}]
+    record_list = records.get_records(roster, engine, order_by=order_list)
+    assert record_list[0][7] == 25
+
+
+def test_get_records_ordered_col_set(roster_table_obj):
+    roster, engine = roster_table_obj
+    order_list = [
+        {"field": "Student Name", "direction": "asc"},
+        {"field": "Grade", "direction": "asc"}
+    ]
+    record_list = records.get_records(roster, engine, order_by=order_list)
+    assert record_list[0][2] == "Alejandro Lam" and record_list[0][7] == 40
+
+
+def test_get_records_ordered_col_set_different_col_order(roster_table_obj):
+    roster, engine = roster_table_obj
+    order_list = [
+        {"field": "Grade", "direction": "asc"},
+        {"field": "Student Name", "direction": "asc"}
+    ]
+    record_list = records.get_records(roster, engine, order_by=order_list)
+    assert record_list[0][7] == 25 and record_list[0][2] == "Amy Gamble"
+
+
+def test_get_records_orders_before_limiting(roster_table_obj):
+    roster, engine = roster_table_obj
+    order_list = [
+        {"field": "Grade", "direction": "asc"},
+        {"field": "Student Name", "direction": "asc"}
+    ]
+    record_list = records.get_records(roster, engine, limit=1, order_by=order_list)
+    assert record_list[0][7] == 25 and record_list[0][2] == "Amy Gamble"
+
+
+dir_to_python_func = {
+    "asc": lambda x, y: x <= y,
+    "desc": lambda x, y: x >= y,
+}
+
+
+single_field_test_list = [
+    (field, direction)
+    for field in ["varchar", "numeric", "date"]
+    for direction in ["asc", "desc"]
+]
+
+
+@pytest.mark.parametrize("field,direction", single_field_test_list)
+def test_get_records_orders_single_field(
+    filter_sort_table_obj, field, direction
+):
+    filter_sort, engine = filter_sort_table_obj
+    order_list = [{"field": field, "direction": direction}]
+
+    record_list = records.get_records(filter_sort, engine, order_by=order_list)
+
+    for i in range(1, len(record_list)):
+        prev = getattr(record_list[i - 1], field)
+        curr = getattr(record_list[i], field)
+        if prev is None or curr is None:
+            continue
+        comp_func = dir_to_python_func[direction]
+        assert comp_func(prev, curr)
+
+
+multi_field_test_list = [
+    list(zip(fields, directions))
+    for fields in [
+        ("Student Email", "Grade"),
+        ("Grade", "Student Email")
+    ]
+    for directions in [
+        ["asc", "asc"],
+        ["asc", "desc"],
+        ["desc", "asc"],
+        ["desc", "desc"],
+    ]
+]
+
+
+@pytest.mark.parametrize("field_dir_pairs", multi_field_test_list)
+def test_get_records_orders_multiple_fields(
+    roster_table_obj, field_dir_pairs
+):
+    roster_sort, engine = roster_table_obj
+    order_list = [
+        {"field": field, "direction": direction}
+        for field, direction in field_dir_pairs
+    ]
+
+    record_list = records.get_records(roster_sort, engine, order_by=order_list)
+
+    for i in range(1, len(record_list)):
+        prev_field_equal = True
+        for field, direction in field_dir_pairs:
+            prev = getattr(record_list[i - 1], field)
+            curr = getattr(record_list[i], field)
+            if prev is None or curr is None:
+                continue
+            comp_func = dir_to_python_func[direction]
+
+            # Only check order when previous field has equal values
+            assert not prev_field_equal or comp_func(prev, curr)
+            prev_field_equal = prev == curr

--- a/db/tests/records/test_sorting.py
+++ b/db/tests/records/test_sorting.py
@@ -91,20 +91,27 @@ dir_to_python_func = {
 
 
 single_field_test_list = [
-    (field, direction)
+    (field, direction, null)
     for field in ["varchar", "numeric", "date"]
     for direction in ["asc", "desc"]
+    for null in ["nullsfirst", "nullslast"]
 ]
 
 
-@pytest.mark.parametrize("field,direction", single_field_test_list)
+@pytest.mark.parametrize("field,direction,null", single_field_test_list)
 def test_get_records_orders_single_field(
-    filter_sort_table_obj, field, direction
+    filter_sort_table_obj, field, direction, null
 ):
     filter_sort, engine = filter_sort_table_obj
     order_list = [{"field": field, "direction": direction}]
+    order_list[0][null] = True
 
     record_list = records.get_records(filter_sort, engine, order_by=order_list)
+
+    if null == "nullsfirst":
+        assert getattr(record_list[0], field) is None
+    elif null == "nullslast":
+        assert getattr(record_list[-1], field) is None
 
     for i in range(1, len(record_list)):
         prev = getattr(record_list[i - 1], field)

--- a/db/tests/records/test_sorting.py
+++ b/db/tests/records/test_sorting.py
@@ -7,7 +7,7 @@ from db import records
 
 
 ROSTER = "Roster"
-FILTERSORT = "FilterSort"
+FILTER_SORT = "filter_sort"
 
 
 @pytest.fixture
@@ -22,7 +22,7 @@ def roster_table_obj(engine_with_roster):
 def filter_sort_table_obj(engine_with_filter_sort):
     engine, schema = engine_with_filter_sort
     metadata = MetaData(bind=engine)
-    roster = Table(FILTERSORT, metadata, schema=schema, autoload_with=engine)
+    roster = Table(FILTER_SORT, metadata, schema=schema, autoload_with=engine)
     return roster, engine
 
 

--- a/mathesar/forms/forms.py
+++ b/mathesar/forms/forms.py
@@ -33,3 +33,4 @@ class UploadFileForm(forms.Form):
 
 class RecordListFilterForm(forms.Form):
     filters = forms.JSONField(required=False, empty_value=[])
+    order_by = forms.JSONField(required=False, empty_value=[])

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -129,9 +129,9 @@ class Table(DatabaseObject):
     def get_record(self, id_value):
         return records.get_record(self._sa_table, self.schema._sa_engine, id_value)
 
-    def get_records(self, limit=None, offset=None, filters=[]):
+    def get_records(self, limit=None, offset=None, filters=[], order_by=[]):
         return records.get_records(self._sa_table, self.schema._sa_engine, limit,
-                                   offset, filters=filters)
+                                   offset, filters=filters, order_by=order_by)
 
     def create_record_or_records(self, record_data):
         return records.create_record_or_records(self._sa_table, self.schema._sa_engine, record_data)

--- a/mathesar/pagination.py
+++ b/mathesar/pagination.py
@@ -30,7 +30,7 @@ class ColumnLimitOffsetPagination(DefaultLimitOffsetPagination):
 
 class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
 
-    def paginate_queryset(self, queryset, request, table_id, filters=[]):
+    def paginate_queryset(self, queryset, request, table_id, filters=[], order_by=[]):
         self.limit = self.get_limit(request)
         if self.limit is None:
             self.limit = self.default_limit
@@ -39,4 +39,5 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
         table = queryset.get(id=table_id)
         self.count = table.sa_num_records
         self.request = request
-        return table.get_records(self.limit, self.offset, filters=filters)
+        return table.get_records(self.limit, self.offset,
+                                 filters=filters, order_by=order_by)

--- a/mathesar/tests/views/api/test_record_api.py
+++ b/mathesar/tests/views/api/test_record_api.py
@@ -86,20 +86,29 @@ def test_record_list_filter(create_table, client):
 
 
 def test_record_list_sort(create_table, client):
-    table_name = 'NASA Record List Filter'
+    table_name = 'NASA Record List Order'
     table = create_table(table_name)
 
     order_by = [
         {'field': 'Center', 'direction': 'desc'},
         {'field': 'Case Number', 'direction': 'asc'},
     ]
-    order_by = json.dumps(order_by)
-    response = client.get(f'/api/v0/tables/{table.id}/records/?order_by={order_by}')
-    response_data = response.json()
+    json_order_by = json.dumps(order_by)
+
+    with patch.object(
+        records, "get_records", side_effect=records.get_records
+    ) as mock_infer:
+        response = client.get(
+            f'/api/v0/tables/{table.id}/records/?order_by={json_order_by}'
+        )
+        response_data = response.json()
 
     assert response.status_code == 200
     assert response_data['count'] == 1393
     assert len(response_data['results']) == 50
+
+    assert mock_infer.call_args is not None
+    assert mock_infer.call_args[1]['order_by'] == order_by
 
 
 def test_record_list_pagination_limit(create_table, client):

--- a/mathesar/tests/views/api/test_record_api.py
+++ b/mathesar/tests/views/api/test_record_api.py
@@ -85,6 +85,23 @@ def test_record_list_filter(create_table, client):
     assert mock_infer.call_args[1]['filters'] == filter_list
 
 
+def test_record_list_sort(create_table, client):
+    table_name = 'NASA Record List Filter'
+    table = create_table(table_name)
+
+    order_by = [
+        {'field': 'Center', 'direction': 'desc'},
+        {'field': 'Case Number', 'direction': 'asc'},
+    ]
+    order_by = json.dumps(order_by)
+    response = client.get(f'/api/v0/tables/{table.id}/records/?order_by={order_by}')
+    response_data = response.json()
+
+    assert response.status_code == 200
+    assert response_data['count'] == 1393
+    assert len(response_data['results']) == 50
+
+
 def test_record_list_pagination_limit(create_table, client):
     table_name = 'NASA Record List Pagination Limit'
     table = create_table(table_name)

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -156,6 +156,8 @@ class RecordViewSet(viewsets.ViewSet):
 
     # For filter parameter formatting, see:
     # https://github.com/centerofci/sqlalchemy-filters#filters-format
+    # For sorting parameter formatting, see:
+    # https://github.com/centerofci/sqlalchemy-filters#sort-format
     def list(self, request, table_pk=None):
         paginator = TableLimitOffsetPagination()
 

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -6,9 +6,11 @@ from rest_framework.response import Response
 from django.core.cache import cache
 from rest_framework.decorators import action
 from django_filters import rest_framework as filters
-from sqlalchemy_filters.exceptions import BadFilterFormat, FieldNotFound
 from psycopg2.errors import DuplicateColumn, UndefinedFunction
 from sqlalchemy.exc import ProgrammingError
+from sqlalchemy_filters.exceptions import (
+    BadFilterFormat, BadSortFormat, FilterFieldNotFound, SortFieldNotFound,
+)
 
 
 from mathesar.database.utils import get_non_default_database_keys
@@ -168,8 +170,10 @@ class RecordViewSet(viewsets.ViewSet):
                 filters=filter_form.cleaned_data['filters'],
                 order_by=filter_form.cleaned_data['order_by']
             )
-        except (FieldNotFound, BadFilterFormat) as e:
+        except (BadFilterFormat, FilterFieldNotFound) as e:
             raise ValidationError({'filters': e})
+        except (BadSortFormat, SortFieldNotFound) as e:
+            raise ValidationError({'order_by': e})
 
         serializer = RecordSerializer(records, many=True)
         return paginator.get_paginated_response(serializer.data)

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -165,7 +165,8 @@ class RecordViewSet(viewsets.ViewSet):
         try:
             records = paginator.paginate_queryset(
                 self.queryset, request, table_pk,
-                filters=filter_form.cleaned_data['filters']
+                filters=filter_form.cleaned_data['filters'],
+                order_by=filter_form.cleaned_data['order_by']
             )
         except (FieldNotFound, BadFilterFormat) as e:
             raise ValidationError({'filters': e})


### PR DESCRIPTION
Fixes #158 

Adds the option to sort the values returned from the record list endpoint.

**Technical details**
Modifies `records.get_records()` to use our fork of sqlalchemy_filters for sorting, and adds handling for the `order_by` url parameter to the record list endpoint.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
