### PR TITLE
Updated issue templates to have headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,20 +4,20 @@ about: Report an issue with Mathesar
 labels: "type: bug"
 ---
 
-**Describe the bug**
+## Description
 <!-- A clear and concise description of what the bug is. -->
 
-**Expected behavior**
+## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-**To Reproduce**
+## To Reproduce
 <!-- How can we recreate this bug? Please try to provide a Minimal, Complete, and Verifiable (http://stackoverflow.com/help/mcve) example if code-related. -->
 
-**Environment**
+## Environment
  - OS: (_eg._ macOS 10.14.6; Fedora 32)
  - Browser: (_eg._ Safari; Firefox)
  - Browser Version: (_eg._ 13; 73)
  - Other info:
 
-**Additional context**
+## Additional context
 <!-- Add any other context about the problem or screenshots here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,11 +4,11 @@ about: Suggest a new feature for Mathesar
 labels: "type: enhancement"
 ---
 
-**Problem**
+## Problem
 <!-- Please provide a clear and concise description of the problem that this feature request is designed to solve.-->
 
-**Proposed solution**
+## Proposed solution
 <!-- A clear and concise description of your proposed solution or feature. -->
 
-**Additional context**
+## Additional context
 <!-- Add any other context or screenshots about the feature request here.-->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,13 +4,13 @@ about: Question about Mathesar development or usage
 labels: question
 ---
 
-**Question**
+## Question
 
-**Environment**
+## Environment
  - OS: (_eg._ macOS 10.14.6; Fedora 32)
  - Browser: (_eg._ Safari; Firefox)
  - Browser Version: (_eg._ 13; 73)
  - Other info:
 
-**Additional context**
+## Additional context
 <!-- Add any other context about the problem or screenshots here. -->


### PR DESCRIPTION
I found myself often editing issues to have headers instead of bold text, so I decided to fix the template.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
