### PR TITLE
Prevent pytest-django from handling non-'default' dbs

### DIFF
--- a/mathesar/tests/conftest.py
+++ b/mathesar/tests/conftest.py
@@ -5,6 +5,40 @@ This inherits the fixtures in the root conftest.py
 import pytest
 
 
+@pytest.fixture(scope="session")
+def django_db_setup(request, django_db_blocker) -> None:
+    """
+    A stripped down version of pytest-django's original django_db_setup fixture
+    See: https://github.com/pytest-dev/pytest-django/blob/master/pytest_django/fixtures.py#L96
+    Also see: https://pytest-django.readthedocs.io/en/latest/database.html#using-a-template-database-for-tests
+
+    Removes most additional options (use migrations, keep / create db, etc.)
+    Adds 'aliases' to the call to setup_databases() which restrict Django to only
+    building and destroying the default Django db, and not our tables dbs.
+    """
+    from django.test.utils import setup_databases, teardown_databases
+
+    with django_db_blocker.unblock():
+        db_cfg = setup_databases(
+            verbosity=request.config.option.verbose,
+            interactive=False,
+            aliases=["default"],
+        )
+
+    def teardown_database() -> None:
+        with django_db_blocker.unblock():
+            try:
+                teardown_databases(db_cfg, verbosity=request.config.option.verbose)
+            except Exception as exc:
+                request.node.warn(
+                    pytest.PytestWarning(
+                        "Error when trying to teardown test databases: %r" % exc
+                    )
+                )
+
+    request.addfinalizer(teardown_database)
+
+
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #318

Prevents pytest-django from handling the building or destruction of non-'default' dbs, allowing us to handle our tables databases as needed.

**Technical details**
Overwrites the pytest-django `django_db_setup` fixture to use pass `aliases=['default']` to `django.test.utils.setup_databases()` (See docstring of new fixture for more information). This restricts the setup to only the `default` db, preventing the multiple teardown issue we were running into.

I've confirmed this prevents the error shown in the original issue, but didn't leave the test in as the problem seems niche enough that I don't we'll run into this again.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
