### PR TITLE
Implement `DATE` type in the backend

### DIFF
--- a/db/columns.py
+++ b/db/columns.py
@@ -160,8 +160,6 @@ class MathesarColumn(Column):
 
     @property
     def default_value(self):
-        print(self.table_)
-        print(self.original_table)
         if self.table_ is not None:
             table_oid = tables.get_oid_from_table(
                 self.table_.name, self.table_.schema, self.engine

--- a/db/tests/types/test_alteration.py
+++ b/db/tests/types/test_alteration.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import timedelta, date
 from decimal import Decimal
 
 import pytest
@@ -31,6 +31,7 @@ INTERVAL = PostgresType.INTERVAL.value.upper()
 NUMERIC = PostgresType.NUMERIC.value.upper()
 REAL = PostgresType.REAL.value.upper()
 SMALLINT = PostgresType.SMALLINT.value.upper()
+DATE = PostgresType.DATE.value.upper()
 VARCHAR = "VARCHAR"
 
 
@@ -268,6 +269,14 @@ MASTER_DB_TYPE_MAP_SPEC = {
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
+    DATE: {
+        ISCHEMA_NAME: PostgresType.DATE.value,
+        REFLECTED_NAME: DATE,
+        TARGET_DICT: {
+            DATE: {VALID: [(date(1999, 1, 18), date(1999, 1, 18))]},
+            VARCHAR: {VALID: [(date(1999, 1, 18), "1999-01-18")]},
+        },
+    },
     VARCHAR: {
         ISCHEMA_NAME: PostgresType.CHARACTER_VARYING.value,
         SUPPORTED_MAP_NAME: "varchar",
@@ -326,6 +335,19 @@ MASTER_DB_TYPE_MAP_SPEC = {
             SMALLINT: {
                 VALID: [("432", 432)],
                 INVALID: ["1.2234"]
+            },
+            DATE: {
+                VALID: [
+                    ("1999-01-18", date(1999, 1, 18)),
+                    ("1/18/1999", date(1999, 1, 18)),
+                    ("jan-1999-18", date(1999, 1, 18)),
+                    ("19990118", date(1999, 1, 18)),
+                ],
+                INVALID: [
+                    "18/1/1999",
+                    "not a date",
+                    "1234",
+                ]
             },
             VARCHAR: {VALID: [("a string", "a string")]},
         }

--- a/db/tests/types/test_inference.py
+++ b/db/tests/types/test_inference.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 from sqlalchemy import Column, MetaData, Table, select
-from sqlalchemy import BOOLEAN, Numeric, NUMERIC, String, VARCHAR
+from sqlalchemy import BOOLEAN, Numeric, NUMERIC, String, VARCHAR, DATE
 from db.tests.types import fixtures
 from db.types import inference
 
@@ -21,6 +21,7 @@ type_data_list = [
     (String, ["t", "false", "2", "0"], VARCHAR),
     (String, ["a", "cat", "mat", "bat"], VARCHAR),
     (String, ["2", "1", "0", "0"], NUMERIC),
+    (String, ["2000-01-12", "6/23/2004", "May-2007-29", "20200909"], DATE),
 ]
 
 

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -171,6 +171,7 @@ def install_all_casts(engine):
     create_integer_casts(engine)
     create_decimal_number_casts(engine)
     create_interval_casts(engine)
+    create_date_casts(engine)
     create_varchar_casts(engine)
 
 
@@ -201,6 +202,11 @@ def create_decimal_number_casts(engine):
     for type_str in decimal_number_types:
         type_body_map = _get_decimal_number_type_body_map(target_type_str=type_str)
         create_cast_functions(type_str, type_body_map, engine)
+
+
+def create_date_casts(engine):
+    type_body_map = _get_date_type_body_map()
+    create_cast_functions(DATE, type_body_map, engine)
 
 
 def create_varchar_casts(engine):
@@ -237,6 +243,7 @@ def get_defined_source_target_cast_tuples(engine):
         NUMERIC: _get_decimal_number_type_body_map(target_type_str=NUMERIC),
         REAL: _get_decimal_number_type_body_map(target_type_str=REAL),
         SMALLINT: _get_integer_type_body_map(target_type_str=SMALLINT),
+        DATE: _get_date_type_body_map(),
         VARCHAR: _get_varchar_type_body_map(engine),
     }
     return {
@@ -471,6 +478,13 @@ def _get_varchar_type_body_map(engine):
     """
     supported_types = get_supported_alter_column_db_types(engine)
     return _get_default_type_body_map(supported_types, VARCHAR)
+
+
+def _get_date_type_body_map():
+    default_behavior_source_types = [DATE, VARCHAR]
+    return _get_default_type_body_map(
+        default_behavior_source_types, DATE,
+    )
 
 
 def _get_default_type_body_map(source_types, target_type_str):

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -481,6 +481,8 @@ def _get_varchar_type_body_map(engine):
 
 
 def _get_date_type_body_map():
+    # Note that default postgres conversion for dates depends on the `DateStyle` option
+    # set on the server, which can be one of DMY, MDY, or YMD. Defaults to MDY.
     default_behavior_source_types = [DATE, VARCHAR]
     return _get_default_type_body_map(
         default_behavior_source_types, DATE,

--- a/db/types/inference.py
+++ b/db/types/inference.py
@@ -23,6 +23,7 @@ TYPE_INFERENCE_DAG = {
     base.STRING: [
         base.PostgresType.BOOLEAN.value,
         base.PostgresType.NUMERIC.value,
+        base.PostgresType.DATE.value,
         base.PostgresType.INTERVAL.value,
         base.MathesarCustomType.EMAIL.value,
     ],

--- a/mathesar/tests/views/api/test_column_api.py
+++ b/mathesar/tests/views/api/test_column_api.py
@@ -86,7 +86,7 @@ def test_column_list(column_test_table, client):
             'nullable': True,
             'primary_key': False,
             'valid_target_types': [
-                'BIGINT', 'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT',
+                'BIGINT', 'BOOLEAN', 'DATE', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT',
                 'INTEGER', 'INTERVAL', 'MATHESAR_TYPES.EMAIL', 'NUMERIC',
                 'REAL', 'SMALLINT', 'VARCHAR',
             ],


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #425

Implements the `DATE` type for use in column alterations in the backend.

**Technical details**
Uses the default postgres string -> date conversion, see [here](https://www.postgresql.org/docs/13/datatype-datetime.html#DATATYPE-DATETIME-INPUT).

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
