### PR TITLE
Improvements to column `PATCH` endpoint

### DIFF
--- a/db/columns.py
+++ b/db/columns.py
@@ -275,96 +275,92 @@ def create_column(engine, table_oid, column_data):
     )
 
 
-def alter_column(
-        engine,
-        table_oid,
-        column_index,
-        column_definition_dict,
-):
-    attribute_alter_map = {
-        TYPE: retype_column,
-        "plain_type": retype_column,
-        NULLABLE: change_column_nullable,
-        "default_value": set_column_default,
-        NAME: rename_column
-    }
+def alter_column(engine, table_oid, column_index, column_data):
+    TYPE_KEY = 'plain_type'
+    TYPE_OPTIONS_KEY = 'type_options'
+    NULLABLE_KEY = NULLABLE
+    DEFAULT_KEY = 'default_value'
+    NAME_KEY = NAME
+
     table = tables.reflect_table_from_oid(table_oid, engine)
     column_index = int(column_index)
+
     with engine.begin() as conn:
-        for column_def_key in attribute_alter_map.keys():
-            if column_def_key in column_definition_dict:
-                attribute_alter_map[column_def_key](
-                    table_oid,
-                    column_index,
-                    column_definition_dict[column_def_key],
-                    engine,
-                    connection_to_use=conn,
-                    table_to_use=table,
-                    type_options=column_definition_dict.get("type_options", {})
-                )
+        if TYPE_KEY in column_data:
+            new_type = column_data[TYPE_KEY]
+            type_options = column_data.get(TYPE_OPTIONS_KEY, {})
+            retype_column(table, column_index, engine, conn, new_type, type_options)
+        if NULLABLE_KEY in column_data:
+            nullable = column_data[NULLABLE_KEY]
+            change_column_nullable(table, column_index, engine, conn, nullable)
+        if DEFAULT_KEY in column_data:
+            default = column_data[DEFAULT_KEY]
+            set_column_default(table, column_index, engine, conn, default)
+        if NAME_KEY in column_data:
+            # Name always needs to be the last item altered
+            # since previous operations need the name to work
+            name = column_data[NAME_KEY]
+            rename_column(table, column_index, engine, conn, name)
+
     return get_mathesar_column_with_engine(
         tables.reflect_table_from_oid(table_oid, engine).columns[column_index],
         engine
     )
 
 
-def _alter_column_nullable(ctx, table_name, column_name, nullable, schema):
-    op = Operations(ctx)
-    op.alter_column(table_name, column_name, nullable=nullable, schema=schema)
-
-
-def change_column_nullable(table_oid, column_index, nullable, engine, connection_to_use=None, table_to_use=None, **kwargs):
-    table = table_to_use
-    if table is None:
-        table = tables.reflect_table_from_oid(table_oid, engine)
+def retype_column(table, column_index, engine, connection, new_type, type_options={}):
     column = table.columns[column_index]
-    if connection_to_use is None:
-        with engine.begin() as conn:
-            ctx = MigrationContext.configure(conn)
-            _alter_column_nullable(ctx, table.name, column.name, nullable, table.schema)
-    else:
-        ctx = MigrationContext.configure(connection_to_use)
-        _alter_column_nullable(ctx, table.name, column.name, nullable, table.schema)
-
-    if not connection_to_use:
-        return get_mathesar_column_with_engine(
-            tables.reflect_table_from_oid(table_oid, engine).columns[column_index],
-            engine
+    column_db_type = get_db_type_name(column.type, engine)
+    column_type_options = MathesarColumn.from_column(column).type_options
+    if (new_type == column_db_type) and _check_type_option_equivalence(type_options, column_type_options):
+        return
+    try:
+        alteration.alter_column_type(
+            table,
+            table.columns[column_index].name,
+            engine,
+            connection,
+            new_type,
+            type_options,
+            friendly_names=False
         )
+    except DataError as e:
+        if type(e.orig) == InvalidParameterValue:
+            raise InvalidTypeOptionError
+        if type(e.orig) == InvalidTextRepresentation:
+            raise InvalidTypeError
+        else:
+            raise e
+    except InternalError as e:
+        raise e.orig
 
 
-def _alter_column_name(ctx, table_name, column_name, new_column_name, schema):
-    op = Operations(ctx)
-    op.alter_column(table_name, column_name, new_column_name=new_column_name, schema=schema)
-
-
-def rename_column(table_oid, column_index, new_column_name, engine, connection_to_use=None, table_to_use=None, **kwargs):
-    table = table_to_use
-    if table is None:
-        table = tables.reflect_table_from_oid(table_oid, engine)
+def change_column_nullable(table, column_index, engine, connection, nullable):
     column = table.columns[column_index]
-    if connection_to_use is None:
-        with engine.begin() as conn:
-            ctx = MigrationContext.configure(conn)
-            _alter_column_name(ctx, table.name, column.name, new_column_name, table.schema)
-    else:
-        ctx = MigrationContext.configure(connection_to_use)
-        _alter_column_name(ctx, table.name, column.name, new_column_name, table.schema)
-
-    if not connection_to_use:
-        return get_mathesar_column_with_engine(
-            tables.reflect_table_from_oid(table_oid, engine).columns[column_index],
-            engine
-        )
+    ctx = MigrationContext.configure(connection)
+    op = Operations(ctx)
+    op.alter_column(table.name, column.name, nullable=nullable, schema=table.schema)
 
 
-def _handle_retype_data_errors(e):
-    if type(e.orig) == InvalidParameterValue:
-        raise InvalidTypeOptionError
-    if type(e.orig) == InvalidTextRepresentation:
-        raise InvalidTypeError
-    else:
-        raise e
+def set_column_default(table, column_index, engine, connection, default):
+    column = table.columns[column_index]
+    default_clause = DefaultClause(str(default)) if default is not None else default
+    try:
+        ctx = MigrationContext.configure(connection)
+        op = Operations(ctx)
+        op.alter_column(table.name, column.name, schema=table.schema, server_default=default_clause)
+    except DataError as e:
+        if (type(e.orig) == InvalidTextRepresentation):
+            raise InvalidDefaultError
+        else:
+            raise e
+
+
+def rename_column(table, column_index, engine, connection, new_name):
+    column = table.columns[column_index]
+    ctx = MigrationContext.configure(connection)
+    op = Operations(ctx)
+    op.alter_column(table.name, column.name, new_column_name=new_name, schema=table.schema)
 
 
 def _check_type_option_equivalence(type_options_1, type_options_2):
@@ -374,39 +370,6 @@ def _check_type_option_equivalence(type_options_1, type_options_2):
     elif type_options_1 == type_options_2:
         return True
     return False
-
-
-def retype_column(table_oid, column_index, new_type, engine, type_options={}, connection_to_use=None, table_to_use=None):
-    table = table_to_use
-    if table is None:
-        table = tables.reflect_table_from_oid(table_oid, engine)
-    column = table.columns[column_index]
-    column_db_type = get_db_type_name(column.type, engine)
-    column_type_options = MathesarColumn.from_column(column).type_options
-    if (new_type == column_db_type) and _check_type_option_equivalence(type_options, column_type_options):
-        return
-    try:
-        alteration.alter_column_type(
-            table.schema,
-            table.name,
-            table.columns[column_index].name,
-            new_type,
-            engine,
-            friendly_names=False,
-            type_options=type_options,
-            connection_to_use=connection_to_use,
-            table_to_use=table_to_use
-        )
-    except DataError as e:
-        _handle_retype_data_errors(e)
-    except InternalError as e:
-        raise e.orig
-
-    if connection_to_use is None:
-        return get_mathesar_column_with_engine(
-            tables.reflect_table_from_oid(table_oid, engine).columns[column_index],
-            engine
-        )
 
 
 def get_mathesar_column_with_engine(col, engine):
@@ -427,14 +390,13 @@ def _validate_columns_for_batch_update(table, column_data):
 
 
 def _batch_update_column_types(table, column_data_list, connection, engine):
-    table_oid = tables.get_oid_from_table(table.name, table.schema, engine)
     for index, column_data in enumerate(column_data_list):
         if 'plain_type' in column_data:
             new_type = column_data['plain_type']
             type_options = column_data.get('type_options', {})
             if type_options is None:
                 type_options = {}
-            retype_column(table_oid, index, new_type, engine, type_options, connection_to_use=connection, table_to_use=table)
+            retype_column(table, index, engine, connection, new_type, type_options)
 
 
 def _batch_alter_table_columns(table, column_data_list, connection):
@@ -518,40 +480,6 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None, 
     return execute_statement(engine, select(text(cast_sql_text)), connection_to_use).first()[0]
 
 
-def _alter_column_default(ctx, table_name, column_name, schema, default_clause):
-    op = Operations(ctx)
-    op.alter_column(table_name, column_name, schema=schema, server_default=default_clause)
-
-
-def set_column_default(table_oid, column_index, default, engine, connection_to_use=None,
-                       table_to_use=None, **_):
-    # Note: default should be textual SQL that produces the desired default
-    if table_to_use is None:
-        table = tables.reflect_table_from_oid(table_oid, engine)
-    else:
-        table = table_to_use
-    column = table.columns[column_index]
-    default_clause = DefaultClause(str(default)) if default is not None else default
-    try:
-        if connection_to_use is None:
-            with engine.begin() as conn:
-                ctx = MigrationContext.configure(conn)
-                _alter_column_default(ctx, table.name, column.name, table.schema, default_clause)
-        else:
-            ctx = MigrationContext.configure(connection_to_use)
-            _alter_column_default(ctx, table.name, column.name, table.schema, default_clause)
-    except DataError as e:
-        if (type(e.orig) == InvalidTextRepresentation):
-            raise InvalidDefaultError
-        else:
-            raise e
-    if connection_to_use is None:
-        return get_mathesar_column_with_engine(
-            tables.reflect_table_from_oid(table_oid, engine).columns[column_index],
-            engine
-        )
-
-
 def _gen_col_name(table, column_name):
     num = 1
     new_column_name = f"{column_name}_{num}"
@@ -592,16 +520,16 @@ def duplicate_column_data(table_oid, from_column, to_column, engine):
 
     from_default = get_column_default(table_oid, from_column, engine)
     if from_default is not None:
-        set_column_default(table_oid, to_column, from_default, engine)
+        with engine.begin() as conn:
+            set_column_default(table, to_column, engine, conn, from_default)
 
 
 def duplicate_column_constraints(table_oid, from_column, to_column, engine,
                                  copy_nullable=True):
     table = tables.reflect_table_from_oid(table_oid, engine)
     if copy_nullable:
-        change_column_nullable(
-            table_oid, to_column, table.c[from_column].nullable, engine
-        )
+        with engine.begin() as conn:
+            change_column_nullable(table, to_column, engine, conn, table.c[from_column].nullable)
 
     constraints_ = constraints.get_column_constraints(from_column, table_oid, engine)
     for constraint in constraints_:

--- a/db/columns.py
+++ b/db/columns.py
@@ -432,6 +432,15 @@ def drop_column(table_oid, column_index, engine):
         op.drop_column(table.name, column.name, schema=table.schema)
 
 
+def get_default_textual_sql(server_default):
+    # server_default.arg can be a string or `DefaultClause` depending on how a table
+    # default was initialized and whether or not it was reflected.
+    if type(server_default.arg) is str:
+        return server_default.arg
+    else:
+        return server_default.arg.text
+
+
 def get_column_default(table_oid, column_index, engine, connection_to_use=None, table_to_use=None):
     table = table_to_use
     if table is None:
@@ -473,10 +482,10 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None, 
     if result.startswith("{FUNCEXPR"):
         return None
 
+    cast_sql_text = get_default_textual_sql(column.server_default)
     # Defaults are stored as text with SQL casts appended
     # Ex: "'test default string'::character varying" or "'2020-01-01'::date"
     # Here, we execute the cast to get the proper python value
-    cast_sql_text = column.server_default.arg.text
     return execute_statement(engine, select(text(cast_sql_text)), connection_to_use).first()[0]
 
 

--- a/db/columns.py
+++ b/db/columns.py
@@ -432,19 +432,8 @@ def drop_column(table_oid, column_index, engine):
         op.drop_column(table.name, column.name, schema=table.schema)
 
 
-def get_default_textual_sql(server_default):
-    # server_default.arg can be a string or `DefaultClause` depending on how a table
-    # default was initialized and whether or not it was reflected.
-    if type(server_default.arg) is str:
-        return server_default.arg
-    else:
-        return server_default.arg.text
-
-
-def get_column_default(table_oid, column_index, engine, connection_to_use=None, table_to_use=None):
-    table = table_to_use
-    if table is None:
-        table = tables.reflect_table_from_oid(table_oid, engine)
+def get_column_default(table_oid, column_index, engine, connection_to_use=None):
+    table = tables.reflect_table_from_oid(table_oid, engine, connection_to_use)
     column = table.columns[column_index]
     if column.server_default is None:
         return None
@@ -482,7 +471,7 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None, 
     if result.startswith("{FUNCEXPR"):
         return None
 
-    default_textual_sql = get_default_textual_sql(column.server_default)
+    default_textual_sql = column.server_default.arg.text
     # Defaults are stored as text with SQL casts appended
     # Ex: "'test default string'::character varying" or "'2020-01-01'::date"
     # Here, we execute the cast to get the proper python value

--- a/db/columns.py
+++ b/db/columns.py
@@ -40,6 +40,10 @@ class InvalidTypeOptionError(Exception):
     pass
 
 
+class InvalidTypeError(Exception):
+    pass
+
+
 class MathesarColumn(Column):
     """
     This class constrains the possible arguments, enabling us to include
@@ -247,7 +251,7 @@ def create_column(engine, table_oid, column_data):
         )
     except DataError as e:
         if type(e.orig) == InvalidTextRepresentation:
-            raise InvalidTypeOptionError
+            raise InvalidTypeError
         else:
             raise e
 
@@ -280,9 +284,9 @@ def alter_column(
     attribute_alter_map = {
         NAME: rename_column,
         TYPE: retype_column,
-        "type": retype_column,
+        "plain_type": retype_column,
         NULLABLE: change_column_nullable,
-        DEFAULT: set_column_default
+        "default_value": set_column_default
     }
     assert len(
         [key for key in column_definition_dict if key in attribute_alter_map]
@@ -317,11 +321,10 @@ def rename_column(table_oid, column_index, new_column_name, engine, **kwargs):
 
 
 def _handle_retype_data_errors(e):
-    if (
-        type(e.orig) == InvalidParameterValue
-        or type(e.orig) == InvalidTextRepresentation
-    ):
+    if type(e.orig) == InvalidParameterValue:
         raise InvalidTypeOptionError
+    if type(e.orig) == InvalidTextRepresentation:
+        raise InvalidTypeError
     else:
         raise e
 

--- a/db/columns.py
+++ b/db/columns.py
@@ -482,11 +482,11 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None, 
     if result.startswith("{FUNCEXPR"):
         return None
 
-    cast_sql_text = get_default_textual_sql(column.server_default)
+    default_textual_sql = get_default_textual_sql(column.server_default)
     # Defaults are stored as text with SQL casts appended
     # Ex: "'test default string'::character varying" or "'2020-01-01'::date"
     # Here, we execute the cast to get the proper python value
-    return execute_statement(engine, select(text(cast_sql_text)), connection_to_use).first()[0]
+    return execute_statement(engine, select(text(default_textual_sql)), connection_to_use).first()[0]
 
 
 def _gen_col_name(table, column_name):

--- a/db/tables.py
+++ b/db/tables.py
@@ -410,7 +410,7 @@ def reflect_table_from_oid(oid, engine, connection_to_use=None):
     )
     result = execute_statement(engine, sel, connection_to_use)
     schema, table_name = result.fetchall()[0]
-    return reflect_table(table_name, schema, engine)
+    return reflect_table(table_name, schema, engine, connection_to_use=connection_to_use)
 
 
 def get_enriched_column_table(raw_sa_table, engine=None):
@@ -450,10 +450,11 @@ def get_oid_from_table(name, schema, engine):
     return inspector.get_table_oid(name, schema=schema)
 
 
-def reflect_table(name, schema, engine, metadata=None):
+def reflect_table(name, schema, engine, metadata=None, connection_to_use=None):
     if metadata is None:
         metadata = MetaData(bind=engine)
-    return Table(name, metadata, schema=schema, autoload_with=engine)
+    autoload_with = engine if connection_to_use is None else connection_to_use
+    return Table(name, metadata, schema=schema, autoload_with=autoload_with, extend_existing=True)
 
 
 def create_empty_table(name):

--- a/db/tables.py
+++ b/db/tables.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import NoSuchTableError, InternalError
 from psycopg2.errors import DependentObjectsStillExist
 
 from db import columns, constants, schemas, records
+from db.utils import execute_statement
 
 
 TEMP_SCHEMA = f"{constants.MATHESAR_PREFIX}temp_schema"
@@ -389,7 +390,7 @@ def _get_column_moving_extraction_args(
     return extracted_table_name, remainder_table_name, extraction_columns
 
 
-def reflect_table_from_oid(oid, engine):
+def reflect_table_from_oid(oid, engine, connection_to_use=None):
     metadata = MetaData()
 
     with warnings.catch_warnings():
@@ -407,8 +408,8 @@ def reflect_table_from_oid(oid, engine):
         )
         .where(pg_class.c.oid == oid)
     )
-    with engine.begin() as conn:
-        schema, table_name = conn.execute(sel).fetchall()[0]
+    result = execute_statement(engine, sel, connection_to_use)
+    schema, table_name = result.fetchall()[0]
     return reflect_table(table_name, schema, engine)
 
 

--- a/db/tests/test_columns.py
+++ b/db/tests/test_columns.py
@@ -6,13 +6,14 @@ from psycopg2.errors import NotNullViolation
 import pytest
 from sqlalchemy import (
     String, Integer, Boolean, Date, ForeignKey, Column, select, Table, MetaData,
-    create_engine, Sequence, Numeric, DateTime, func, UniqueConstraint,
+    Sequence, Numeric, DateTime, func, UniqueConstraint,
 )
 from sqlalchemy.exc import IntegrityError
 from db import columns, tables, constants, constraints
 from db.types import email, alteration
 from db.types.base import get_db_type_name
 from db.tests.types import fixtures
+
 
 engine_with_types = fixtures.engine_with_types
 temporary_testing_schema = fixtures.temporary_testing_schema
@@ -33,14 +34,15 @@ def from_column_column(*args, **kwargs):
     return columns.MathesarColumn.from_column(col)
 
 
-def _rename_column(schema, table_name, old_col_name, new_col_name, engine):
+def _rename_column(table, old_col_name, new_col_name, engine):
     """
     Renames the colum of a table and assert the change went through
     """
-    table_oid = tables.get_oid_from_table(table_name, schema, engine)
+    table_oid = tables.get_oid_from_table(table.name, table.schema, engine)
     column_index = columns.get_column_index_from_name(table_oid, old_col_name, engine)
-    columns.rename_column(table_oid, column_index, new_col_name, engine)
-    table = tables.reflect_table(table_name, schema, engine)
+    with engine.begin() as conn:
+        columns.rename_column(table, column_index, engine, conn, new_col_name)
+    table = tables.reflect_table(table.name, table.schema, engine)
     assert new_col_name in table.columns
     assert old_col_name not in table.columns
     return table
@@ -243,47 +245,27 @@ def test_MC_type_options(engine):
     "column_dict,func_name",
     [
         ({"name": "blah"}, "rename_column"),
-        ({"sa_type": "blah"}, "retype_column"),
-        ({"type": "blah"}, "retype_column"),
+        ({"plain_type": "blah"}, "retype_column"),
         ({"nullable": True}, "change_column_nullable"),
-        ({"default": 1}, "set_column_default"),
+        ({"default_value": 1}, "set_column_default"),
     ]
 )
-def test_alter_column_chooses_wisely(column_dict, func_name):
-    engine = create_engine("postgresql://")
+def test_alter_column_chooses_wisely(column_dict, func_name, engine_with_schema):
+    table_name = "table_with_columns"
+    engine, schema = engine_with_schema
+    metadata = MetaData(bind=engine, schema=schema)
+    table = Table(table_name, metadata, Column('col', String))
+    table.create()
+    table_oid = tables.get_oid_from_table(table.name, table.schema, engine)
+
     with patch.object(columns, func_name) as mock_alterer:
         columns.alter_column(
             engine,
-            1234,
-            5678,
+            table_oid,
+            0,
             column_dict
         )
-    mock_alterer.assert_called_with(
-        1234,
-        5678,
-        list(column_dict.values())[0],
-        engine,
-        type_options={},
-    )
-
-
-def test_alter_column_adds_type_options():
-    engine = create_engine("postgresql://")
-    column_dict = {"type": "numeric", "type_options": {"precision": 3}}
-    with patch.object(columns, "retype_column") as mock_retyper:
-        columns.alter_column(
-            engine,
-            1234,
-            5678,
-            column_dict
-        )
-    mock_retyper.assert_called_with(
-        1234,
-        5678,
-        column_dict["type"],
-        engine,
-        type_options=column_dict["type_options"],
-    )
+        mock_alterer.assert_called_once()
 
 
 def test_rename_column(engine_with_schema):
@@ -292,8 +274,9 @@ def test_rename_column(engine_with_schema):
     table_name = "table_with_columns"
     engine, schema = engine_with_schema
     metadata = MetaData(bind=engine, schema=schema)
-    Table(table_name, metadata, Column(old_col_name, String)).create()
-    _rename_column(schema, table_name, old_col_name, new_col_name, engine)
+    table = Table(table_name, metadata, Column(old_col_name, String))
+    table.create()
+    _rename_column(table, old_col_name, new_col_name, engine)
 
 
 def test_rename_column_foreign_keys(engine_with_schema):
@@ -305,7 +288,7 @@ def test_rename_column_foreign_keys(engine_with_schema):
         table_name, ["Filler 1"], "Extracted", "Remainder", schema, engine
     )
     new_fk_name = "new_" + fk_name
-    remainder = _rename_column(schema, remainder.name, fk_name, new_fk_name, engine)
+    remainder = _rename_column(remainder, fk_name, new_fk_name, engine)
 
     fk = list(remainder.foreign_keys)[0]
     assert fk.parent.name == new_fk_name
@@ -322,7 +305,7 @@ def test_rename_column_sequence(engine_with_schema):
         ins = table.insert()
         conn.execute(ins)
 
-    table = _rename_column(schema, table_name, old_col_name, new_col_name, engine)
+    table = _rename_column(table, old_col_name, new_col_name, engine)
 
     with engine.begin() as conn:
         ins = table.insert()
@@ -342,7 +325,7 @@ def test_rename_column_index(engine_with_schema):
     table = Table(table_name, metadata, Column(old_col_name, Integer, index=True))
     table.create()
 
-    table = _rename_column(schema, table_name, old_col_name, new_col_name, engine)
+    table = _rename_column(table, old_col_name, new_col_name, engine)
 
     with engine.begin() as conn:
         index = engine.dialect.get_indexes(conn, table_name, schema)[0]
@@ -381,20 +364,18 @@ def test_retype_column_correct_column(engine_with_schema):
         Column(nontarget_column_name, String),
     )
     table.create()
-    table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    with patch.object(columns.alteration, "alter_column_type") as mock_retyper:
-        columns.retype_column(table_oid, 0, target_type, engine)
-    mock_retyper.assert_called_with(
-        schema,
-        table_name,
-        target_column_name,
-        "boolean",
-        engine,
-        friendly_names=False,
-        type_options={},
-        connection_to_use=None,
-        table_to_use=None
-    )
+    with engine.begin() as conn:
+        with patch.object(columns.alteration, "alter_column_type") as mock_retyper:
+            columns.retype_column(table, 0, engine, conn, target_type)
+        mock_retyper.assert_called_with(
+            table,
+            target_column_name,
+            engine,
+            conn,
+            "boolean",
+            {},
+            friendly_names=False
+        )
 
 
 @pytest.mark.parametrize('target_type', ['numeric', 'decimal'])
@@ -410,21 +391,19 @@ def test_retype_column_adds_options(engine_with_schema, target_type):
         Column(nontarget_column_name, String),
     )
     table.create()
-    table_oid = tables.get_oid_from_table(table_name, schema, engine)
     type_options = {"precision": 5}
-    with patch.object(columns.alteration, "alter_column_type") as mock_retyper:
-        columns.retype_column(table_oid, 0, target_type, engine, type_options=type_options)
-    mock_retyper.assert_called_with(
-        schema,
-        table_name,
-        target_column_name,
-        target_type,
-        engine,
-        friendly_names=False,
-        type_options=type_options,
-        connection_to_use=None,
-        table_to_use=None
-    )
+    with engine.begin() as conn:
+        with patch.object(columns.alteration, "alter_column_type") as mock_retyper:
+            columns.retype_column(table, 0, engine, conn, target_type, type_options)
+        mock_retyper.assert_called_with(
+            table,
+            target_column_name,
+            engine,
+            conn,
+            target_type,
+            type_options,
+            friendly_names=False
+        )
 
 
 type_set = {
@@ -545,11 +524,17 @@ def test_change_column_nullable_changes(engine_with_schema, nullable_tup):
         Column(nontarget_column_name, String),
     )
     table.create()
-    table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    changed_column = columns.change_column_nullable(
-        table_oid,
-        0,
-        nullable_tup[1],
+    with engine.begin() as conn:
+        columns.change_column_nullable(
+            table,
+            0,
+            engine,
+            conn,
+            nullable_tup[1],
+        )
+    changed_table = tables.reflect_table(table_name, schema, engine)
+    changed_column = columns.get_mathesar_column_with_engine(
+        changed_table.columns[0],
         engine
     )
     assert changed_column.nullable is nullable_tup[1]
@@ -575,11 +560,17 @@ def test_change_column_nullable_with_data(engine_with_schema, nullable_tup):
     )
     with engine.begin() as conn:
         conn.execute(ins)
-    table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    changed_column = columns.change_column_nullable(
-        table_oid,
-        0,
-        nullable_tup[1],
+    with engine.begin() as conn:
+        columns.change_column_nullable(
+            table,
+            0,
+            engine,
+            conn,
+            nullable_tup[1],
+        )
+    changed_table = tables.reflect_table(table_name, schema, engine)
+    changed_column = columns.get_mathesar_column_with_engine(
+        changed_table.columns[0],
         engine
     )
     assert changed_column.nullable is nullable_tup[1]
@@ -604,15 +595,16 @@ def test_change_column_nullable_changes_raises_with_null_data(engine_with_schema
     )
     with engine.begin() as conn:
         conn.execute(ins)
-    table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    with pytest.raises(IntegrityError) as e:
-        columns.change_column_nullable(
-            table_oid,
-            0,
-            False,
-            engine
-        )
-        assert type(e.orig) == NotNullViolation
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError) as e:
+            columns.change_column_nullable(
+                table,
+                0,
+                engine,
+                conn,
+                False,
+            )
+            assert type(e.orig) == NotNullViolation
 
 
 def test_drop_column_correct_column(engine_with_schema):
@@ -703,7 +695,7 @@ def test_get_column_generated_default(engine_with_schema, col):
 
 
 @pytest.mark.parametrize("col_type", column_test_dict.keys())
-def test_create_column_default(engine_with_schema, col_type):
+def test_column_default_create(engine_with_schema, col_type):
     engine, schema = engine_with_schema
     table_name = "create_column_default_table"
     column_name = "create_column_default_column"
@@ -714,8 +706,10 @@ def test_create_column_default(engine_with_schema, col_type):
         Column(column_name, col_type)
     )
     table.create()
+
+    with engine.begin() as conn:
+        columns.set_column_default(table, 0, engine, conn, set_default)
     table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    columns.set_column_default(table_oid, 0, set_default, engine)
     default = columns.get_column_default(table_oid, 0, engine)
     created_default = _get_default(engine, table)
 
@@ -724,7 +718,7 @@ def test_create_column_default(engine_with_schema, col_type):
 
 
 @pytest.mark.parametrize("col_type", column_test_dict.keys())
-def test_update_column_default(engine_with_schema, col_type):
+def test_column_default_update(engine_with_schema, col_type):
     engine, schema = engine_with_schema
     table_name = "update_column_default_table"
     column_name = "update_column_default_column"
@@ -735,8 +729,10 @@ def test_update_column_default(engine_with_schema, col_type):
         Column(column_name, col_type, server_default=start_default)
     )
     table.create()
+
+    with engine.begin() as conn:
+        columns.set_column_default(table, 0, engine, conn, set_default)
     table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    columns.set_column_default(table_oid, 0, set_default, engine)
     default = columns.get_column_default(table_oid, 0, engine)
     created_default = _get_default(engine, table)
 
@@ -746,7 +742,7 @@ def test_update_column_default(engine_with_schema, col_type):
 
 
 @pytest.mark.parametrize("col_type", column_test_dict.keys())
-def test_delete_column_default(engine_with_schema, col_type):
+def test_column_default_delete(engine_with_schema, col_type):
     engine, schema = engine_with_schema
     table_name = "delete_column_default_table"
     column_name = "delete_column_default_column"
@@ -757,8 +753,10 @@ def test_delete_column_default(engine_with_schema, col_type):
         Column(column_name, col_type, server_default=set_default)
     )
     table.create()
+
+    with engine.begin() as conn:
+        columns.set_column_default(table, 0, engine, conn, None)
     table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    columns.set_column_default(table_oid, 0, None, engine)
     default = columns.get_column_default(table_oid, 0, engine)
     created_default = _get_default(engine, table)
 

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -1,4 +1,4 @@
-from sqlalchemy import text, DDL, MetaData, Table, select
+from sqlalchemy import text, DDL, select
 from sqlalchemy.sql import quoted_name
 from sqlalchemy.sql.functions import Function
 
@@ -94,34 +94,29 @@ def get_robust_supported_alter_column_type_map(engine):
 
 
 def alter_column_type(
-        schema,
-        table_name,
+        table,
         column_name,
-        target_type_str,
         engine,
-        friendly_names=True,
+        connection,
+        target_type_str,
         type_options={},
-        connection_to_use=None,
-        table_to_use=None
+        friendly_names=True,
 ):
     _preparer = engine.dialect.identifier_preparer
     supported_types = get_supported_alter_column_types(
         engine, friendly_names=friendly_names
     )
     target_type = supported_types.get(target_type_str)
+    schema = table.schema
 
-    metadata = MetaData(bind=engine, schema=schema)
-    table = table_to_use
-    if table is None:
-        table = Table(table_name, metadata, schema=schema, autoload_with=engine)
     column = table.columns[column_name]
-    table_oid = tables.get_oid_from_table(table_name, schema, engine)
-    column_index = columns.get_column_index_from_name(table_oid, column_name, engine, connection_to_use)
+    table_oid = tables.get_oid_from_table(table.name, schema, engine)
+    column_index = columns.get_column_index_from_name(table_oid, column_name, engine, connection)
 
-    default = columns.get_column_default(table_oid, column_index, engine, connection_to_use, table_to_use)
+    default = columns.get_column_default(table_oid, column_index, engine, connection, table)
     if default is not None:
         default_text = column.server_default.arg.text
-        columns.set_column_default(table_oid, column_index, None, engine, connection_to_use, table_to_use)
+        columns.set_column_default(table_oid, column_index, None, engine, connection, table)
 
     prepared_table_name = _preparer.format_table(table)
     prepared_column_name = _preparer.format_column(column)
@@ -134,13 +129,13 @@ def alter_column_type(
       USING {cast_function_name}({prepared_column_name});
     """
 
-    execute_statement(engine, DDL(alter_stmt), connection_to_use)
+    execute_statement(engine, DDL(alter_stmt), connection)
 
     if default is not None:
         cast_stmt = f"{cast_function_name}({default_text})"
         default_stmt = select(text(cast_stmt))
-        new_default = str(execute_statement(engine, default_stmt, connection_to_use).first()[0])
-        columns.set_column_default(table_oid, column_index, new_default, engine, connection_to_use, table_to_use)
+        new_default = str(execute_statement(engine, default_stmt, connection).first()[0])
+        columns.set_column_default(table_oid, column_index, new_default, engine, connection, table)
 
 
 def get_column_cast_expression(column, target_type_str, engine, type_options={}):

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -113,7 +113,6 @@ def alter_column_type(
     # Re-reflect table so that column is accurate
     table = tables.reflect_table_from_oid(table_oid, engine, connection)
     column = table.columns[column_name]
-
     column_index = columns.get_column_index_from_name(table_oid, column_name, engine, connection)
 
     default = columns.get_column_default(table_oid, column_index, engine, connection)

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -115,8 +115,8 @@ def alter_column_type(
 
     default = columns.get_column_default(table_oid, column_index, engine, connection, table)
     if default is not None:
-        default_text = column.server_default.arg.text
-        columns.set_column_default(table_oid, column_index, None, engine, connection, table)
+        default_text = columns.get_default_textual_sql(column.server_default)
+        columns.set_column_default(table, column_index, engine, connection, None)
 
     prepared_table_name = _preparer.format_table(table)
     prepared_column_name = _preparer.format_column(column)
@@ -135,7 +135,7 @@ def alter_column_type(
         cast_stmt = f"{cast_function_name}({default_text})"
         default_stmt = select(text(cast_stmt))
         new_default = str(execute_statement(engine, default_stmt, connection).first()[0])
-        columns.set_column_default(table_oid, column_index, new_default, engine, connection, table)
+        columns.set_column_default(table, column_index, new_default, engine, connection, new_default)
 
 
 def get_column_cast_expression(column, target_type_str, engine, type_options={}):

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -135,7 +135,7 @@ def alter_column_type(
         cast_stmt = f"{cast_function_name}({default_text})"
         default_stmt = select(text(cast_stmt))
         new_default = str(execute_statement(engine, default_stmt, connection).first()[0])
-        columns.set_column_default(table, column_index, new_default, engine, connection, new_default)
+        columns.set_column_default(table, column_index, engine, connection, new_default)
 
 
 def get_column_cast_expression(column, target_type_str, engine, type_options={}):

--- a/db/types/alteration.py
+++ b/db/types/alteration.py
@@ -109,13 +109,16 @@ def alter_column_type(
     target_type = supported_types.get(target_type_str)
     schema = table.schema
 
-    column = table.columns[column_name]
     table_oid = tables.get_oid_from_table(table.name, schema, engine)
+    # Re-reflect table so that column is accurate
+    table = tables.reflect_table_from_oid(table_oid, engine, connection)
+    column = table.columns[column_name]
+
     column_index = columns.get_column_index_from_name(table_oid, column_name, engine, connection)
 
-    default = columns.get_column_default(table_oid, column_index, engine, connection, table)
+    default = columns.get_column_default(table_oid, column_index, engine, connection)
     if default is not None:
-        default_text = columns.get_default_textual_sql(column.server_default)
+        default_text = column.server_default.arg.text
         columns.set_column_default(table, column_index, engine, connection, None)
 
     prepared_table_name = _preparer.format_table(table)

--- a/db/types/inference.py
+++ b/db/types/inference.py
@@ -68,26 +68,25 @@ def infer_column_type(
 
     logger.debug(f"column_type_str: {column_type_str}")
     for type_str in type_inference_dag.get(column_type_str, []):
-        try:
-            alter_column_type(
-                schema, table_name, column_name, type_str, engine
-            )
-            logger.info(f"Column {column_name} altered to type {type_str}")
-            column_type = infer_column_type(
-                schema,
-                table_name,
-                column_name,
-                engine,
-                depth=depth + 1,
-                type_inference_dag=type_inference_dag,
-            )
-            break
-        # It's expected we catch this error when the test to see whether
-        # a type is appropriate for a column fails.
-        except DatabaseError:
-            logger.info(
-                f"Cannot alter column {column_name} to type {type_str}"
-            )
+        with engine.begin() as conn:
+            try:
+                alter_column_type(table, column_name, engine, conn, type_str)
+                logger.info(f"Column {column_name} altered to type {type_str}")
+                column_type = infer_column_type(
+                    schema,
+                    table_name,
+                    column_name,
+                    engine,
+                    depth=depth + 1,
+                    type_inference_dag=type_inference_dag,
+                )
+                break
+            # It's expected we catch this error when the test to see whether
+            # a type is appropriate for a column fails.
+            except DatabaseError:
+                logger.info(
+                    f"Cannot alter column {column_name} to type {type_str}"
+                )
     return column_type
 
 

--- a/db/types/inference.py
+++ b/db/types/inference.py
@@ -68,25 +68,25 @@ def infer_column_type(
 
     logger.debug(f"column_type_str: {column_type_str}")
     for type_str in type_inference_dag.get(column_type_str, []):
-        with engine.begin() as conn:
-            try:
+        try:
+            with engine.begin() as conn:
                 alter_column_type(table, column_name, engine, conn, type_str)
-                logger.info(f"Column {column_name} altered to type {type_str}")
-                column_type = infer_column_type(
-                    schema,
-                    table_name,
-                    column_name,
-                    engine,
-                    depth=depth + 1,
-                    type_inference_dag=type_inference_dag,
-                )
-                break
-            # It's expected we catch this error when the test to see whether
-            # a type is appropriate for a column fails.
-            except DatabaseError:
-                logger.info(
-                    f"Cannot alter column {column_name} to type {type_str}"
-                )
+            logger.info(f"Column {column_name} altered to type {type_str}")
+            column_type = infer_column_type(
+                schema,
+                table_name,
+                column_name,
+                engine,
+                depth=depth + 1,
+                type_inference_dag=type_inference_dag,
+            )
+            break
+        # It's expected we catch this error when the test to see whether
+        # a type is appropriate for a column fails.
+        except DatabaseError:
+            logger.info(
+                f"Cannot alter column {column_name} to type {type_str}"
+            )
     return column_type
 
 

--- a/mathesar/tests/views/api/test_column_api.py
+++ b/mathesar/tests/views/api/test_column_api.py
@@ -350,6 +350,18 @@ def test_column_update_type(column_test_table, client):
     assert response.json()["type"] == type_
 
 
+def test_column_update_name_and_type(column_test_table, client):
+    cache.clear()
+    type_ = "BOOLEAN"
+    new_name = 'new name'
+    data = {"type": type_, "name": new_name}
+    response = client.patch(
+        f"/api/v0/tables/{column_test_table.id}/columns/3/", data=data
+    )
+    assert response.json()["type"] == type_
+    assert response.json()["name"] == new_name
+
+
 def test_column_update_type_options(column_test_table, client):
     cache.clear()
     type_ = "NUMERIC"
@@ -357,8 +369,8 @@ def test_column_update_type_options(column_test_table, client):
     data = {"type": type_, "type_options": type_options}
     response = client.patch(
         f"/api/v0/tables/{column_test_table.id}/columns/3/",
-        data=json.dumps(data),
-        content_type='application/json'
+        data,
+        format='json'
     )
     assert response.json()["type"] == type_
     assert response.json()["type_options"] == type_options

--- a/mathesar/tests/views/api/test_column_api.py
+++ b/mathesar/tests/views/api/test_column_api.py
@@ -362,6 +362,33 @@ def test_column_update_name_and_type(column_test_table, client):
     assert response.json()["name"] == new_name
 
 
+def test_column_update_name_type_nullable(column_test_table, client):
+    cache.clear()
+    type_ = "BOOLEAN"
+    new_name = 'new name'
+    data = {"type": type_, "name": new_name, "nullable": True}
+    response = client.patch(
+        f"/api/v0/tables/{column_test_table.id}/columns/3/", data=data
+    )
+    assert response.json()["type"] == type_
+    assert response.json()["name"] == new_name
+    assert response.json()["nullable"] is True
+
+
+def test_column_update_name_type_nullable_default(column_test_table, client):
+    cache.clear()
+    type_ = "BOOLEAN"
+    new_name = 'new name'
+    data = {"type": type_, "name": new_name, "nullable": True, "default": True}
+    response = client.patch(
+        f"/api/v0/tables/{column_test_table.id}/columns/3/", data=data
+    )
+    assert response.json()["type"] == type_
+    assert response.json()["name"] == new_name
+    assert response.json()["nullable"] is True
+    assert response.json()["default"] is True
+
+
 def test_column_update_type_options(column_test_table, client):
     cache.clear()
     type_ = "NUMERIC"


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #563
Fixes #564 
Related to #592 

<!-- Concisely describe what the pull request does. -->

Improves the column `PATCH` endpoint in a few ways:
- The data is processed and validated by a `ColumnSerializer`
- Invalid type casting errors get their own exception instead of piggybacking on `InvalidTypeOptionsError`
- Type options are validated at the serializer level to ensure that no unknown fields are passed in.
- Allows all column attributes to be updated in a single request.

Some refactoring was done on the backend to enable this:
- All alter column helper functions (altering a single attribute) now take a connection and a table (instead of optionally creating a new connection and re-reflecting the table)
- The `alter_column` function was made more readable by calling each function explicitly instead of mapping function names to a dict. This also ensures that functions aren't passed arguments they don't need (e.g. previously, `type_options` was getting passed to all alteration functions, even setting the default or setting nullable)
- The reflect table functions now take a `connection` argument so that we can re-reflect tables if needed while doing other operations. This was essential to get default values working correctly.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
