### PR TITLE
Add github action for automatic deploys to staging

### DIFF
--- a/.github/actions/ansible/Dockerfile
+++ b/.github/actions/ansible/Dockerfile
@@ -1,0 +1,10 @@
+FROM quay.io/ansible/ansible-runner:latest
+
+# Required addons that don't come by default
+RUN ansible-galaxy collection install ansible.posix -p /usr/share/ansible/collections \
+    && ansible-galaxy collection install community.general -p /usr/share/ansible/collections \
+    && ansible-galaxy collection install community.postgresql -p /usr/share/ansible/collections
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/ansible/action.yml
+++ b/.github/actions/ansible/action.yml
@@ -1,0 +1,30 @@
+name: 'Ansible'
+description: 'Runs an Ansible playbook'
+inputs:
+  playbook:
+    description: 'Playbook file to run'
+    required: true
+    default: 'staging'
+  inventory:
+    description: 'Host list to run playbook against'
+    required: true
+    default: 'hosts/staging'
+  vault_password:
+    description: 'Password used to get secrets out of the ansible vault'
+    required: true
+  deploy_user:
+    description: 'SSH username for connections to use'
+    required: true
+    default: 'deployer'
+  deploy_key:
+    description: 'SSH key for connections to use'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.playbook }}
+    - ${{ inputs.inventory }}
+    - ${{ inputs.vault_password }}
+    - ${{ inputs.deploy_user }}
+    - ${{ inputs.deploy_key }}

--- a/.github/actions/ansible/entrypoint.sh
+++ b/.github/actions/ansible/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Put the vault password in to a file
+mkdir -p /tmp/private && chmod 700 /tmp/private
+echo "${INPUT_VAULT_PASSWORD}" > /tmp/private/vault_password
+
+# Put the key in to a file
+echo "${INPUT_DEPLOY_KEY}" > /tmp/private/deploy_key && chmod 400 /tmp/private/deploy_key
+
+ansible-playbook ${INPUT_PLAYBOOK}.yml \
+    -i "${INPUT_INVENTORY}" \
+    --vault-password-file /tmp/private/vault_password \
+    --private-key /tmp/private/deploy_key \
+    -u "${INPUT_DEPLOY_USER}"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to staging
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  staging-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout ansible repo
+      uses: actions/checkout@v2
+      with:
+        repository: 'centerofci/mathesar-ansible'
+        token: ${{ secrets.GH_PAT_ANSIBLE_REPO }} # Repo is private, so an access token is used
+    # This checkout is used for getting the 'action' from the current repo
+    - name: Checkout mathesar repo
+      uses: actions/checkout@v2
+      with:
+        path: mathesar
+    - name: Run ansible
+      uses: ./mathesar/.github/actions/ansible
+      with:
+        playbook: staging
+        inventory: hosts/staging
+        vault_password: ${{ secrets.ANSIBLE_VAULT_PASS }}
+        deploy_key: ${{ secrets.STAGING_DEPLOY_KEY }}


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #359 

**Technical details**
This change adds a new github action which:

* creates a docker image with the required ansible commands and
  collections
* accepts the required parameters to run `ansible-playbook`
* includes a workflow for triggering this action and cloning the ansible
  repo

Three github secrets are required to be added for this, which I've done already:

* `GH_PAT_ANSIBLE_REPO` - used for cloning the private ansible repo
* `ANSIBLE_VAULT_PASS` - passed to ansible-playbook so it can read
  secrets
* `STAGING_DEPLOY_KEY` - passed to ansible-playbook so it can connect to
  the host

I tested this against a separate repo and was able to successfully push a commit to it, and have ansible run.

When ansible runs, it will:

* ensure the server is set up as per the mathesar-ansible configuration
* ensure the `mathesar` repo on the staging server is up to date
* if the mathesar repo changes, it will install from `requirements.txt` and run migrations

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
