### PR TITLE
Reflect db objects before rendering page

### DIFF
--- a/mathesar/database/utils.py
+++ b/mathesar/database/utils.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 
-from mathesar.models import Schema, Database
 from db.engine import get_connection_string
 
 
@@ -22,22 +21,3 @@ def get_database_key(engine):
 
 def get_non_default_database_keys():
     return [key for key in settings.DATABASES if key != 'default']
-
-
-def update_databases():
-    databases = set(settings.DATABASES)
-    # We only want to track non-django dbs
-    databases.remove('default')
-
-    # Update deleted databases
-    for database in Database.objects.all():
-        if database.name in databases:
-            databases.remove(database.name)
-        else:
-            database.deleted = True
-            Schema.objects.filter(database=database).delete()
-            database.save()
-
-    # Create databases that aren't models yet
-    for database in databases:
-        Database.objects.create(name=database)

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -3,8 +3,9 @@ from django.core.cache import cache
 from django.db import models
 from django.utils.functional import cached_property
 
-from mathesar.database.base import create_mathesar_engine
+from mathesar import reflection
 from mathesar.utils import models as model_utils
+from mathesar.database.base import create_mathesar_engine
 from db import tables, records, schemas, columns
 from db.types.alteration import get_supported_alter_column_types
 
@@ -19,8 +20,15 @@ class BaseModel(models.Model):
         abstract = True
 
 
+class DatabaseObjectManager(models.Manager):
+    def get_queryset(self):
+        reflection.reflect_db_objects()
+        return super().get_queryset()
+
+
 class DatabaseObject(BaseModel):
     oid = models.IntegerField()
+    objects = DatabaseObjectManager()
 
     class Meta:
         abstract = True

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -28,6 +28,7 @@ class DatabaseObjectManager(models.Manager):
 
 class DatabaseObject(BaseModel):
     oid = models.IntegerField()
+    current_objects = models.Manager()
     objects = DatabaseObjectManager()
 
     class Meta:
@@ -43,6 +44,8 @@ _engines = {}
 
 
 class Database(BaseModel):
+    current_objects = models.Manager()
+    objects = DatabaseObjectManager()
     name = models.CharField(max_length=128, unique=True)
     deleted = models.BooleanField(blank=True, default=False)
 

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -28,6 +28,9 @@ class DatabaseObjectManager(models.Manager):
 
 class DatabaseObject(BaseModel):
     oid = models.IntegerField()
+    # The default manager does not reflect databse objects.
+    # This saves us from having to deal with Django trying to automatically reflect db
+    # objects in the background when we might not expect it.
     current_objects = models.Manager()
     objects = DatabaseObjectManager()
 

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -28,7 +28,7 @@ class DatabaseObjectManager(models.Manager):
 
 class DatabaseObject(BaseModel):
     oid = models.IntegerField()
-    # The default manager does not reflect databse objects.
+    # The default manager, current_objects, does not reflect databse objects.
     # This saves us from having to deal with Django trying to automatically reflect db
     # objects in the background when we might not expect it.
     current_objects = models.Manager()

--- a/mathesar/reflection.py
+++ b/mathesar/reflection.py
@@ -1,0 +1,72 @@
+from django.conf import settings
+from django.core.cache import cache
+
+from mathesar.models import Database, Table, Schema
+from mathesar.database.base import create_mathesar_engine
+from mathesar.database.utils import get_non_default_database_keys
+from db.tables import get_table_oids_from_schema
+from db.schemas import get_mathesar_schemas_with_oids
+
+DB_REFLECTION_KEY = 'database_reflected_recently'
+DB_REFLECTION_INTERVAL = 60 * 5  # we reflect DB changes every 5 minutes
+
+
+def reflect_databases():
+    databases = set(settings.DATABASES)
+    # We only want to track non-django dbs
+    databases.remove('default')
+
+    # Update deleted databases
+    for database in Database.objects.all():
+        if database.name in databases:
+            databases.remove(database.name)
+        else:
+            database.deleted = True
+            Schema.objects.filter(database=database).delete()
+            database.save()
+
+    # Create databases that aren't models yet
+    for database in databases:
+        Database.objects.create(name=database)
+
+
+def reflect_schemas_from_database(database):
+    engine = create_mathesar_engine(database)
+    db_schema_oids = {
+        schema["oid"] for schema in get_mathesar_schemas_with_oids(engine)
+    }
+
+    database = Database.objects.get(name=database)
+    schemas = [
+        Schema.objects.get_or_create(oid=oid, database=database)
+        for oid in db_schema_oids
+    ]
+    for schema in Schema.objects.all():
+        if schema.database.name == database and schema.oid not in db_schema_oids:
+            schema.delete()
+    return schemas
+
+
+def reflect_tables_from_schema(schema):
+    db_table_oids = {
+        table["oid"]
+        for table in get_table_oids_from_schema(schema.oid, schema._sa_engine)
+    }
+    tables = [
+        Table.objects.get_or_create(oid=oid, schema=schema)
+        for oid in db_table_oids
+    ]
+    for table in Table.objects.all().filter(schema=schema):
+        if table.oid not in db_table_oids:
+            table.delete()
+    return tables
+
+
+def reflect_db_objects():
+    if not cache.get(DB_REFLECTION_KEY):
+        reflect_databases()
+        for database_key in get_non_default_database_keys():
+            reflect_schemas_from_database(database_key)
+        for schema in Schema.objects.all():
+            reflect_tables_from_schema(schema)
+        cache.set(DB_REFLECTION_KEY, True, DB_REFLECTION_INTERVAL)

--- a/mathesar/reflection.py
+++ b/mathesar/reflection.py
@@ -12,6 +12,11 @@ DB_REFLECTION_KEY = 'database_reflected_recently'
 DB_REFLECTION_INTERVAL = 60 * 5  # we reflect DB changes every 5 minutes
 
 
+# NOTE: All querysets used for reflection should use the .current_objects manager
+# instead of the .objects manger. The .objects manager calls reflect_db_objects when a
+# queryset is created, and will recurse if used in these functions.
+
+
 def reflect_databases():
     databases = set(settings.DATABASES)
     # We only want to track non-django dbs

--- a/mathesar/reflection.py
+++ b/mathesar/reflection.py
@@ -1,11 +1,12 @@
 from django.conf import settings
 from django.core.cache import cache
 
-from mathesar.models import Database, Table, Schema
 from mathesar.database.base import create_mathesar_engine
 from mathesar.database.utils import get_non_default_database_keys
 from db.tables import get_table_oids_from_schema
 from db.schemas import get_mathesar_schemas_with_oids
+# We import the entire models module to avoid a circular import error
+from mathesar import models
 
 DB_REFLECTION_KEY = 'database_reflected_recently'
 DB_REFLECTION_INTERVAL = 60 * 5  # we reflect DB changes every 5 minutes
@@ -17,17 +18,17 @@ def reflect_databases():
     databases.remove('default')
 
     # Update deleted databases
-    for database in Database.objects.all():
+    for database in models.Database.objects.all():
         if database.name in databases:
             databases.remove(database.name)
         else:
             database.deleted = True
-            Schema.objects.filter(database=database).delete()
+            models.Schema.objects.filter(database=database).delete()
             database.save()
 
     # Create databases that aren't models yet
     for database in databases:
-        Database.objects.create(name=database)
+        models.Database.objects.create(name=database)
 
 
 def reflect_schemas_from_database(database):
@@ -36,12 +37,12 @@ def reflect_schemas_from_database(database):
         schema["oid"] for schema in get_mathesar_schemas_with_oids(engine)
     }
 
-    database = Database.objects.get(name=database)
+    database = models.Database.objects.get(name=database)
     schemas = [
-        Schema.objects.get_or_create(oid=oid, database=database)
+        models.Schema.objects.get_or_create(oid=oid, database=database)
         for oid in db_schema_oids
     ]
-    for schema in Schema.objects.all():
+    for schema in models.Schema.objects.all():
         if schema.database.name == database and schema.oid not in db_schema_oids:
             schema.delete()
     return schemas
@@ -53,10 +54,10 @@ def reflect_tables_from_schema(schema):
         for table in get_table_oids_from_schema(schema.oid, schema._sa_engine)
     }
     tables = [
-        Table.objects.get_or_create(oid=oid, schema=schema)
+        models.Table.objects.get_or_create(oid=oid, schema=schema)
         for oid in db_table_oids
     ]
-    for table in Table.objects.all().filter(schema=schema):
+    for table in models.Table.objects.all().filter(schema=schema):
         if table.oid not in db_table_oids:
             table.delete()
     return tables
@@ -67,6 +68,6 @@ def reflect_db_objects():
         reflect_databases()
         for database_key in get_non_default_database_keys():
             reflect_schemas_from_database(database_key)
-        for schema in Schema.objects.all():
+        for schema in models.Schema.objects.all():
             reflect_tables_from_schema(schema)
         cache.set(DB_REFLECTION_KEY, True, DB_REFLECTION_INTERVAL)

--- a/mathesar/tests/conftest.py
+++ b/mathesar/tests/conftest.py
@@ -47,7 +47,7 @@ def django_db_setup(request, django_db_blocker) -> None:
 @pytest.fixture(scope="session", autouse=True)
 def test_db_model(test_db_name, django_db_blocker, django_db_setup):
     with django_db_blocker.unblock():
-        database_model = Database.objects.create(name=test_db_name)
+        database_model = Database.current_objects.create(name=test_db_name)
     return database_model
 
 

--- a/mathesar/tests/test_models.py
+++ b/mathesar/tests/test_models.py
@@ -1,6 +1,9 @@
+import pytest
 from unittest.mock import patch
 from django.core.cache import cache
+
 from mathesar import models
+from mathesar import reflection
 
 
 def test_schema_name_sets_cache(monkeypatch, test_db_model):
@@ -45,3 +48,17 @@ def test_schema_name_handles_missing(monkeypatch, test_db_model):
     schema = models.Schema(oid=123, database=test_db_model)
     name_ = schema.name
     assert name_ == 'MISSING'
+
+
+@pytest.mark.parametrize("model", [models.Database, models.Schema, models.Table])
+def test_model_queryset_reflects_db_objects(model):
+    with patch.object(reflection, 'reflect_db_objects') as mock_reflect:
+        model.objects.all()
+    mock_reflect.assert_called()
+
+
+@pytest.mark.parametrize("model", [models.Database, models.Schema, models.Table])
+def test_model_current_queryset_does_not_reflects_db_objects(model):
+    with patch.object(reflection, 'reflect_db_objects') as mock_reflect:
+        model.current_objects.all()
+    mock_reflect.assert_not_called()

--- a/mathesar/tests/views/api/test_database_api.py
+++ b/mathesar/tests/views/api/test_database_api.py
@@ -2,7 +2,7 @@ import pytest
 from django.conf import settings
 from django.core.cache import cache
 
-from mathesar.views.api import reflect_db_objects
+from mathesar.reflection import reflect_db_objects
 from mathesar.models import Table, Schema, Database
 from db.types import CUSTOM_TYPE_DICT
 from db.tests.types import fixtures

--- a/mathesar/tests/views/api/test_schema_api.py
+++ b/mathesar/tests/views/api/test_schema_api.py
@@ -5,7 +5,7 @@ from db import schemas
 from mathesar.database.base import create_mathesar_engine
 from mathesar.models import Schema, Database
 from mathesar import models
-from mathesar.views import api
+from mathesar import reflection
 from mathesar.utils.schemas import create_schema_and_object
 
 
@@ -58,7 +58,7 @@ def test_schema_list_filter(client, monkeypatch):
 
     monkeypatch.setattr(models.schemas, "get_schema_name_from_oid", mock_get_name_from_oid)
     monkeypatch.setattr(models, "create_mathesar_engine", lambda x: x)
-    monkeypatch.setattr(api, "reflect_db_objects", lambda: None)
+    monkeypatch.setattr(reflection, "reflect_db_objects", lambda: None)
 
     schemas = {
         (schema_params[i][0], schema_params[i][1]): Schema.objects.create(
@@ -288,14 +288,14 @@ def test_schema_get_with_reflect_delete(client, test_db_name):
 
 
 def test_schema_viewset_sets_cache(client):
-    cache.delete(api.DB_REFLECTION_KEY)
-    assert not cache.get(api.DB_REFLECTION_KEY)
+    cache.delete(reflection.DB_REFLECTION_KEY)
+    assert not cache.get(reflection.DB_REFLECTION_KEY)
     client.get('/api/v0/schemas/')
-    assert cache.get(api.DB_REFLECTION_KEY)
+    assert cache.get(reflection.DB_REFLECTION_KEY)
 
 
 def test_schema_viewset_checks_cache(client):
-    cache.delete(api.DB_REFLECTION_KEY)
-    with patch.object(api, 'reflect_schemas_from_database') as mock_reflect:
+    cache.delete(reflection.DB_REFLECTION_KEY)
+    with patch.object(reflection, 'reflect_schemas_from_database') as mock_reflect:
         client.get('/api/v0/schemas/')
     mock_reflect.assert_called()

--- a/mathesar/tests/views/api/test_table_api.py
+++ b/mathesar/tests/views/api/test_table_api.py
@@ -8,7 +8,7 @@ from sqlalchemy import text
 from mathesar.models import Table
 from mathesar.models import DataFile, Schema
 from mathesar.utils.schemas import create_schema_and_object
-from mathesar.views import api
+from mathesar import reflection
 from db.tests.types import fixtures
 from db import tables
 
@@ -508,14 +508,14 @@ def test_table_get_with_reflect_delete(client, table_for_reflection):
 
 
 def test_table_viewset_sets_cache(client):
-    cache.delete(api.DB_REFLECTION_KEY)
-    assert not cache.get(api.DB_REFLECTION_KEY)
+    cache.delete(reflection.DB_REFLECTION_KEY)
+    assert not cache.get(reflection.DB_REFLECTION_KEY)
     client.get('/api/v0/schemas/')
-    assert cache.get(api.DB_REFLECTION_KEY)
+    assert cache.get(reflection.DB_REFLECTION_KEY)
 
 
 def test_table_viewset_checks_cache(client):
-    cache.delete(api.DB_REFLECTION_KEY)
-    with patch.object(api, 'reflect_tables_from_schema') as mock_reflect:
+    cache.delete(reflection.DB_REFLECTION_KEY)
+    with patch.object(reflection, 'reflect_tables_from_schema') as mock_reflect:
         client.get('/api/v0/tables/')
     mock_reflect.assert_called()

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -9,7 +9,7 @@ router.register(r'tables', api.TableViewSet, basename='table')
 router.register(r'schemas', api.SchemaViewSet, basename='schema')
 router.register(r'database_keys', api.DatabaseKeyViewSet, basename='database-key')
 router.register(r'databases', api.DatabaseViewSet, basename='database')
-router.register(r'data_files', api.DataFileViewSet)
+router.register(r'data_files', api.DataFileViewSet, basename='data-file')
 
 table_router = routers.NestedSimpleRouter(router, r'tables', lookup='table')
 table_router.register(r'records', api.RecordViewSet, basename='table-record')

--- a/mathesar/utils/schemas.py
+++ b/mathesar/utils/schemas.py
@@ -1,10 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import ValidationError
 
-from db.schemas import (
-    create_schema, get_schema_oid_from_name, get_mathesar_schemas,
-    get_mathesar_schemas_with_oids
-)
+from db.schemas import create_schema, get_schema_oid_from_name, get_mathesar_schemas
 from mathesar.database.base import create_mathesar_engine
 from mathesar.models import Schema, Database
 
@@ -26,20 +23,3 @@ def create_schema_and_object(name, database):
 
     schema = Schema.objects.create(oid=schema_oid, database=database_model)
     return schema
-
-
-def reflect_schemas_from_database(database):
-    engine = create_mathesar_engine(database)
-    db_schema_oids = {
-        schema["oid"] for schema in get_mathesar_schemas_with_oids(engine)
-    }
-
-    database = Database.objects.get(name=database)
-    schemas = [
-        Schema.objects.get_or_create(oid=oid, database=database)
-        for oid in db_schema_oids
-    ]
-    for schema in Schema.objects.all():
-        if schema.database.name == database and schema.oid not in db_schema_oids:
-            schema.delete()
-    return schemas

--- a/mathesar/utils/tables.py
+++ b/mathesar/utils/tables.py
@@ -1,21 +1,6 @@
-from db.tables import get_table_oids_from_schema, infer_table_column_types, create_mathesar_table, get_oid_from_table
+from db.tables import infer_table_column_types, create_mathesar_table, get_oid_from_table
 from mathesar.database.base import create_mathesar_engine
 from mathesar.models import Table
-
-
-def reflect_tables_from_schema(schema):
-    db_table_oids = {
-        table["oid"]
-        for table in get_table_oids_from_schema(schema.oid, schema._sa_engine)
-    }
-    tables = [
-        Table.objects.get_or_create(oid=oid, schema=schema)
-        for oid in db_table_oids
-    ]
-    for table in Table.objects.all().filter(schema=schema):
-        if table.oid not in db_table_oids:
-            table.delete()
-    return tables
 
 
 def get_table_column_types(table):

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -129,7 +129,7 @@ class ColumnViewSet(viewsets.ViewSet):
 
     def list(self, request, table_pk=None):
         paginator = ColumnLimitOffsetPagination()
-        columns = paginator.paginate_queryset(self.get_queryset(self), request, table_pk)
+        columns = paginator.paginate_queryset(self.get_queryset(), request, table_pk)
         serializer = ColumnSerializer(columns, many=True)
         return paginator.get_paginated_response(serializer.data)
 
@@ -206,7 +206,7 @@ class RecordViewSet(viewsets.ViewSet):
 
         try:
             records = paginator.paginate_queryset(
-                self.get_queryset(self), request, table_pk,
+                self.get_queryset(), request, table_pk,
                 filters=filter_form.cleaned_data['filters'],
                 order_by=filter_form.cleaned_data['order_by'],
                 group_count_by=filter_form.cleaned_data['group_count_by'],

--- a/mathesar/views/api.py
+++ b/mathesar/views/api.py
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
 
 
 class SchemaViewSet(viewsets.GenericViewSet, ListModelMixin, RetrieveModelMixin):
-    queryset = Schema.objects.all().order_by('-created_at')
+    def get_queryset(self):
+        return Schema.objects.all().order_by('-created_at')
     serializer_class = SchemaSerializer
     pagination_class = DefaultLimitOffsetPagination
     filter_backends = (filters.DjangoFilterBackend,)
@@ -73,7 +74,9 @@ class SchemaViewSet(viewsets.GenericViewSet, ListModelMixin, RetrieveModelMixin)
 
 
 class TableViewSet(viewsets.GenericViewSet, ListModelMixin, RetrieveModelMixin):
-    queryset = Table.objects.all().order_by('-created_at')
+    def get_queryset(self):
+        return Table.objects.all().order_by('-created_at')
+
     serializer_class = TableSerializer
     pagination_class = DefaultLimitOffsetPagination
     filter_backends = (filters.DjangoFilterBackend,)
@@ -121,11 +124,12 @@ class TableViewSet(viewsets.GenericViewSet, ListModelMixin, RetrieveModelMixin):
 
 
 class ColumnViewSet(viewsets.ViewSet):
-    queryset = Table.objects.all().order_by('-created_at')
+    def get_queryset(self):
+        return Table.objects.all().order_by('-created_at')
 
     def list(self, request, table_pk=None):
         paginator = ColumnLimitOffsetPagination()
-        columns = paginator.paginate_queryset(self.get_queryset(), request, table_pk)
+        columns = paginator.paginate_queryset(self.get_queryset(self), request, table_pk)
         serializer = ColumnSerializer(columns, many=True)
         return paginator.get_paginated_response(serializer.data)
 
@@ -185,7 +189,8 @@ class RecordViewSet(viewsets.ViewSet):
     # There is no "update" method.
     # We're not supporting PUT requests because there aren't a lot of use cases
     # where the entire record needs to be replaced, PATCH suffices for updates.
-    queryset = Table.objects.all().order_by('-created_at')
+    def get_queryset(self):
+        return Table.objects.all().order_by('-created_at')
 
     # For filter parameter formatting, see:
     # https://github.com/centerofci/sqlalchemy-filters#filters-format
@@ -201,7 +206,7 @@ class RecordViewSet(viewsets.ViewSet):
 
         try:
             records = paginator.paginate_queryset(
-                self.get_queryset(), request, table_pk,
+                self.get_queryset(self), request, table_pk,
                 filters=filter_form.cleaned_data['filters'],
                 order_by=filter_form.cleaned_data['order_by'],
                 group_count_by=filter_form.cleaned_data['group_count_by'],
@@ -250,7 +255,8 @@ class DatabaseKeyViewSet(viewsets.ViewSet):
 
 
 class DatabaseViewSet(viewsets.GenericViewSet, ListModelMixin, RetrieveModelMixin):
-    queryset = Database.objects.all().order_by('-created_at')
+    def get_queryset(self):
+        return Database.objects.all().order_by('-created_at')
     serializer_class = DatabaseSerializer
     pagination_class = DefaultLimitOffsetPagination
     filter_backends = (filters.DjangoFilterBackend,)


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #365

Reflects all db objects before rendering the requested page.

**Technical details**
Adds a call to `reflect_db_objects` in `mathesar/views/frontend.py` before schemas are retrieved, ensuring that the initial data will be up to date. I've confirmed locally that this resolves the issue detailed in #365.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
