### PR TITLE
Implement adding a new empty table

### DIFF
--- a/mathesar_ui/src/header/Header.scss
+++ b/mathesar_ui/src/header/Header.scss
@@ -36,6 +36,27 @@ header {
 
     .quick-links {
       margin-right: 15px;
+
+      .new-table {
+        display: flex;
+        align-items: center;
+
+        .label {
+          margin-left: 4px;
+        }
+      }
     }
+  }
+}
+
+.new-table-options {
+  list-style-type: none;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  button {
+    display: flex;
+    width: 100%;
   }
 }

--- a/mathesar_ui/src/header/Header.svelte
+++ b/mathesar_ui/src/header/Header.svelte
@@ -7,9 +7,9 @@
     faUpload,
     faTable,
   } from '@fortawesome/free-solid-svg-icons';
-  import { postAPI } from '@mathesar/utils/api';
+  import { createTable, refetchTablesForSchema } from '@mathesar/stores/tables';
+  import { currentSchemaId } from '@mathesar/stores/schemas';
   import { currentDBName } from '@mathesar/stores/databases';
-  import { currentSchemaId, refetchSchema } from '@mathesar/stores/schemas';
   import { newImport, importStatuses } from '@mathesar/stores/fileImports';
   import {
     addTab,
@@ -24,15 +24,12 @@
   import SchemaSelector from './schema-selector/SchemaSelector.svelte';
   import ImportIndicator from './import-indicator/ImportIndicator.svelte';
 
-  async function createEmptyTable() {
-    const response = await postAPI<{ id: number, name: string }>('/tables/', {
-      schema: $currentSchemaId as number,
-    });
-    const { id, name } = response;
-    await refetchSchema($currentDBName, $currentSchemaId);
-    addTab($currentDBName, $currentSchemaId, { id, label: name });
+  async function handleCreateEmptyTable() {
+    const table = await createTable($currentSchemaId);
+    await refetchTablesForSchema($currentSchemaId);
+    addTab($currentDBName, $currentSchemaId, { id: table.id, label: table.name });
   }
-
+  
   function beginDataImport() {
     if ($currentDBName && $currentSchemaId) {
       const fileData = get(newImport($currentDBName, $currentSchemaId));
@@ -71,7 +68,7 @@
           </svelte:fragment>
           <svelte:fragment slot="content">
             <div class="new-table-options">
-              <Button on:click={createEmptyTable} appearance="plain">
+              <Button on:click={handleCreateEmptyTable} appearance="plain">
                 <Icon data={faTable} size="0.8em"/>
                 <span>Empty table</span>
               </Button>

--- a/mathesar_ui/src/stores/tables.ts
+++ b/mathesar_ui/src/stores/tables.ts
@@ -8,6 +8,7 @@ import {
 } from 'svelte/store';
 import {
   getAPI,
+  postAPI,
   States,
 } from '@mathesar/utils/api';
 import { preloadCommonData } from '@mathesar/utils/preloadData';
@@ -118,6 +119,13 @@ export function getTablesStoreForSchema(schemaId: SchemaEntry['id']): Writable<D
     void refetchTablesForSchema(schemaId);
   }
   return store;
+}
+
+export function createTable(
+  schema: SchemaEntry['id'],
+  name: string | undefined = undefined,
+): CancellablePromise<TableEntry> {
+  return postAPI<TableEntry>('/tables/', { schema, name });
 }
 
 export const tables: Readable<DBTablesStoreData> = derived(


### PR DESCRIPTION
Fixes #444 by allowing users to create a new empty table


## API changes

### Before

- POST to `/tables/` without the `data_files` parameter would fail with an internal error.

### After

- POST to `/tables/` only requires the `schema` parameter. Such a request will create a new empty table with an automatically-generated name and no data.
- Code within `TableViewSet.create` is also slightly more succinct and readable.


## Front-end changes

### Before

- Users can only add a new table if they have some data to upload.

![before](https://user-images.githubusercontent.com/42411/131594818-47c609fb-118b-4d7f-ac79-18520032fc15.png)

### After

- Clicking "New table" and then "Import data" has the same behavior as the "New table" button did previously.
- Clicking "New table" and then "Empty table" adds a new empty table and opens a new tab for that table.
- _This PR does not add or change any code for user to set table names. Rather (as specified in the ticket) the user is expected to create an empty table and then rename it to their liking afterwards._

![after](https://user-images.githubusercontent.com/42411/131594828-fd55fd60-cb28-483e-a646-aff844b5c551.png)

## Notes

- On `mathesar_ui/src/header/Header.svelte:28` I don't really like the inline type for `postAPI`. I'd rather see this whole function call moved into a store somewhere. But I'm not sure of the best place within the rest of the codebase to organize this sort of code. I looked for a type definition for the API response from the `/tables/` endpoint but couldn't immediately find one. I'm happy to make changes here as needed.
- When running the linter locally I was getting a linting error _"Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment"_ in `mathesar_ui/src/header/Header.svelte:29` which is why I'm using `as number` (which I generally avoid). I didn't expect this error, and I didn't spend the time fo fully diagnose it. I'm happy to make adjustments here if needed. Some things to note:
    - I ran into some issues while installing Mathesar, so I ended up running the linter from outside the Docker container.
    - I noticed that the `currentSchemaId` store has a type annotation which evaluates to `number`, but a value which can be `null`. I'm surprised TS is not complaining about that. Small code-smell. Could be related. I don't know.

## Limits of scope

Since I'm new I wanted to keep this PR as focused as possible. Here are some tasks I did _not_ complete now but which represent the type of work I would would expect to regularly incorporate into my PRs after becoming more familiar with the project:

- Add test to assert that POST to `/tables/` with only `schema` param succeeds.
- After choosing "Empty table", display a loading spinner somewhere (probably in place of the "New table" drop down) to show the user that we're waiting for the API to create the table.
- If the server fails to create the empty table, display an error message to the user.



## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] ~I added tests for the changes I made (if applicable).~
- [ ] ~I added or updated documentation (if applicable).~
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

