### PR TITLE
Pin ansible docker image to specific version

### DIFF
--- a/.github/actions/ansible/Dockerfile
+++ b/.github/actions/ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/ansible-runner:latest
+FROM quay.io/ansible/ansible-runner:stable-2.11-latest
 
 # Required addons that don't come by default
 RUN ansible-galaxy collection install ansible.posix -p /usr/share/ansible/collections \


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #534

Pins the ansible version to 2.11 when running via github actions.

**Technical details**
Previously used latest, which recently changed to version 2.12 and caused different behaviour. Tested this by using this image locally. With the 'latest' version, we get prompted to accept the host key, which can be seen when running the docker image locally:

```
TASK [Gathering Facts] ****************************************************************************************************************************************
The authenticity of host 'staging.mathesar.org (34.134.65.106)' can't be established.
ECDSA key fingerprint is SHA256:mNL78aXqeJKgfaRMeT6X1x2bnx+DKnvoYd0HdPtYy1I.
Are you sure you want to continue connecting (yes/no/[fingerprint])? 
```

When  switching to 2.11 (which was previously latest:

```
TASK [Gathering Facts] ****************************************************************************************************************************************
ok: [staging.mathesar.org]
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
