### PR TITLE
Extend the create table endpoint to accept request without data file

### DIFF
--- a/mathesar/serializers.py
+++ b/mathesar/serializers.py
@@ -50,6 +50,7 @@ class TableSerializer(serializers.ModelSerializer):
     columns = SimpleColumnSerializer(many=True, read_only=True, source='sa_columns')
     records = serializers.SerializerMethodField()
     name = serializers.CharField()
+    data_files = serializers.PrimaryKeyRelatedField(required=False, many=True, queryset=DataFile.objects.all())
 
     class Meta:
         model = Table

--- a/mathesar/tests/views/api/test_table_api.py
+++ b/mathesar/tests/views/api/test_table_api.py
@@ -303,7 +303,7 @@ def test_table_create_with_empty_datafile(client, schema):
     assert len(table.get_records()) == 0
     check_table_response(response_table, table, table_name)
 
-    
+
 def test_table_partial_update(create_table, client):
     table_name = 'NASA Table Partial Update'
     new_table_name = 'NASA Table Partial Update New'

--- a/mathesar/tests/views/api/test_table_api.py
+++ b/mathesar/tests/views/api/test_table_api.py
@@ -265,6 +265,43 @@ def test_table_create_from_datafile(client, data_file, schema):
     check_table_response(response_table, table, table_name)
 
 
+def test_table_create_without_datafile(client, schema):
+    num_tables = Table.objects.count()
+    table_name = 'test_table_no_file'
+    body = {  # No `data_files` field
+        'name': table_name,
+        'schema': schema.id,
+    }
+    response = client.post('/api/v0/tables/', body)
+    response_table = response.json()
+    table = Table.objects.get(id=response_table['id'])
+
+    assert response.status_code == 201
+    assert Table.objects.count() == num_tables + 1
+    assert len(table.sa_columns) == 1  # only the internal `mathesar_id` column
+    assert len(table.get_records()) == 0
+    check_table_response(response_table, table, table_name)
+
+
+def test_table_create_with_empty_datafile(client, schema):
+    num_tables = Table.objects.count()
+    table_name = 'test_table_empty_files'
+    body = {
+        'data_files': [],  # Empty `data_files` field
+        'name': table_name,
+        'schema': schema.id,
+    }
+    response = client.post('/api/v0/tables/', body)
+    response_table = response.json()
+    table = Table.objects.get(id=response_table['id'])
+
+    assert response.status_code == 201
+    assert Table.objects.count() == num_tables + 1
+    assert len(table.sa_columns) == 1  # only the internal `mathesar_id` column
+    assert len(table.get_records()) == 0
+    check_table_response(response_table, table, table_name)
+
+
 def test_table_404(client):
     response = client.get('/api/v0/tables/3000/')
     assert response.status_code == 404

--- a/mathesar/utils/datafiles.py
+++ b/mathesar/utils/datafiles.py
@@ -4,12 +4,12 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 
-from mathesar.serializers import TableSerializer, DataFileSerializer
+from mathesar.serializers import DataFileSerializer
 from mathesar.imports.csv import create_table_from_csv, get_sv_dialect
 from mathesar.errors import InvalidTableError
 
 
-def create_table_from_datafile(request, data):
+def create_table_from_datafile(data):
     name = data['name']
     schema = data['schema']
     if len(data['data_files']) == 1:
@@ -18,8 +18,7 @@ def create_table_from_datafile(request, data):
         raise ValidationError({'data_files': 'Multiple data files are unsupported'})
 
     table = create_table_from_csv(data_file, name, schema)
-    serializer = TableSerializer(table, context={'request': request})
-    return Response(serializer.data, status=status.HTTP_201_CREATED)
+    return table
 
 
 def create_datafile(request, original_file):

--- a/mathesar/utils/tables.py
+++ b/mathesar/utils/tables.py
@@ -1,5 +1,6 @@
-from db.tables import get_table_oids_from_schema, infer_table_column_types
 from db.columns import MathesarColumn
+from db.tables import get_table_oids_from_schema, infer_table_column_types, create_mathesar_table, get_oid_from_table
+from mathesar.database.base import create_mathesar_engine
 from mathesar.models import Table
 
 
@@ -29,3 +30,21 @@ def get_table_column_types(table):
         and not col.foreign_keys
     }
     return col_types
+
+
+def create_empty_table(data):
+    """
+    Create an empty table, with only Mathesar's internal columns.
+
+    :param data: the parsed and validated data from the incoming request
+    :return: the newly created blank table
+    """
+
+    name = data['name']
+    schema = data['schema']
+
+    engine = create_mathesar_engine(schema.database.name)
+    db_table = create_mathesar_table(name, schema.name, [], engine)
+    db_table_oid = get_oid_from_table(db_table.name, db_table.schema, engine)
+    table, _ = Table.objects.get_or_create(oid=db_table_oid, schema=schema)
+    return table

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -25,6 +25,7 @@ from mathesar.serializers import (
 from mathesar.utils.schemas import create_schema_and_object, reflect_schemas_from_database
 from mathesar.utils.tables import reflect_tables_from_schema, get_table_column_types
 from mathesar.utils.datafiles import create_table_from_datafile, create_datafile
+from mathesar.utils.tables import create_empty_table
 from mathesar.filters import SchemaFilter, TableFilter, DatabaseFilter
 from mathesar.forms import RecordListFilterForm
 
@@ -81,7 +82,14 @@ class TableViewSet(viewsets.GenericViewSet, ListModelMixin, RetrieveModelMixin,
     def create(self, request):
         serializer = TableSerializer(data=request.data, context={'request': request})
         if serializer.is_valid():
-            return create_table_from_datafile(request, serializer.validated_data)
+            valid_data = serializer.validated_data
+            if 'data_files' in valid_data and valid_data['data_files']:
+                table = create_table_from_datafile(valid_data)
+            else:
+                table = create_empty_table(valid_data)
+
+            serializer = TableSerializer(table, context={'request': request})
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
         else:
             raise ValidationError(serializer.errors)
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #188

<!-- Concisely describe what the pull request does. -->
This PR provides a way to create blank tables from the API.

**Technical details**
This PR makes the `data_files` parameter optional in the serializer, which treats requests without the `data_files` field as valid. A new util `create_empty_table` has been added (which follows the same flow as the CSV upload) to generate a blank table.

Tables generated from this util only have the default `mathesar_id` column and no rows.

**Screenshots**
![image](https://user-images.githubusercontent.com/16580576/126062321-926941f1-de48-4bdb-a7a6-fa05375aa0a7.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
