### PR TITLE
Added workflow to handle stale issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report an issue with Mathesar
-labels: "type: bug", "status: triage"
+labels: "type: bug, status: triage"
 ---
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report an issue with Mathesar
-labels: "type: bug"
+labels: "type: bug", "status: triage"
 ---
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest a new feature for Mathesar
-labels: "type: enhancement"
+labels: "type: enhancement, status: triage"
 ---
 
 ## Problem

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: Question about Mathesar development or usage
-labels: question
+labels: "question, status: triage"
 ---
 
 ## Question

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,5 @@ jobs:
         days-before-issue-close: 1000
         days-before-pr-close: 30
         exempt-issue-labels: 'status: future'
-        labels-to-remove-when-unstale: 'status: triage','status: stale'
+        labels-to-remove-when-unstale: 'status: triage,status: stale'
         delete-branch: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '17 21 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has not been updated in 90 days and is being marked as stale.'
+        stale-pr-message: 'This pull request has not been updated in 45 days and is being marked as stale. It will automatically be closed in 30 days if not updated by then.'
+        stale-issue-label: 'status: triage'
+        stale-pr-label: 'status: stale'
+        days-before-issue-stale: 90
+        days-before-pr-stale: 45
+        days-before-issue-close: 1000
+        days-before-pr-close: 30
+        exempt-issue-labels: 'status: future'
+        labels-to-remove-when-unstale: 'status: triage','status: stale'
+        delete-branch: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,11 +19,11 @@ jobs:
         stale-issue-message: 'This issue has not been updated in 90 days and is being marked as stale.'
         stale-pr-message: 'This pull request has not been updated in 45 days and is being marked as stale. It will automatically be closed in 30 days if not updated by then.'
         stale-issue-label: 'status: triage'
-        stale-pr-label: 'status: stale'
+        stale-pr-label: 'stale'
         days-before-issue-stale: 90
         days-before-pr-stale: 45
         days-before-issue-close: 1000
         days-before-pr-close: 30
         exempt-issue-labels: 'status: future'
-        labels-to-remove-when-unstale: 'status: triage,status: stale'
+        labels-to-remove-when-unstale: 'status: triage,stale'
         delete-branch: true


### PR DESCRIPTION
GitHub suggested I add a workflow to handle stale issues and PRs while browsing issues and it seemed like a good idea.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
