### PR TITLE
Floating point and Decimal types

### DIFF
--- a/db/tests/test_columns.py
+++ b/db/tests/test_columns.py
@@ -8,10 +8,12 @@ from sqlalchemy import (
 )
 from sqlalchemy.exc import IntegrityError
 from db import columns, tables, constants
-from db.types import email
+from db.types import email, alteration
 from db.tests.types import fixtures
 
 engine_with_types = fixtures.engine_with_types
+temporary_testing_schema = fixtures.temporary_testing_schema
+engine_email_type = fixtures.engine_email_type
 
 
 def init_column(*args, **kwargs):
@@ -383,10 +385,10 @@ def test_retype_column_correct_column(engine_with_schema):
     )
 
 
-def test_retype_column_adds_options(engine_with_schema):
+@pytest.mark.parametrize('target_type', ['numeric', 'decimal'])
+def test_retype_column_adds_options(engine_with_schema, target_type):
     engine, schema = engine_with_schema
     table_name = "atableone"
-    target_type = "numeric"
     target_column_name = "thecolumntochange"
     nontarget_column_name = "notthecolumntochange"
     table = Table(
@@ -404,19 +406,47 @@ def test_retype_column_adds_options(engine_with_schema):
         schema,
         table_name,
         target_column_name,
-        "numeric",
+        target_type,
         engine,
         friendly_names=False,
         type_options=type_options,
     )
 
 
-def test_create_column(engine_with_schema):
-    engine, schema = engine_with_schema
+type_set = {
+    'BOOLEAN',
+    'DECIMAL',
+    'DOUBLE PRECISION',
+    'FLOAT',
+    'INTERVAL',
+    'NUMERIC',
+    'REAL',
+    'VARCHAR',
+    'mathesar_types.email',
+}
+
+
+def test_type_list_completeness(engine_with_types):
+    """
+    This metatest ensures that tests parameterized on the type_set
+    use the entire set supported.
+    """
+    actual_supported_db_types = alteration.get_supported_alter_column_db_types(
+        engine_with_types
+    )
+    assert type_set == actual_supported_db_types
+
+
+@pytest.mark.parametrize("target_type", type_set)
+def test_create_column(engine_email_type, target_type):
+    engine, schema = engine_email_type
     table_name = "atableone"
-    target_type = "BOOLEAN"
     initial_column_name = "original_column"
     new_column_name = "added_column"
+    input_output_type_map = {type_: type_ for type_ in type_set}
+    # update the map with types that reflect differently than they're
+    # set when creating a column
+    input_output_type_map.update({'FLOAT': 'DOUBLE PRECISION', 'DECIMAL': 'NUMERIC'})
     table = Table(
         table_name,
         MetaData(bind=engine, schema=schema),
@@ -429,13 +459,13 @@ def test_create_column(engine_with_schema):
     altered_table = tables.reflect_table_from_oid(table_oid, engine)
     assert len(altered_table.columns) == 2
     assert created_col.name == new_column_name
-    assert created_col.type.compile(engine.dialect) == "BOOLEAN"
+    assert created_col.type.compile(engine.dialect) == input_output_type_map[target_type]
 
 
-def test_create_column_options(engine_with_schema):
-    engine, schema = engine_with_schema
+@pytest.mark.parametrize("target_type", ["NUMERIC", "DECIMAL"])
+def test_create_column_options(engine_email_type, target_type):
+    engine, schema = engine_email_type
     table_name = "atableone"
-    target_type = "NUMERIC"
     initial_column_name = "original_column"
     new_column_name = "added_column"
     table = Table(

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -284,11 +284,12 @@ def test_get_full_cast_map(engine_with_types):
     should be updated accordingly.
     """
     expect_cast_map = {
-        'NUMERIC': ['BOOLEAN', 'NUMERIC', 'VARCHAR'],
-        'VARCHAR': ['NUMERIC', 'VARCHAR', 'INTERVAL', 'mathesar_types.email', 'BOOLEAN'],
+        'FLOAT': ['BOOLEAN', 'FLOAT', 'NUMERIC', 'VARCHAR'],
+        'NUMERIC': ['BOOLEAN', 'FLOAT', 'NUMERIC', 'VARCHAR'],
+        'VARCHAR': ['NUMERIC', 'FLOAT', 'VARCHAR', 'INTERVAL', 'mathesar_types.email', 'BOOLEAN'],
         'mathesar_types.email': ['mathesar_types.email', 'VARCHAR'],
         'INTERVAL': ['INTERVAL', 'VARCHAR'],
-        'BOOLEAN': ['NUMERIC', 'BOOLEAN', 'VARCHAR']
+        'BOOLEAN': ['NUMERIC', 'FLOAT', 'BOOLEAN', 'VARCHAR']
     }
     actual_cast_map = alteration.get_full_cast_map(engine_with_types)
     assert len(actual_cast_map) == len(expect_cast_map)

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -18,6 +18,87 @@ engine_email_type = fixtures.engine_email_type
 temporary_testing_schema = fixtures.temporary_testing_schema
 
 
+BOOLEAN = "BOOLEAN"
+DECIMAL = "DECIMAL"
+DOUBLE = "DOUBLE PRECISION"
+EMAIL = "mathesar_types.email"
+FLOAT = "FLOAT"
+INTERVAL = "INTERVAL"
+NUMERIC = "NUMERIC"
+REAL = "REAL"
+VARCHAR = "VARCHAR"
+
+
+ISCHEMA_NAME = "ischema_name"
+TARGET_LIST = "target_list"
+REFLECTED_NAME = "reflected_name"
+SUPPORTED_MAP_NAME = "supported_map_name"
+
+MASTER_DB_TYPE_MAP_SPEC = {
+    # This dict specifies the full map of what types can be cast to what
+    # target types in Mathesar.  Format of each key, val pair is:
+    # <db_set_type_name>: {
+    #     ISCHEMA_NAME: <name for looking up in engine.dialect.ischema_names>,
+    #     REFLECTED_NAME: <name for reflection of db type>,
+    #     SUPPORTED_MAP_NAME: <optional; key in supported type map dictionaries>
+    #     TARGET_LIST: <list of target db types for alteration>,
+    # }
+    # The tuples in TARGET_LIST should be (set, reflect), where 'set' is
+    # a valid DB type for setting a column type, and 'reflect' is the
+    # type actually reflected afterwards
+    BOOLEAN: {
+        ISCHEMA_NAME: "boolean",
+        REFLECTED_NAME: BOOLEAN,
+        TARGET_LIST: [BOOLEAN, DECIMAL, DOUBLE, FLOAT, NUMERIC, REAL, VARCHAR]
+    },
+    DECIMAL: {
+        ISCHEMA_NAME: "decimal",
+        REFLECTED_NAME: NUMERIC,
+        TARGET_LIST: [BOOLEAN, DECIMAL, DOUBLE, FLOAT, NUMERIC, REAL, VARCHAR]
+    },
+    DOUBLE: {
+        ISCHEMA_NAME: "double precision",
+        REFLECTED_NAME: DOUBLE,
+        TARGET_LIST: [BOOLEAN, DECIMAL, DOUBLE, FLOAT, NUMERIC, REAL, VARCHAR]
+    },
+    FLOAT: {
+        ISCHEMA_NAME: "float",
+        REFLECTED_NAME: DOUBLE,
+        TARGET_LIST: [BOOLEAN, DECIMAL, DOUBLE, FLOAT, NUMERIC, REAL, VARCHAR]
+    },
+    INTERVAL: {
+        ISCHEMA_NAME: "interval",
+        REFLECTED_NAME: INTERVAL,
+        TARGET_LIST: [INTERVAL, VARCHAR]
+    },
+    EMAIL: {
+        ISCHEMA_NAME: "mathesar_types.email",
+        SUPPORTED_MAP_NAME: "email",
+        REFLECTED_NAME: EMAIL,
+        TARGET_LIST: [EMAIL, VARCHAR]
+    },
+    NUMERIC: {
+        ISCHEMA_NAME: "numeric",
+        REFLECTED_NAME: NUMERIC,
+        TARGET_LIST: [BOOLEAN, DECIMAL, DOUBLE, FLOAT, NUMERIC, REAL, VARCHAR]
+    },
+    REAL: {
+        ISCHEMA_NAME: "real",
+        REFLECTED_NAME: REAL,
+        TARGET_LIST: [BOOLEAN, DECIMAL, DOUBLE, FLOAT, NUMERIC, REAL, VARCHAR]
+    },
+    VARCHAR: {
+        ISCHEMA_NAME: "character varying",
+        SUPPORTED_MAP_NAME: "varchar",
+        REFLECTED_NAME: VARCHAR,
+        TARGET_LIST: [
+            BOOLEAN, DECIMAL, DOUBLE, EMAIL, FLOAT, INTERVAL, NUMERIC, REAL,
+            VARCHAR,
+        ]
+    }
+}
+
+
 def test_get_alter_column_types_with_custom_engine(engine_with_types):
     type_dict = alteration.get_supported_alter_column_types(engine_with_types)
     assert all(
@@ -41,13 +122,28 @@ def test_get_alter_column_types_with_unfriendly_names(engine_with_types):
 
 
 type_test_list = [
-    (String, "boolean", {}, "BOOLEAN"),
-    (String, "interval", {}, "INTERVAL"),
-    (String, "numeric", {}, "NUMERIC"),
-    (String, "numeric", {"precision": 5}, "NUMERIC(5, 0)"),
-    (String, "numeric", {"precision": 5, "scale": 3}, "NUMERIC(5, 3)"),
-    (String, "string", {}, "VARCHAR"),
-    (String, "email", {}, "mathesar_types.email"),
+    (
+        val[ISCHEMA_NAME],
+        MASTER_DB_TYPE_MAP_SPEC[target].get(
+            SUPPORTED_MAP_NAME, MASTER_DB_TYPE_MAP_SPEC[target][ISCHEMA_NAME]
+        ),
+        {},
+        MASTER_DB_TYPE_MAP_SPEC[target][REFLECTED_NAME]
+    )
+    for val in MASTER_DB_TYPE_MAP_SPEC.values()
+    for target in val[TARGET_LIST]
+] + [
+    (val[ISCHEMA_NAME], "numeric", {"precision": 5}, "NUMERIC(5, 0)")
+    for val in MASTER_DB_TYPE_MAP_SPEC.values() if NUMERIC in val[TARGET_LIST]
+] + [
+    (val[ISCHEMA_NAME], "numeric", {"precision": 5, "scale": 3}, "NUMERIC(5, 3)")
+    for val in MASTER_DB_TYPE_MAP_SPEC.values() if NUMERIC in val[TARGET_LIST]
+] + [
+    (val[ISCHEMA_NAME], "decimal", {"precision": 5}, "NUMERIC(5, 0)")
+    for val in MASTER_DB_TYPE_MAP_SPEC.values() if DECIMAL in val[TARGET_LIST]
+] + [
+    (val[ISCHEMA_NAME], "decimal", {"precision": 5, "scale": 3}, "NUMERIC(5, 3)")
+    for val in MASTER_DB_TYPE_MAP_SPEC.values() if DECIMAL in val[TARGET_LIST]
 ]
 
 
@@ -57,6 +153,11 @@ type_test_list = [
 def test_alter_column_type_alters_column_type(
         engine_email_type, type_, target_type, options, expect_type
 ):
+    """
+    The massive number of cases make sure all type casting functions at
+    least pass a smoke test for each type mapping defined in
+    MASTER_DB_TYPE_MAP_SPEC above.
+    """
     engine, schema = engine_email_type
     TABLE_NAME = "testtable"
     COLUMN_NAME = "testcol"
@@ -64,7 +165,7 @@ def test_alter_column_type_alters_column_type(
     input_table = Table(
         TABLE_NAME,
         metadata,
-        Column(COLUMN_NAME, type_),
+        Column(COLUMN_NAME, engine.dialect.ischema_names[type_]),
         schema=schema
     )
     input_table.create()
@@ -272,67 +373,8 @@ def test_get_column_cast_expression_numeric_options(
 
 
 expect_cast_tuples = [
-    # This list specifies the full map of what types can be cast to what
-    # target types in Mathesar.  When the map is modified, this test
-    # should be updated accordingly.
-    (
-        'BOOLEAN',
-        [
-            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
-            'REAL', 'VARCHAR',
-        ]
-    ),
-    (
-        'DECIMAL',
-        [
-            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
-            'REAL', 'VARCHAR'
-        ]
-    ),
-    (
-        'DOUBLE PRECISION',
-        [
-            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
-            'REAL', 'VARCHAR',
-        ]
-    ),
-    (
-        'FLOAT',
-        [
-            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
-            'REAL', 'VARCHAR',
-        ]
-    ),
-    (
-        'INTERVAL',
-        ['INTERVAL', 'VARCHAR']
-    ),
-    (
-        'mathesar_types.email',
-        ['mathesar_types.email', 'VARCHAR']
-    ),
-    (
-        'NUMERIC',
-        [
-            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
-            'REAL', 'VARCHAR',
-        ]
-    ),
-    (
-        'REAL',
-        [
-            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
-            'REAL', 'VARCHAR'
-        ]
-    ),
-    (
-        'VARCHAR',
-        [
-            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'INTERVAL',
-            'mathesar_types.email', 'NUMERIC', 'REAL', 'VARCHAR',
-        ]
-    ),
-
+    (key, [target for target in val[TARGET_LIST]])
+    for key, val in MASTER_DB_TYPE_MAP_SPEC.items()
 ]
 
 

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -18,12 +18,6 @@ engine_email_type = fixtures.engine_email_type
 temporary_testing_schema = fixtures.temporary_testing_schema
 
 
-def test_get_alter_column_types_with_standard_engine(engine):
-    type_dict = alteration.get_supported_alter_column_types(engine)
-    assert len(type_dict) > 0
-    assert all([type_ not in type_dict for type_ in types.CUSTOM_TYPE_DICT])
-
-
 def test_get_alter_column_types_with_custom_engine(engine_with_types):
     type_dict = alteration.get_supported_alter_column_types(engine_with_types)
     assert all(
@@ -284,22 +278,29 @@ expect_cast_tuples = [
     (
         'BOOLEAN',
         [
-            'NUMERIC', 'DOUBLE PRECISION', 'FLOAT', 'BOOLEAN', 'REAL',
-            'VARCHAR',
+            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
+            'REAL', 'VARCHAR',
+        ]
+    ),
+    (
+        'DECIMAL',
+        [
+            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
+            'REAL', 'VARCHAR'
         ]
     ),
     (
         'DOUBLE PRECISION',
         [
-            'BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL',
-            'VARCHAR',
+            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
+            'REAL', 'VARCHAR',
         ]
     ),
     (
         'FLOAT',
         [
-            'BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL',
-            'VARCHAR',
+            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
+            'REAL', 'VARCHAR',
         ]
     ),
     (
@@ -312,16 +313,22 @@ expect_cast_tuples = [
     ),
     (
         'NUMERIC',
-        ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL', 'VARCHAR']
+        [
+            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
+            'REAL', 'VARCHAR',
+        ]
     ),
     (
         'REAL',
-        ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL', 'VARCHAR']
+        [
+            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC',
+            'REAL', 'VARCHAR'
+        ]
     ),
     (
         'VARCHAR',
         [
-            'BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'INTERVAL',
+            'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT', 'INTERVAL',
             'mathesar_types.email', 'NUMERIC', 'REAL', 'VARCHAR',
         ]
     ),

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -277,29 +277,61 @@ def test_get_column_cast_expression_numeric_options(
     assert str(cast_expr) == expect_cast_expr
 
 
-def test_get_full_cast_map(engine_with_types):
-    """
-    This test specifies the full map of what types can be cast to what
-    target types in Mathesar.  When the map is modified, this test
-    should be updated accordingly.
-    """
-    expect_cast_map = {
-        'FLOAT': ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'VARCHAR'],
-        'DOUBLE PRECISION': ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'VARCHAR'],
-        'NUMERIC': ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'VARCHAR'],
-        'VARCHAR': [
-            'NUMERIC', 'DOUBLE PRECISION', 'FLOAT', 'VARCHAR', 'INTERVAL',
-            'mathesar_types.email', 'BOOLEAN'
-        ],
-        'mathesar_types.email': ['mathesar_types.email', 'VARCHAR'],
-        'INTERVAL': ['INTERVAL', 'VARCHAR'],
-        'BOOLEAN': ['NUMERIC', 'DOUBLE PRECISION', 'FLOAT', 'BOOLEAN', 'VARCHAR']
-    }
-    actual_cast_map = alteration.get_full_cast_map(engine_with_types)
-    assert len(actual_cast_map) == len(expect_cast_map)
-    assert all(
+expect_cast_tuples = [
+    # This list specifies the full map of what types can be cast to what
+    # target types in Mathesar.  When the map is modified, this test
+    # should be updated accordingly.
+    (
+        'BOOLEAN',
         [
-            sorted(actual_cast_map[type_]) == sorted(expect_target_list)
-            for type_, expect_target_list in expect_cast_map.items()
+            'NUMERIC', 'DOUBLE PRECISION', 'FLOAT', 'BOOLEAN', 'REAL',
+            'VARCHAR',
         ]
-    )
+    ),
+    (
+        'DOUBLE PRECISION',
+        [
+            'BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL',
+            'VARCHAR',
+        ]
+    ),
+    (
+        'FLOAT',
+        [
+            'BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL',
+            'VARCHAR',
+        ]
+    ),
+    (
+        'INTERVAL',
+        ['INTERVAL', 'VARCHAR']
+    ),
+    (
+        'mathesar_types.email',
+        ['mathesar_types.email', 'VARCHAR']
+    ),
+    (
+        'NUMERIC',
+        ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL', 'VARCHAR']
+    ),
+    (
+        'REAL',
+        ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'REAL', 'VARCHAR']
+    ),
+    (
+        'VARCHAR',
+        [
+            'BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'INTERVAL',
+            'mathesar_types.email', 'NUMERIC', 'REAL', 'VARCHAR',
+        ]
+    ),
+
+]
+
+
+@pytest.mark.parametrize("source_type,expect_target_types", expect_cast_tuples)
+def test_get_full_cast_map(engine_with_types, source_type, expect_target_types):
+    actual_cast_map = alteration.get_full_cast_map(engine_with_types)
+    actual_target_types = actual_cast_map[source_type]
+    assert len(actual_target_types) == len(expect_target_types)
+    assert sorted(actual_target_types) == sorted(expect_target_types)

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -284,12 +284,16 @@ def test_get_full_cast_map(engine_with_types):
     should be updated accordingly.
     """
     expect_cast_map = {
-        'FLOAT': ['BOOLEAN', 'FLOAT', 'NUMERIC', 'VARCHAR'],
-        'NUMERIC': ['BOOLEAN', 'FLOAT', 'NUMERIC', 'VARCHAR'],
-        'VARCHAR': ['NUMERIC', 'FLOAT', 'VARCHAR', 'INTERVAL', 'mathesar_types.email', 'BOOLEAN'],
+        'FLOAT': ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'VARCHAR'],
+        'DOUBLE PRECISION': ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'VARCHAR'],
+        'NUMERIC': ['BOOLEAN', 'DOUBLE PRECISION', 'FLOAT', 'NUMERIC', 'VARCHAR'],
+        'VARCHAR': [
+            'NUMERIC', 'DOUBLE PRECISION', 'FLOAT', 'VARCHAR', 'INTERVAL',
+            'mathesar_types.email', 'BOOLEAN'
+        ],
         'mathesar_types.email': ['mathesar_types.email', 'VARCHAR'],
         'INTERVAL': ['INTERVAL', 'VARCHAR'],
-        'BOOLEAN': ['NUMERIC', 'FLOAT', 'BOOLEAN', 'VARCHAR']
+        'BOOLEAN': ['NUMERIC', 'DOUBLE PRECISION', 'FLOAT', 'BOOLEAN', 'VARCHAR']
     }
     actual_cast_map = alteration.get_full_cast_map(engine_with_types)
     assert len(actual_cast_map) == len(expect_cast_map)

--- a/db/types/__init__.py
+++ b/db/types/__init__.py
@@ -1,5 +1,10 @@
+from sqlalchemy import DECIMAL as sa_decimal
 from db.types import email
+from db.types.alteration import DECIMAL
 
 CUSTOM_TYPE_DICT = {
+    # For some reason, SQLAlchemy doesn't add DECIMAL to the default
+    # ischema_names supported by a PostgreSQL engine
+    DECIMAL: sa_decimal,
     email.QUALIFIED_EMAIL: email.Email,
 }

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -392,7 +392,7 @@ def _get_varchar_type_body_map(engine):
     All types in get_supported_alter_column_types are supported.
     """
     supported_types = get_supported_alter_column_db_types(engine)
-    return _get_default_type_body_map( supported_types, VARCHAR, )
+    return _get_default_type_body_map(supported_types, VARCHAR)
 
 
 def _get_default_type_body_map(source_types, target_type_str):

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -354,6 +354,37 @@ def _get_numeric_type_body_map():
     }
 
 
+def _get_float_type_body_map():
+    """
+    Get SQL strings that create various functions for casting different
+    types to floats.
+
+    numeric -> float:  Identity. No remarks
+    boolean -> float:  We cast TRUE -> 1, FALSE -> 0
+    varchar -> float:  We use the default PostgreSQL behavior.
+    """
+    return {
+        FLOAT: """
+        BEGIN
+          RETURN $1;
+        END;
+        """,
+        BOOLEAN: f"""
+        BEGIN
+          IF $1 THEN
+            RETURN 1::{FLOAT};
+          END IF;
+          RETURN 0::{FLOAT};
+        END;
+        """,
+        VARCHAR: f"""
+        BEGIN
+          RETURN $1::{FLOAT};
+        END;
+        """,
+    }
+
+
 def _get_varchar_type_body_map(engine):
     """
     Get SQL strings that create various functions for casting different

--- a/mathesar/tests/views/api/test_column_api.py
+++ b/mathesar/tests/views/api/test_column_api.py
@@ -71,6 +71,7 @@ def test_column_list(column_test_table, client):
             'primary_key': False,
             'valid_target_types': [
                 'BOOLEAN',
+                'DOUBLE PRECISION',
                 'FLOAT',
                 'INTERVAL',
                 'NUMERIC',

--- a/mathesar/tests/views/api/test_column_api.py
+++ b/mathesar/tests/views/api/test_column_api.py
@@ -71,6 +71,7 @@ def test_column_list(column_test_table, client):
             'primary_key': False,
             'valid_target_types': [
                 'BOOLEAN',
+                'FLOAT',
                 'INTERVAL',
                 'NUMERIC',
                 'VARCHAR',

--- a/mathesar/tests/views/api/test_column_api.py
+++ b/mathesar/tests/views/api/test_column_api.py
@@ -71,6 +71,7 @@ def test_column_list(column_test_table, client):
             'primary_key': False,
             'valid_target_types': [
                 'BOOLEAN',
+                'DECIMAL',
                 'DOUBLE PRECISION',
                 'FLOAT',
                 'INTERVAL',

--- a/mathesar/tests/views/api/test_column_api.py
+++ b/mathesar/tests/views/api/test_column_api.py
@@ -75,6 +75,7 @@ def test_column_list(column_test_table, client):
                 'FLOAT',
                 'INTERVAL',
                 'NUMERIC',
+                'REAL',
                 'VARCHAR',
                 'mathesar_types.email',
             ],


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #381 
Fixes #382
Fixes #383 


<!-- Concisely describe what the pull request does. -->

This PR adds backend support for `DECIMAL`, `FLOAT`, `DOUBLE PRECISION`, and `REAL` data types.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

- SQLAlchemy uses `DOUBLE PRECISION` for its `Float` type by default.  We'll use that behavior, and so we're setting up `FLOAT` and `DOUBLE PRECISION` up as aliases.
- None of the types in this PR are targets for type inference, so no changes were made to inference logic.
- This PR makes major changes to the tests for type casting and column alteration.  There are now a large number of automatically-generated test cases for type casting.  The reason for these cases, and for automatically generating them, is to make sure there's at least one smoke test for each source, target pair for each type casting function.  The auto-generated tests don't actually _run_ each SQL function, but do ensure that they exist with the proper function signatures.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
