### PR TITLE
Explicitly declare header BooleanField in DataFileSerializer

### DIFF
--- a/mathesar/serializers.py
+++ b/mathesar/serializers.py
@@ -92,6 +92,7 @@ class DataFileSerializer(serializers.ModelSerializer):
     user = serializers.PrimaryKeyRelatedField(
         default=serializers.CurrentUserDefault(), read_only=True
     )
+    header = serializers.BooleanField(default=True)
 
     class Meta:
         model = DataFile
@@ -100,8 +101,8 @@ class DataFileSerializer(serializers.ModelSerializer):
         ]
         extra_kwargs = {'delimiter': {'trim_whitespace': False},
                         'escapechar': {'trim_whitespace': False},
-                        'quotechar': {'trim_whitespace': False},
-                        'header': {'required': True}}
+                        'quotechar': {'trim_whitespace': False}
+                        }
         # We only currently support importing to a new table, so setting a table via API is invalid.
         # User should be set automatically, not submitted via the API.
         read_only_fields = ['table_imported_to']


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #491

<!-- Concisely describe what the pull request does. -->
This PR ensures that the first row of an imported CSV file is used as a table header, instead of auto-generated `column-0`, etc. This is the working implementation, replacement for #493.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
The problem is that when a POST request for creating a DataFile is sent with the `header` BooleanField empty, it is automatically set to False. Therefore, the default for `header` defined in the DataFile model is not applied. This is a [newish behavior in Django for Boolean Fields](https://www.django-rest-framework.org/api-guide/fields/#booleanfield). 
To solve this, we manually declare header as a `BooleanField` in `DataFileSerializer` with default set to `True`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
