### PR TITLE
Record grouping

### DIFF
--- a/db/records.py
+++ b/db/records.py
@@ -92,7 +92,8 @@ def get_group_counts(
     for field in group_by:
         if type(field) not in (str, Column):
             raise BadGroupFormat(f"Group field {field} must be a string or Column.")
-        if field not in table.c:
+        field_name = field if type(field) == str else field.name
+        if field_name not in table.c:
             raise GroupFieldNotFound(f"Group field {field} not found in {table}.")
 
     group_by = _create_col_objects(table, group_by)

--- a/db/records.py
+++ b/db/records.py
@@ -59,7 +59,7 @@ def get_records(
 
 
 def get_group_counts(
-        table, engine, limit=None, offset=None, order_by=[], filters=[], group_by=[],
+        table, engine, group_by, limit=None, offset=None, order_by=[], filters=[],
 ):
     """
     Returns counts by specified groupings
@@ -69,13 +69,13 @@ def get_group_counts(
         engine:   SQLAlchemy engine object
         limit:    int, gives number of rows to return
         offset:   int, gives number of rows to skip
+        group_by: list or tuple of column names or column objects to group by
         order_by: list of dictionaries, where each dictionary has a 'field' and
                   'direction' field.
                   See: https://github.com/centerofci/sqlalchemy-filters#sort-format
         filters:  list of dictionaries, where each dictionary has a 'field' and 'op'
                   field, in addition to an 'value' field if appropriate.
                   See: https://github.com/centerofci/sqlalchemy-filters#filters-format
-        group_count_by: list or tuple of column names or column objects to group by
     """
     group_by = _create_col_objects(table, group_by)
     query = (

--- a/db/records.py
+++ b/db/records.py
@@ -110,10 +110,9 @@ def get_group_counts(
     with engine.begin() as conn:
         records = conn.execute(query).fetchall()
 
-    # Use a tuple as the key if we are grouping by mutliple fields
     # Last field is the count, preceding fields are the group by fields
     counts = {
-        record[0] if len(group_by) == 1 else (*record[:-1],): record[-1]
+        (*record[:-1],): record[-1]
         for record in records
     }
     return counts

--- a/db/records.py
+++ b/db/records.py
@@ -62,7 +62,7 @@ def get_group_counts(
         table, engine, limit=None, offset=None, order_by=[], filters=[], group_by=[],
 ):
     """
-    Returns records from a table.
+    Returns counts by specified groupings
 
     Args:
         table:    SQLAlchemy table object
@@ -89,7 +89,11 @@ def get_group_counts(
     if filters is not None:
         query = apply_filters(query, filters)
     with engine.begin() as conn:
-        return conn.execute(query).fetchall()
+        records = conn.execute(query).fetchall()
+
+    # Last field is the count, preceding fields are the group by fields
+    counts = {(*record[:-1],): record[-1] for record in records}
+    return counts
 
 
 def get_distinct_tuple_values(

--- a/db/records.py
+++ b/db/records.py
@@ -91,8 +91,12 @@ def get_group_counts(
     with engine.begin() as conn:
         records = conn.execute(query).fetchall()
 
+    # Use a tuple as the key if we are grouping by mutliple fields
     # Last field is the count, preceding fields are the group by fields
-    counts = {(*record[:-1],): record[-1] for record in records}
+    counts = {
+        record[0] if len(group_by) == 1 else (*record[:-1],): record[-1]
+        for record in records
+    }
     return counts
 
 

--- a/db/tests/records/conftest.py
+++ b/db/tests/records/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+from sqlalchemy import MetaData, Table
+
+
+ROSTER = "Roster"
+FILTER_SORT = "filter_sort"
+
+
+@pytest.fixture
+def roster_table_obj(engine_with_roster):
+    engine, schema = engine_with_roster
+    metadata = MetaData(bind=engine)
+    roster = Table(ROSTER, metadata, schema=schema, autoload_with=engine)
+    return roster, engine
+
+
+@pytest.fixture
+def filter_sort_table_obj(engine_with_filter_sort):
+    engine, schema = engine_with_filter_sort
+    metadata = MetaData(bind=engine)
+    roster = Table(FILTER_SORT, metadata, schema=schema, autoload_with=engine)
+    return roster, engine

--- a/db/tests/records/test_filtering.py
+++ b/db/tests/records/test_filtering.py
@@ -2,30 +2,9 @@ import re
 import pytest
 from datetime import datetime
 
-from sqlalchemy import MetaData, Table
 from sqlalchemy_filters.exceptions import BadFilterFormat, FilterFieldNotFound
 
 from db import records
-
-
-ROSTER = "Roster"
-FILTER_SORT = "filter_sort"
-
-
-@pytest.fixture
-def roster_table_obj(engine_with_roster):
-    engine, schema = engine_with_roster
-    metadata = MetaData(bind=engine)
-    roster = Table(ROSTER, metadata, schema=schema, autoload_with=engine)
-    return roster, engine
-
-
-@pytest.fixture
-def filter_sort_table_obj(engine_with_filter_sort):
-    engine, schema = engine_with_filter_sort
-    metadata = MetaData(bind=engine)
-    roster = Table(FILTER_SORT, metadata, schema=schema, autoload_with=engine)
-    return roster, engine
 
 
 def test_get_records_filters_using_col_str_names(roster_table_obj):

--- a/db/tests/records/test_grouping.py
+++ b/db/tests/records/test_grouping.py
@@ -1,3 +1,9 @@
+import itertools
+from collections import Counter
+
+import pytest
+from sqlalchemy import select
+
 from db import records
 
 
@@ -32,6 +38,7 @@ def test_get_group_counts_limit_ordering(filter_sort_table_obj):
     group_by = [filter_sort.c.numeric]
     counts = records.get_group_counts(filter_sort, engine, limit=limit,
                                       order_by=order_by, group_by=group_by)
+    assert len(counts) == 50
     for i in range(1, 100):
         if i > 50:
             assert i in counts
@@ -53,3 +60,32 @@ def test_get_group_counts_limit_offset_ordering(filter_sort_table_obj):
             assert i in counts
         else:
             assert i not in counts
+
+
+count_values_test_list = itertools.chain(*[
+    itertools.combinations([
+        "Student Name",
+        "Student Email",
+        "Teacher Email",
+        "Subject",
+        "Grade"
+    ], i) for i in range(1, 5)
+])
+
+
+@pytest.mark.parametrize("group_by", count_values_test_list)
+def test_get_group_counts_count_values(roster_table_obj, group_by):
+    roster, engine = roster_table_obj
+    print(group_by)
+    counts = records.get_group_counts(roster, engine, group_by=group_by)
+
+    cols = [roster.c[f] for f in group_by]
+    with engine.begin() as conn:
+        all_records = conn.execute(select(*cols)).fetchall()
+    manual_count = Counter(all_records)
+
+    for key, value in counts.items():
+        # The counter uses tuples as keys
+        if type(key) is not tuple:
+            key = (key,)
+        assert manual_count[key] == value

--- a/db/tests/records/test_grouping.py
+++ b/db/tests/records/test_grouping.py
@@ -10,7 +10,7 @@ from db import records
 def test_get_group_counts_str_field(filter_sort_table_obj):
     filter_sort, engine = filter_sort_table_obj
     group_by = ["varchar"]
-    counts = records.get_group_counts(filter_sort, engine, group_by=group_by)
+    counts = records.get_group_counts(filter_sort, engine, group_by)
     assert len(counts) == 101
     assert "string1" in counts
 
@@ -18,7 +18,7 @@ def test_get_group_counts_str_field(filter_sort_table_obj):
 def test_get_group_counts_col_field(filter_sort_table_obj):
     filter_sort, engine = filter_sort_table_obj
     group_by = [filter_sort.c.varchar]
-    counts = records.get_group_counts(filter_sort, engine, group_by=group_by)
+    counts = records.get_group_counts(filter_sort, engine, group_by)
     assert len(counts) == 101
     assert "string1" in counts
 
@@ -26,7 +26,7 @@ def test_get_group_counts_col_field(filter_sort_table_obj):
 def test_get_group_counts_mixed_str_col_field(filter_sort_table_obj):
     filter_sort, engine = filter_sort_table_obj
     group_by = ["varchar", filter_sort.c.numeric]
-    counts = records.get_group_counts(filter_sort, engine, group_by=group_by)
+    counts = records.get_group_counts(filter_sort, engine, group_by)
     assert len(counts) == 101
     assert ("string1", 1) in counts
 
@@ -36,8 +36,8 @@ def test_get_group_counts_limit_ordering(filter_sort_table_obj):
     limit = 50
     order_by = [{"field": "numeric", "direction": "desc", "nullslast": True}]
     group_by = [filter_sort.c.numeric]
-    counts = records.get_group_counts(filter_sort, engine, limit=limit,
-                                      order_by=order_by, group_by=group_by)
+    counts = records.get_group_counts(filter_sort, engine, group_by, limit=limit,
+                                      order_by=order_by)
     assert len(counts) == 50
     for i in range(1, 100):
         if i > 50:
@@ -52,8 +52,8 @@ def test_get_group_counts_limit_offset_ordering(filter_sort_table_obj):
     limit = 50
     order_by = [{"field": "numeric", "direction": "desc", "nullslast": True}]
     group_by = [filter_sort.c.numeric]
-    counts = records.get_group_counts(filter_sort, engine, limit=limit, offset=offset,
-                                      order_by=order_by, group_by=group_by)
+    counts = records.get_group_counts(filter_sort, engine, group_by, limit=limit,
+                                      offset=offset, order_by=order_by)
     assert len(counts) == 50
     for i in range(1, 100):
         if i > 25 and i <= 75:
@@ -77,7 +77,7 @@ count_values_test_list = itertools.chain(*[
 def test_get_group_counts_count_values(roster_table_obj, group_by):
     roster, engine = roster_table_obj
     print(group_by)
-    counts = records.get_group_counts(roster, engine, group_by=group_by)
+    counts = records.get_group_counts(roster, engine, group_by)
 
     cols = [roster.c[f] for f in group_by]
     with engine.begin() as conn:

--- a/db/tests/records/test_grouping.py
+++ b/db/tests/records/test_grouping.py
@@ -76,7 +76,6 @@ count_values_test_list = itertools.chain(*[
 @pytest.mark.parametrize("group_by", count_values_test_list)
 def test_get_group_counts_count_values(roster_table_obj, group_by):
     roster, engine = roster_table_obj
-    print(group_by)
     counts = records.get_group_counts(roster, engine, group_by)
 
     cols = [roster.c[f] for f in group_by]

--- a/db/tests/records/test_grouping.py
+++ b/db/tests/records/test_grouping.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy import select
 
 from db import records
+from db.records import GroupFieldNotFound, BadGroupFormat
 
 
 def test_get_group_counts_str_field(filter_sort_table_obj):
@@ -88,3 +89,18 @@ def test_get_group_counts_count_values(roster_table_obj, group_by):
         if type(key) is not tuple:
             key = (key,)
         assert manual_count[key] == value
+
+
+exceptions_test_list = [
+    ("string", BadGroupFormat),
+    ({"dictionary": ""}, BadGroupFormat),
+    ([{"field": "varchar"}], BadGroupFormat),
+    (["non_existent_field"], GroupFieldNotFound),
+]
+
+
+@pytest.mark.parametrize("group_by,exception", exceptions_test_list)
+def test_get_group_counts_exceptions(filter_sort_table_obj, group_by, exception):
+    filter_sort, engine = filter_sort_table_obj
+    with pytest.raises(exception):
+        records.get_group_counts(filter_sort, engine, group_by)

--- a/db/tests/records/test_grouping.py
+++ b/db/tests/records/test_grouping.py
@@ -13,7 +13,7 @@ def test_get_group_counts_str_field(filter_sort_table_obj):
     group_by = ["varchar"]
     counts = records.get_group_counts(filter_sort, engine, group_by)
     assert len(counts) == 101
-    assert "string1" in counts
+    assert ("string1",) in counts
 
 
 def test_get_group_counts_col_field(filter_sort_table_obj):
@@ -21,7 +21,7 @@ def test_get_group_counts_col_field(filter_sort_table_obj):
     group_by = [filter_sort.c.varchar]
     counts = records.get_group_counts(filter_sort, engine, group_by)
     assert len(counts) == 101
-    assert "string1" in counts
+    assert ("string1",) in counts
 
 
 def test_get_group_counts_mixed_str_col_field(filter_sort_table_obj):
@@ -42,9 +42,9 @@ def test_get_group_counts_limit_ordering(filter_sort_table_obj):
     assert len(counts) == 50
     for i in range(1, 100):
         if i > 50:
-            assert i in counts
+            assert (i,) in counts
         else:
-            assert i not in counts
+            assert (i,) not in counts
 
 
 def test_get_group_counts_limit_offset_ordering(filter_sort_table_obj):
@@ -58,9 +58,9 @@ def test_get_group_counts_limit_offset_ordering(filter_sort_table_obj):
     assert len(counts) == 50
     for i in range(1, 100):
         if i > 25 and i <= 75:
-            assert i in counts
+            assert (i,) in counts
         else:
-            assert i not in counts
+            assert (i,) not in counts
 
 
 count_values_test_list = itertools.chain(*[
@@ -85,9 +85,6 @@ def test_get_group_counts_count_values(roster_table_obj, group_by):
     manual_count = Counter(all_records)
 
     for key, value in counts.items():
-        # The counter uses tuples as keys
-        if type(key) is not tuple:
-            key = (key,)
         assert manual_count[key] == value
 
 

--- a/db/tests/records/test_grouping.py
+++ b/db/tests/records/test_grouping.py
@@ -1,0 +1,55 @@
+from db import records
+
+
+def test_get_group_counts_str_field(filter_sort_table_obj):
+    filter_sort, engine = filter_sort_table_obj
+    group_by = ["varchar"]
+    counts = records.get_group_counts(filter_sort, engine, group_by=group_by)
+    assert len(counts) == 101
+    assert "string1" in counts
+
+
+def test_get_group_counts_col_field(filter_sort_table_obj):
+    filter_sort, engine = filter_sort_table_obj
+    group_by = [filter_sort.c.varchar]
+    counts = records.get_group_counts(filter_sort, engine, group_by=group_by)
+    assert len(counts) == 101
+    assert "string1" in counts
+
+
+def test_get_group_counts_mixed_str_col_field(filter_sort_table_obj):
+    filter_sort, engine = filter_sort_table_obj
+    group_by = ["varchar", filter_sort.c.numeric]
+    counts = records.get_group_counts(filter_sort, engine, group_by=group_by)
+    assert len(counts) == 101
+    assert ("string1", 1) in counts
+
+
+def test_get_group_counts_limit_ordering(filter_sort_table_obj):
+    filter_sort, engine = filter_sort_table_obj
+    limit = 50
+    order_by = [{"field": "numeric", "direction": "desc", "nullslast": True}]
+    group_by = [filter_sort.c.numeric]
+    counts = records.get_group_counts(filter_sort, engine, limit=limit,
+                                      order_by=order_by, group_by=group_by)
+    for i in range(1, 100):
+        if i > 50:
+            assert i in counts
+        else:
+            assert i not in counts
+
+
+def test_get_group_counts_limit_offset_ordering(filter_sort_table_obj):
+    filter_sort, engine = filter_sort_table_obj
+    offset = 25
+    limit = 50
+    order_by = [{"field": "numeric", "direction": "desc", "nullslast": True}]
+    group_by = [filter_sort.c.numeric]
+    counts = records.get_group_counts(filter_sort, engine, limit=limit, offset=offset,
+                                      order_by=order_by, group_by=group_by)
+    assert len(counts) == 50
+    for i in range(1, 100):
+        if i > 25 and i <= 75:
+            assert i in counts
+        else:
+            assert i not in counts

--- a/db/tests/records/test_records.py
+++ b/db/tests/records/test_records.py
@@ -1,25 +1,5 @@
 import pytest
-from sqlalchemy import MetaData, Table
 from db import records
-
-ROSTER = "Roster"
-FILTER_SORT = "filter_sort"
-
-
-@pytest.fixture
-def roster_table_obj(engine_with_roster):
-    engine, schema = engine_with_roster
-    metadata = MetaData(bind=engine)
-    roster = Table(ROSTER, metadata, schema=schema, autoload_with=engine)
-    return roster, engine
-
-
-@pytest.fixture
-def filter_sort_table_obj(engine_with_filter_sort):
-    engine, schema = engine_with_filter_sort
-    metadata = MetaData(bind=engine)
-    roster = Table(FILTER_SORT, metadata, schema=schema, autoload_with=engine)
-    return roster, engine
 
 
 def test_get_records_gets_all_records(roster_table_obj):

--- a/db/tests/records/test_sorting.py
+++ b/db/tests/records/test_sorting.py
@@ -1,29 +1,8 @@
 import pytest
 
-from sqlalchemy import MetaData, Table
 from sqlalchemy_filters.exceptions import BadSortFormat, SortFieldNotFound
 
 from db import records
-
-
-ROSTER = "Roster"
-FILTER_SORT = "filter_sort"
-
-
-@pytest.fixture
-def roster_table_obj(engine_with_roster):
-    engine, schema = engine_with_roster
-    metadata = MetaData(bind=engine)
-    roster = Table(ROSTER, metadata, schema=schema, autoload_with=engine)
-    return roster, engine
-
-
-@pytest.fixture
-def filter_sort_table_obj(engine_with_filter_sort):
-    engine, schema = engine_with_filter_sort
-    metadata = MetaData(bind=engine)
-    roster = Table(FILTER_SORT, metadata, schema=schema, autoload_with=engine)
-    return roster, engine
 
 
 def test_get_records_gets_ordered_records_str_col_name(roster_table_obj):

--- a/mathesar/forms/forms.py
+++ b/mathesar/forms/forms.py
@@ -34,3 +34,4 @@ class UploadFileForm(forms.Form):
 class RecordListFilterForm(forms.Form):
     filters = forms.JSONField(required=False, empty_value=[])
     order_by = forms.JSONField(required=False, empty_value=[])
+    group_count_by = forms.JSONField(required=False, empty_value=[])

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -134,11 +134,11 @@ class Table(DatabaseObject):
                                    offset, filters=filters, order_by=order_by)
 
     def get_group_counts(
-        self, limit=None, offset=None, filters=[], order_by=[], group_count_by=[]
+        self, group_by, limit=None, offset=None, filters=[], order_by=[]
     ):
-        return records.get_records(self._sa_table, self.schema._sa_engine, limit,
-                                   offset, filters=filters, order_by=order_by,
-                                   group_count_by=group_count_by)
+        return records.get_group_counts(self._sa_table, self.schema._sa_engine,
+                                        group_by, limit, offset, filters=filters,
+                                        order_by=order_by)
 
     def create_record_or_records(self, record_data):
         return records.create_record_or_records(self._sa_table, self.schema._sa_engine, record_data)

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -133,6 +133,13 @@ class Table(DatabaseObject):
         return records.get_records(self._sa_table, self.schema._sa_engine, limit,
                                    offset, filters=filters, order_by=order_by)
 
+    def get_group_counts(
+        self, limit=None, offset=None, filters=[], order_by=[], group_count_by=[]
+    ):
+        return records.get_records(self._sa_table, self.schema._sa_engine, limit,
+                                   offset, filters=filters, order_by=order_by,
+                                   group_count_by=group_count_by)
+
     def create_record_or_records(self, record_data):
         return records.create_record_or_records(self._sa_table, self.schema._sa_engine, record_data)
 

--- a/mathesar/pagination.py
+++ b/mathesar/pagination.py
@@ -47,14 +47,16 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
                 group_count_by, self.limit, self.offset,
                 filters=filters, order_by=order_by
             )
+            # Convert the tuple keys into strings so it can be converted to JSON
+            group_count = {','.join(k): v for k, v in group_count.items()}
             self.group_count = {
-                "group_count_by": group_count_by,
-                "results": group_count,
+                'group_count_by': group_count_by,
+                'results': group_count,
             }
         else:
             self.group_count = {
-                "group_count_by": None,
-                "results": None,
+                'group_count_by': None,
+                'results': None,
             }
 
         return table.get_records(

--- a/mathesar/pagination.py
+++ b/mathesar/pagination.py
@@ -44,8 +44,8 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
 
         if group_count_by:
             group_count = table.get_group_counts(
-                self.limit, self.offest, self.limit, self.offset,
-                filters=filters, order_by=order_by, group_by=group_count_by
+                group_count_by, self.limit, self.offset,
+                filters=filters, order_by=order_by
             )
             self.group_count = {
                 "group_count_by": group_count_by,

--- a/mathesar/tests/views/api/test_record_api.py
+++ b/mathesar/tests/views/api/test_record_api.py
@@ -114,6 +114,33 @@ def test_record_list_sort(create_table, client):
     assert mock_infer.call_args[1]['order_by'] == order_by
 
 
+def test_record_list_group(create_table, client):
+    table_name = 'NASA Record List Group'
+    table = create_table(table_name)
+
+    group_count_by = ['Center', 'Case Number']
+    json_group_count_by = json.dumps(group_count_by)
+
+    with patch.object(
+        records, "get_group_counts", side_effect=records.get_group_counts
+    ) as mock_infer:
+        response = client.get(
+            f'/api/v0/tables/{table.id}/records/?group_count_by={json_group_count_by}'
+        )
+        response_data = response.json()
+
+    assert response.status_code == 200
+    assert response_data['count'] == 1393
+    assert len(response_data['results']) == 50
+
+    assert 'group_count' in response_data
+    assert response_data['group_count']['group_count_by'] == group_count_by
+    assert 'results' in response_data['group_count']
+
+    assert mock_infer.call_args is not None
+    assert mock_infer.call_args[0][2] == group_count_by
+
+
 def test_record_list_pagination_limit(create_table, client):
     table_name = 'NASA Record List Pagination Limit'
     table = create_table(table_name)

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -16,7 +16,7 @@ from sqlalchemy_filters.exceptions import (
 from mathesar.database.utils import get_non_default_database_keys
 from mathesar.models import Table, Schema, DataFile
 from mathesar.pagination import (
-    ColumnLimitOffsetPagination, DefaultLimitOffsetPagination, TableLimitOffsetPagination
+    ColumnLimitOffsetPagination, DefaultLimitOffsetPagination, TableLimitOffsetGroupPagination
 )
 from mathesar.serializers import (
     TableSerializer, SchemaSerializer, RecordSerializer, DataFileSerializer, ColumnSerializer,
@@ -159,7 +159,7 @@ class RecordViewSet(viewsets.ViewSet):
     # For sorting parameter formatting, see:
     # https://github.com/centerofci/sqlalchemy-filters#sort-format
     def list(self, request, table_pk=None):
-        paginator = TableLimitOffsetPagination()
+        paginator = TableLimitOffsetGroupPagination()
 
         # Use a Django Form to automatically parse JSON URL parameters
         filter_form = RecordListFilterForm(request.GET)

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -27,6 +27,8 @@ from mathesar.utils.datafiles import create_table_from_datafile, create_datafile
 from mathesar.filters import SchemaFilter, TableFilter
 from mathesar.forms.forms import RecordListFilterForm
 
+from db.records import BadGroupFormat, GroupFieldNotFound
+
 logger = logging.getLogger(__name__)
 
 DB_REFLECTION_KEY = 'database_reflected_recently'
@@ -177,6 +179,8 @@ class RecordViewSet(viewsets.ViewSet):
             raise ValidationError({'filters': e})
         except (BadSortFormat, SortFieldNotFound) as e:
             raise ValidationError({'order_by': e})
+        except (BadGroupFormat, GroupFieldNotFound) as e:
+            raise ValidationError({'group_count_by': e})
 
         serializer = RecordSerializer(records, many=True)
         return paginator.get_paginated_response(serializer.data)

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -170,7 +170,8 @@ class RecordViewSet(viewsets.ViewSet):
             records = paginator.paginate_queryset(
                 self.queryset, request, table_pk,
                 filters=filter_form.cleaned_data['filters'],
-                order_by=filter_form.cleaned_data['order_by']
+                order_by=filter_form.cleaned_data['order_by'],
+                group_count_by=filter_form.cleaned_data['group_count_by'],
             )
         except (BadFilterFormat, FilterFieldNotFound) as e:
             raise ValidationError({'filters': e})


### PR DESCRIPTION
Fixes #216

Adds the ability to get group count information from the record list endpoint.

**Technical details**
Adds a `get_group_counts()` function to the `db` module, which takes in a list of fields to group by and returns a dictionary mapping tuples of fields to their counts. Also adds a `group_count_by` parameter to the record list endpoint, where a user can pass a list of fields to group by and get
```python
'group_count': {
    'group_count_by': [fields_used_for_grouping],
    'results': {dictionary_mapping_fields_to_counts},
}
```
including in the return data. The keys for `results` are strings, with composite fields names joined by `,`s. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
