### PR TITLE
Fix grouping counts

### DIFF
--- a/mathesar/pagination.py
+++ b/mathesar/pagination.py
@@ -67,7 +67,7 @@ class TableLimitOffsetGroupPagination(TableLimitOffsetPagination):
                 filters=filters, order_by=order_by
             )
             # Convert the tuple keys into strings so it can be converted to JSON
-            group_count = [{"columns": list(cols), "count": count}
+            group_count = [{"values": list(cols), "count": count}
                            for cols, count in group_count.items()]
             self.group_count = {
                 'group_count_by': group_count_by,

--- a/mathesar/pagination.py
+++ b/mathesar/pagination.py
@@ -67,7 +67,8 @@ class TableLimitOffsetGroupPagination(TableLimitOffsetPagination):
                 filters=filters, order_by=order_by
             )
             # Convert the tuple keys into strings so it can be converted to JSON
-            group_count = {','.join(k): v for k, v in group_count.items()}
+            group_count = [{"columns": list(cols), "count": count}
+                           for cols, count in group_count.items()]
             self.group_count = {
                 'group_count_by': group_count_by,
                 'results': group_count,

--- a/mathesar/tests/views/api/test_record_api.py
+++ b/mathesar/tests/views/api/test_record_api.py
@@ -137,10 +137,13 @@ def _test_record_list_group(table, client, group_count_by, expected_groups):
     assert 'group_count' in response_data
     assert response_data['group_count']['group_count_by'] == group_count_by
     assert 'results' in response_data['group_count']
+    assert 'columns' in response_data['group_count']['results'][0]
+    assert 'count' in response_data['group_count']['results'][0]
 
     results = response_data['group_count']['results']
+    returned_groups = {tuple(group["columns"]) for group in results}
     for expected_group in expected_groups:
-        assert expected_group in results
+        assert expected_group in returned_groups
 
     assert mock_infer.call_args is not None
     assert mock_infer.call_args[0][2] == group_count_by
@@ -151,8 +154,8 @@ def test_record_list_group_single_column(create_table, client):
     table = create_table(table_name)
     group_count_by = ['Center']
     expected_groups = [
-        'NASA Marshall Space Flight Center',
-        'NASA Stennis Space Center'
+        ('NASA Marshall Space Flight Center',),
+        ('NASA Stennis Space Center',)
     ]
     _test_record_list_group(table, client, group_count_by, expected_groups)
 
@@ -162,8 +165,8 @@ def test_record_list_group_multi_column(create_table, client):
     table = create_table(table_name)
     group_count_by = ['Center', 'Status']
     expected_groups = [
-        'NASA Marshall Space Flight Center,Issued',
-        'NASA Stennis Space Center,Issued',
+        ('NASA Marshall Space Flight Center', 'Issued'),
+        ('NASA Stennis Space Center', 'Issued'),
     ]
     _test_record_list_group(table, client, group_count_by, expected_groups)
 

--- a/mathesar/tests/views/api/test_record_api.py
+++ b/mathesar/tests/views/api/test_record_api.py
@@ -137,11 +137,11 @@ def _test_record_list_group(table, client, group_count_by, expected_groups):
     assert 'group_count' in response_data
     assert response_data['group_count']['group_count_by'] == group_count_by
     assert 'results' in response_data['group_count']
-    assert 'columns' in response_data['group_count']['results'][0]
+    assert 'values' in response_data['group_count']['results'][0]
     assert 'count' in response_data['group_count']['results'][0]
 
     results = response_data['group_count']['results']
-    returned_groups = {tuple(group["columns"]) for group in results}
+    returned_groups = {tuple(group['values']) for group in results}
     for expected_group in expected_groups:
         assert expected_group in returned_groups
 

--- a/mathesar/tests/views/api/test_record_api.py
+++ b/mathesar/tests/views/api/test_record_api.py
@@ -116,14 +116,18 @@ def test_record_list_sort(create_table, client):
 
 
 def _test_record_list_group(table, client, group_count_by, expected_groups):
+    order_by = [
+        {'field': 'Center', 'direction': 'desc'},
+        {'field': 'Case Number', 'direction': 'asc'},
+    ]
+    json_order_by = json.dumps(order_by)
     json_group_count_by = json.dumps(group_count_by)
+    query_str = f'group_count_by={json_group_count_by}&order_by={json_order_by}'
 
     with patch.object(
         records, "get_group_counts", side_effect=records.get_group_counts
     ) as mock_infer:
-        response = client.get(
-            f'/api/v0/tables/{table.id}/records/?group_count_by={json_group_count_by}'
-        )
+        response = client.get(f'/api/v0/tables/{table.id}/records/?{query_str}')
         response_data = response.json()
 
     assert response.status_code == 200
@@ -147,8 +151,8 @@ def test_record_list_group_single_column(create_table, client):
     table = create_table(table_name)
     group_count_by = ['Center']
     expected_groups = [
-        'NASA Ames Research Center',
-        'NASA Kennedy Space Center'
+        'NASA Marshall Space Flight Center',
+        'NASA Stennis Space Center'
     ]
     _test_record_list_group(table, client, group_count_by, expected_groups)
 
@@ -158,8 +162,8 @@ def test_record_list_group_multi_column(create_table, client):
     table = create_table(table_name)
     group_count_by = ['Center', 'Status']
     expected_groups = [
-        'NASA Ames Research Center,Issued',
-        'NASA Kennedy Space Center,Issued',
+        'NASA Marshall Space Flight Center,Issued',
+        'NASA Stennis Space Center,Issued',
     ]
     _test_record_list_group(table, client, group_count_by, expected_groups)
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #352

Updates the record endpoint to have proper grouping behaviors.

**Technical details**
Updates the `get_group_counts()` function to create a subquery with the appropriate parameters applied, before grouping on the result. Also updates the limit offset tests and adds a new filtering + grouping test.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
