### PR TITLE
Add first pass at filter docs for API #388

### DIFF
--- a/mathesar/filters.py
+++ b/mathesar/filters.py
@@ -1,16 +1,23 @@
 from django_filters import BooleanFilter, DateTimeFromToRangeFilter
 from django_property_filter import PropertyFilterSet, PropertyBaseInFilter, PropertyCharFilter
 
+from mathesar.database.types import MathesarTypeIdentifier
 from mathesar.models import Schema, Table, Database
 
-FILTER_OPTIONS_BY_TYPE_NAME = {
-    'Boolean':
-        {
-            'eq': '<boolean>',
-            'ne': '<boolean>',
-            'is_null': None,
-            'is_not_null': None
-        },
+FILTER_OPTIONS_BY_TYPE_IDENTIFIER = {
+    MathesarTypeIdentifier.BOOLEAN.value:
+    {
+        "db_type": "BOOLEAN",
+        "options": [{
+            "op": "eq",
+            "value": {
+                "allowed_types": ["BOOLEAN"],
+            }
+        }, {
+            "op": "is_null",
+            "value": "null",
+        }]
+    }
 }
 
 

--- a/mathesar/filters.py
+++ b/mathesar/filters.py
@@ -3,6 +3,16 @@ from django_property_filter import PropertyFilterSet, PropertyBaseInFilter, Prop
 
 from mathesar.models import Schema, Table, Database
 
+FILTER_OPTIONS_BY_TYPE_NAME = {
+    'Boolean':
+        {
+            'eq': '<boolean>',
+            'ne': '<boolean>',
+            'is_null': None,
+            'is_not_null': None
+        },
+}
+
 
 class CharInFilter(PropertyBaseInFilter, PropertyCharFilter):
     pass

--- a/mathesar/serializers.py
+++ b/mathesar/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import empty
 from rest_framework.settings import api_settings
 
+from mathesar.filters import FILTER_OPTIONS_BY_TYPE_NAME
 from mathesar.models import Table, Schema, DataFile, Database, Constraint
 
 
@@ -225,6 +226,10 @@ class TypeSerializer(serializers.Serializer):
     identifier = serializers.CharField()
     name = serializers.CharField()
     db_types = serializers.ListField(child=serializers.CharField())
+    filter_options = serializers.SerializerMethodField()
+
+    def get_filter_options(self, obj):
+        return FILTER_OPTIONS_BY_TYPE_NAME.get(obj.get('name'))
 
 
 class DatabaseSerializer(serializers.ModelSerializer):

--- a/mathesar/serializers.py
+++ b/mathesar/serializers.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import empty
 from rest_framework.settings import api_settings
 
-from mathesar.filters import FILTER_OPTIONS_BY_TYPE_NAME
+from mathesar.filters import FILTER_OPTIONS_BY_TYPE_IDENTIFIER
 from mathesar.models import Table, Schema, DataFile, Database, Constraint
 
 
@@ -226,10 +226,10 @@ class TypeSerializer(serializers.Serializer):
     identifier = serializers.CharField()
     name = serializers.CharField()
     db_types = serializers.ListField(child=serializers.CharField())
-    filter_options = serializers.SerializerMethodField()
+    filters = serializers.SerializerMethodField()
 
-    def get_filter_options(self, obj):
-        return FILTER_OPTIONS_BY_TYPE_NAME.get(obj.get('name'))
+    def get_filters(self, obj):
+        return FILTER_OPTIONS_BY_TYPE_IDENTIFIER.get(obj.get('identifier'))
 
 
 class DatabaseSerializer(serializers.ModelSerializer):

--- a/mathesar/tests/views/api/test_database_api.py
+++ b/mathesar/tests/views/api/test_database_api.py
@@ -2,6 +2,7 @@ import pytest
 from django.conf import settings
 from django.core.cache import cache
 
+from mathesar.filters import FILTER_OPTIONS_BY_TYPE_IDENTIFIER
 from mathesar.reflection import reflect_db_objects
 from mathesar.models import Table, Schema, Database
 from db.tests.types import fixtures
@@ -161,7 +162,10 @@ def test_type_list(client, test_db_name):
     assert response.status_code == 200
     assert len(response_data) == len(database.supported_types)
     for supported_type in response_data:
-        assert all([key in supported_type for key in ['identifier', 'name', 'db_types']])
+        assert all([key in supported_type for key in ['identifier', 'name', 'db_types', 'filters']])
+        found_filters = supported_type.get('filters')
+        expected_filters = FILTER_OPTIONS_BY_TYPE_IDENTIFIER.get(supported_type.get('identifier'))
+        assert found_filters == expected_filters
 
 
 def test_database_types_installed(client, test_db_name, engine_email_type):


### PR DESCRIPTION
This commit adds a first pass at trying to add options for filtering to
the /api/v0/databases/<id>/types/ output.

The idea here is to make it pretty trivial to add the options for new
types to the endpoint. I'm not totally sold on the this being the best
format per-se, but I like how it gets injected automatically for a given
type and depends only on providing a definition. The definition can
change, but the place they go stays constant.

Fixes #388

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
