### PR TITLE
Text types

### DIFF
--- a/db/columns/base.py
+++ b/db/columns/base.py
@@ -144,6 +144,7 @@ class MathesarColumn(Column):
     @property
     def type_options(self):
         full_type_options = {
+            "length": getattr(self.type, "length", None),
             "precision": getattr(self.type, "precision", None),
             "scale": getattr(self.type, "scale", None),
         }

--- a/db/columns/operations/alter.py
+++ b/db/columns/operations/alter.py
@@ -105,8 +105,12 @@ def retype_column(
     new_type = new_type if new_type is not None else column_db_type
     column_type_options = get_type_options(column)
 
-    if (new_type == column_db_type) and _check_type_option_equivalence(type_options, column_type_options):
+    if (
+            (new_type.lower() == column_db_type.lower())
+            and _check_type_option_equivalence(type_options, column_type_options)
+    ):
         return
+
     try:
         alter_column_type(
             table,

--- a/db/columns/operations/alter.py
+++ b/db/columns/operations/alter.py
@@ -64,7 +64,7 @@ def alter_column_type(table, column_name, engine, connection, target_type_str, t
     default = get_column_default(table_oid, column_index, engine, connection)
     if default is not None:
         default_text = column.server_default.arg.text
-        set_column_default(table, column_index, engine, connection, None)
+    set_column_default(table, column_index, engine, connection, None)
 
     prepared_table_name = _preparer.format_table(table)
     prepared_column_name = _preparer.format_column(column)

--- a/db/tests/columns/operations/test_create.py
+++ b/db/tests/columns/operations/test_create.py
@@ -129,6 +129,32 @@ def test_create_column_options(engine_email_type, target_type):
     assert created_col.type_options == {"precision": 5, "scale": 3}
 
 
+@pytest.mark.parametrize("target_type", ["CHAR", "VARCHAR"])
+def test_create_column_length_options(engine_email_type, target_type):
+    engine, schema = engine_email_type
+    table_name = "atableone"
+    initial_column_name = "original_column"
+    new_column_name = "added_column"
+    table = Table(
+        table_name,
+        MetaData(bind=engine, schema=schema),
+        Column(initial_column_name, Integer),
+    )
+    table.create()
+    table_oid = get_oid_from_table(table_name, schema, engine)
+    column_data = {
+        "name": new_column_name,
+        "type": target_type,
+        "type_options": {"length": 5},
+    }
+    created_col = create_column(engine, table_oid, column_data)
+    altered_table = reflect_table_from_oid(table_oid, engine)
+    assert len(altered_table.columns) == 2
+    assert created_col.name == new_column_name
+    assert created_col.plain_type == target_type
+    assert created_col.type_options == {"length": 5}
+
+
 def test_create_column_bad_options(engine_with_schema):
     engine, schema = engine_with_schema
     table_name = "atableone"

--- a/db/tests/columns/operations/test_create.py
+++ b/db/tests/columns/operations/test_create.py
@@ -50,6 +50,7 @@ def _check_duplicate_unique_constraint(
 type_set = {
     'BIGINT',
     'BOOLEAN',
+    'CHAR',
     'DECIMAL',
     'DOUBLE PRECISION',
     'FLOAT',
@@ -86,7 +87,7 @@ def test_create_column(engine_email_type, target_type):
     input_output_type_map = {type_: type_ for type_ in type_set}
     # update the map with types that reflect differently than they're
     # set when creating a column
-    input_output_type_map.update({'FLOAT': 'DOUBLE PRECISION', 'DECIMAL': 'NUMERIC'})
+    input_output_type_map.update({'FLOAT': 'DOUBLE PRECISION', 'DECIMAL': 'NUMERIC', 'CHAR': 'CHAR(1)'})
     table = Table(
         table_name,
         MetaData(bind=engine, schema=schema),

--- a/db/tests/columns/test_base.py
+++ b/db/tests/columns/test_base.py
@@ -1,7 +1,9 @@
 import re
 
 import pytest
-from sqlalchemy import String, Integer, ForeignKey, Table, MetaData, Numeric
+from sqlalchemy import (
+    String, Integer, ForeignKey, Table, MetaData, Numeric, VARCHAR, CHAR
+)
 
 from db.columns.base import MathesarColumn
 from db.columns.defaults import DEFAULT_COLUMNS
@@ -220,6 +222,16 @@ def test_MC_type_options(engine):
     mc = MathesarColumn('testable_col', Numeric(5, 2))
     mc.add_engine(engine)
     assert mc.type_options == {'precision': 5, 'scale': 2}
+
+
+@pytest.mark.parametrize(
+    "target_type,type_options",
+    [(VARCHAR(3), {'length': 3}), (CHAR(4), {'length': 4})]
+)
+def test_MC_type_options_str(engine, target_type, type_options):
+    mc = MathesarColumn('testable_col', target_type)
+    mc.add_engine(engine)
+    assert mc.type_options == type_options
 
 
 def get_mathesar_column_init_args():

--- a/db/tests/types/operations/test_cast.py
+++ b/db/tests/types/operations/test_cast.py
@@ -110,7 +110,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         TARGET_DICT: {
             BIGINT: {VALID: [(True, 1), (False, 0)]},
             BOOLEAN: {VALID: [(True, True), (False, False)]},
-            CHAR: {VALID: [(True, 't'), (False, 'f')]},
+            CHAR: {VALID: []},
             DECIMAL: {VALID: [(True, Decimal('1.0')), (False, Decimal('0'))]},
             DOUBLE: {VALID: [(True, 1.0), (False, 0.0)]},
             FLOAT: {VALID: [(True, 1.0), (False, 0.0)]},
@@ -152,7 +152,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         ISCHEMA_NAME: PostgresType.DATE.value,
         REFLECTED_NAME: DATE,
         TARGET_DICT: {
-            CHAR: {VALID: [(date(1999, 1, 18), "1")]},
+            CHAR: {VALID: []},
             DATE: {VALID: [(date(1999, 1, 18), date(1999, 1, 18))]},
             TEXT: {VALID: [(date(1999, 1, 18), "1999-01-18")]},
             VARCHAR: {VALID: [(date(1999, 1, 18), "1999-01-18")]},
@@ -215,7 +215,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         SUPPORTED_MAP_NAME: MathesarCustomType.EMAIL.value,
         REFLECTED_NAME: EMAIL,
         TARGET_DICT: {
-            CHAR: {VALID: [("bob@example.com", "b")]},
+            CHAR: {VALID: []},
             EMAIL: {VALID: [("alice@example.com", "alice@example.com")]},
             TEXT: {VALID: [("bob@example.com", "bob@example.com")]},
             VARCHAR: {VALID: [("bob@example.com", "bob@example.com")]},
@@ -292,14 +292,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         SUPPORTED_MAP_NAME: MathesarCustomType.MONEY.value,
         REFLECTED_NAME: MONEY,
         TARGET_DICT: {
-            CHAR: {
-                VALID: [
-                    (
-                        {money.VALUE: 1234.12, money.CURRENCY: 'XYZ'},
-                        '('
-                    )
-                ]
-            },
+            CHAR: {VALID: []},
             MONEY: {
                 VALID: [
                     (

--- a/db/tests/types/operations/test_cast.py
+++ b/db/tests/types/operations/test_cast.py
@@ -27,6 +27,7 @@ temporary_testing_schema = fixtures.temporary_testing_schema
 
 BIGINT = PostgresType.BIGINT.value.upper()
 BOOLEAN = PostgresType.BOOLEAN.value.upper()
+DATE = PostgresType.DATE.value.upper()
 DECIMAL = PostgresType.DECIMAL.value.upper()
 DOUBLE = PostgresType.DOUBLE_PRECISION.value.upper()
 FLOAT = PostgresType.FLOAT.value.upper()
@@ -35,8 +36,11 @@ INTERVAL = PostgresType.INTERVAL.value.upper()
 NUMERIC = PostgresType.NUMERIC.value.upper()
 REAL = PostgresType.REAL.value.upper()
 SMALLINT = PostgresType.SMALLINT.value.upper()
-DATE = PostgresType.DATE.value.upper()
+TEXT = PostgresType.TEXT.value.upper()
+
+CHAR = "CHAR"
 VARCHAR = "VARCHAR"
+
 # Custom types
 EMAIL = get_qualified_name(MathesarCustomType.EMAIL.value).upper()
 MONEY = get_qualified_name(MathesarCustomType.MONEY.value).upper()
@@ -80,6 +84,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         TARGET_DICT: {
             BIGINT: {VALID: [(500, 500), (500000000000, 500000000000)]},
             BOOLEAN: {VALID: [(1, True), (0, False)], INVALID: [3]},
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, Decimal('1.0'))]},
             DOUBLE: {VALID: [(3, 3.0)]},
             FLOAT: {VALID: [(4, 4.0)]},
@@ -95,6 +100,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
             NUMERIC: {VALID: [(1, Decimal('1.0'))]},
             REAL: {VALID: [(5, 5.0)]},
             SMALLINT: {VALID: [(500, 500)]},
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
@@ -104,6 +110,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         TARGET_DICT: {
             BIGINT: {VALID: [(True, 1), (False, 0)]},
             BOOLEAN: {VALID: [(True, True), (False, False)]},
+            CHAR: {VALID: [(True, 't'), (False, 'f')]},
             DECIMAL: {VALID: [(True, Decimal('1.0')), (False, Decimal('0'))]},
             DOUBLE: {VALID: [(True, 1.0), (False, 0.0)]},
             FLOAT: {VALID: [(True, 1.0), (False, 0.0)]},
@@ -111,8 +118,45 @@ MASTER_DB_TYPE_MAP_SPEC = {
             NUMERIC: {VALID: [(True, Decimal('1.0')), (False, Decimal('0'))]},
             REAL: {VALID: [(True, 1.0), (False, 0.0)]},
             SMALLINT: {VALID: [(True, 1), (False, 0)]},
+            TEXT: {VALID: [(True, 'true'), (False, 'false')]},
             VARCHAR: {VALID: [(True, 'true'), (False, 'false')]},
         }
+    },
+    CHAR: {
+        ISCHEMA_NAME: PostgresType.CHARACTER.value,
+        SUPPORTED_MAP_NAME: "char",
+        REFLECTED_NAME: CHAR,
+        TARGET_DICT: {
+            BIGINT: {VALID: [("4", 4)], INVALID: ["c"]},
+            BOOLEAN: {VALID: [("t", True), ("f", False)], INVALID: ["c"]},
+            CHAR: {VALID: [("a", "a")]},
+            DECIMAL: {VALID: [("1", Decimal("1"))], INVALID: ["a"]},
+            DOUBLE: {VALID: [("1", 1)], INVALID: ["b"]},
+            EMAIL: {VALID: [], INVALID: ["a"]},
+            FLOAT: {VALID: [("1", 1.0)], INVALID: ["b"]},
+            INTEGER: {VALID: [("4", 4)], INVALID: ["j"] },
+            INTERVAL: {VALID: []},
+            MONEY: {
+                VALID: [("1", {money.VALUE: 1, money.CURRENCY: "USD"})],
+                INVALID: ["n"],
+            },
+            NUMERIC: {VALID: [("1", Decimal("1"))], INVALID: ["a"]},
+            REAL: {VALID: [("1", 1.0)], INVALID: ["b"]},
+            SMALLINT: {VALID: [("4", 4)], INVALID: ["j"] },
+            DATE: {VALID: [], INVALID: ["n"]},
+            TEXT: {VALID: [("a", "a")]},
+            VARCHAR: {VALID: [("a", "a")]},
+        }
+    },
+    DATE: {
+        ISCHEMA_NAME: PostgresType.DATE.value,
+        REFLECTED_NAME: DATE,
+        TARGET_DICT: {
+            CHAR: {VALID: [(date(1999, 1, 18), "1")]},
+            DATE: {VALID: [(date(1999, 1, 18), date(1999, 1, 18))]},
+            TEXT: {VALID: [(date(1999, 1, 18), "1999-01-18")]},
+            VARCHAR: {VALID: [(date(1999, 1, 18), "1999-01-18")]},
+        },
     },
     DECIMAL: {
         ISCHEMA_NAME: PostgresType.DECIMAL.value,
@@ -123,6 +167,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 VALID: [(1, True), (0, False), (1.0, True), (0.0, False)],
                 INVALID: [Decimal('1.3')]
             },
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, 1.0)]},
             DOUBLE: {VALID: [(1, 1.0), (1.5, 1.5)]},
             FLOAT: {VALID: [(1, 1.0), (1.5, 1.5)]},
@@ -141,10 +186,8 @@ MASTER_DB_TYPE_MAP_SPEC = {
             },
             NUMERIC: {VALID: [(1, 1.0)]},
             REAL: {VALID: [(1, 1.0), (1.5, 1.5)]},
-            SMALLINT: {
-                VALID: [(500, 500)],
-                INVALID: [12341234]
-            },
+            SMALLINT: {VALID: [(500, 500)], INVALID: [12341234]},
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
@@ -154,6 +197,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         TARGET_DICT: {
             BIGINT: {VALID: [(500, 500)]},
             BOOLEAN: {VALID: [(1.0, True), (0.0, False)]},
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, 1.0)]},
             DOUBLE: {VALID: [(1, 1.0), (1.5, 1.5)]},
             FLOAT: {VALID: [(1, 1.0), (1.5, 1.5)]},
@@ -162,6 +206,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
             NUMERIC: {VALID: [(1, 1.0)]},
             REAL: {VALID: [(1, 1.0), (1.5, 1.5)]},
             SMALLINT: {VALID: [(500, 500)]},
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
@@ -170,7 +215,9 @@ MASTER_DB_TYPE_MAP_SPEC = {
         SUPPORTED_MAP_NAME: MathesarCustomType.EMAIL.value,
         REFLECTED_NAME: EMAIL,
         TARGET_DICT: {
+            CHAR: {VALID: [("bob@example.com", "b")]},
             EMAIL: {VALID: [("alice@example.com", "alice@example.com")]},
+            TEXT: {VALID: [("bob@example.com", "bob@example.com")]},
             VARCHAR: {VALID: [("bob@example.com", "bob@example.com")]},
         }
     },
@@ -180,6 +227,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         TARGET_DICT: {
             BIGINT: {VALID: [(500, 500)]},
             BOOLEAN: {VALID: [(1.0, True), (0.0, False)], INVALID: [1.234]},
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, 1.0)]},
             DOUBLE: {VALID: [(1, 1.0), (1.5, 1.5)]},
             FLOAT: {VALID: [(1, 1.0), (1.5, 1.5)]},
@@ -188,6 +236,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
             NUMERIC: {VALID: [(1, 1.0)]},
             REAL: {VALID: [(1, 1.0), (1.5, 1.5)]},
             SMALLINT: {VALID: [(500, 500), (-5, -5)], INVALID: [-3.234, 234.34]},
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
@@ -197,6 +246,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         TARGET_DICT: {
             BIGINT: {VALID: [(500, 500)]},
             BOOLEAN: {VALID: [(1, True), (0, False)], INVALID: [3]},
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, Decimal('1.0'))]},
             DOUBLE: {VALID: [(3, 3.0)]},
             FLOAT: {VALID: [(4, 4.0)]},
@@ -205,6 +255,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
             NUMERIC: {VALID: [(1, Decimal('1.0'))]},
             REAL: {VALID: [(5, 5.0)]},
             SMALLINT: {VALID: [(500, 500)]},
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
@@ -212,6 +263,9 @@ MASTER_DB_TYPE_MAP_SPEC = {
         ISCHEMA_NAME: PostgresType.INTERVAL.value,
         REFLECTED_NAME: INTERVAL,
         TARGET_DICT: {
+            CHAR: {
+                VALID: []
+            },
             INTERVAL: {
                 VALID: [
                     (
@@ -219,6 +273,9 @@ MASTER_DB_TYPE_MAP_SPEC = {
                         timedelta(days=3, hours=3, minutes=5, seconds=30),
                     )
                 ]
+            },
+            TEXT: {
+                VALID: []
             },
             VARCHAR: {
                 VALID: [
@@ -235,11 +292,27 @@ MASTER_DB_TYPE_MAP_SPEC = {
         SUPPORTED_MAP_NAME: MathesarCustomType.MONEY.value,
         REFLECTED_NAME: MONEY,
         TARGET_DICT: {
+            CHAR: {
+                VALID: [
+                    (
+                        {money.VALUE: 1234.12, money.CURRENCY: 'XYZ'},
+                        '('
+                    )
+                ]
+            },
             MONEY: {
                 VALID: [
                     (
                         {money.VALUE: 1234.12, money.CURRENCY: 'XYZ'},
                         {money.VALUE: 1234.12, money.CURRENCY: 'XYZ'}
+                    )
+                ]
+            },
+            TEXT: {
+                VALID: [
+                    (
+                        {money.VALUE: 1234.12, money.CURRENCY: 'XYZ'},
+                        '(1234.12,XYZ)'
                     )
                 ]
             },
@@ -262,6 +335,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 VALID: [(1, True), (0, False), (1.0, True), (0.0, False)],
                 INVALID: [42, -1]
             },
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, 1.0)]},
             DOUBLE: {VALID: [(1, 1.0), (1.5, 1.5)]},
             FLOAT: {VALID: [(1, 1.0), (1.5, 1.5)]},
@@ -276,6 +350,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 VALID: [(500, 500)],
                 INVALID: [1.234, 12341234]
             },
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
@@ -288,6 +363,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 VALID: [(1.0, True), (0.0, False)],
                 INVALID: [42, -1]
             },
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, 1.0)]},
             DOUBLE: {VALID: [(1, 1.0), (1.5, 1.5)]},
             FLOAT: {VALID: [(1, 1.0), (1.5, 1.5)]},
@@ -302,6 +378,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 VALID: [(500, 500)],
                 INVALID: [3.345]
             },
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
@@ -311,6 +388,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
         TARGET_DICT: {
             BIGINT: {VALID: [(500, 500)]},
             BOOLEAN: {VALID: [(1, True), (0, False)], INVALID: [3]},
+            CHAR: {VALID: [(3, "3")]},
             DECIMAL: {VALID: [(1, Decimal('1.0'))]},
             DOUBLE: {VALID: [(3, 3.0)]},
             FLOAT: {VALID: [(4, 4.0)]},
@@ -319,21 +397,13 @@ MASTER_DB_TYPE_MAP_SPEC = {
             NUMERIC: {VALID: [(1, Decimal('1.0'))]},
             REAL: {VALID: [(5, 5.0)]},
             SMALLINT: {VALID: [(500, 500)]},
+            TEXT: {VALID: [(3, "3")]},
             VARCHAR: {VALID: [(3, "3")]},
         }
     },
-    DATE: {
-        ISCHEMA_NAME: PostgresType.DATE.value,
-        REFLECTED_NAME: DATE,
-        TARGET_DICT: {
-            DATE: {VALID: [(date(1999, 1, 18), date(1999, 1, 18))]},
-            VARCHAR: {VALID: [(date(1999, 1, 18), "1999-01-18")]},
-        },
-    },
-    VARCHAR: {
-        ISCHEMA_NAME: PostgresType.CHARACTER_VARYING.value,
-        SUPPORTED_MAP_NAME: "varchar",
-        REFLECTED_NAME: VARCHAR,
+    TEXT: {
+        ISCHEMA_NAME: PostgresType.TEXT.value,
+        REFLECTED_NAME: TEXT,
         TARGET_DICT: {
             BIGINT: {
                 VALID: [("432", 432), ("1234123412341234", 1234123412341234)],
@@ -345,6 +415,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 ],
                 INVALID: ["cat"],
             },
+            CHAR: {VALID: [("a", "a")]},
             DECIMAL: {
                 VALID: [("1.2", Decimal("1.2")), ("1", Decimal("1"))],
                 INVALID: ["abc"],
@@ -406,6 +477,88 @@ MASTER_DB_TYPE_MAP_SPEC = {
                     "1234",
                 ]
             },
+            TEXT: {VALID: [("a string", "a string")]},
+            VARCHAR: {VALID: [("a string", "a string")]},
+        }
+    },
+    VARCHAR: {
+        ISCHEMA_NAME: PostgresType.CHARACTER_VARYING.value,
+        SUPPORTED_MAP_NAME: "varchar",
+        REFLECTED_NAME: VARCHAR,
+        TARGET_DICT: {
+            BIGINT: {
+                VALID: [("432", 432), ("1234123412341234", 1234123412341234)],
+                INVALID: ["1.2234"]
+            },
+            BOOLEAN: {
+                VALID: [
+                    ("true", True), ("false", False), ("t", True), ("f", False)
+                ],
+                INVALID: ["cat"],
+            },
+            CHAR: {VALID: [("a", "a")]},
+            DATE: {
+                VALID: [
+                    ("1999-01-18", date(1999, 1, 18)),
+                    ("1/18/1999", date(1999, 1, 18)),
+                    ("jan-1999-18", date(1999, 1, 18)),
+                    ("19990118", date(1999, 1, 18)),
+                ],
+                INVALID: [
+                    "18/1/1999",
+                    "not a date",
+                    "1234",
+                ]
+            },
+            DECIMAL: {
+                VALID: [("1.2", Decimal("1.2")), ("1", Decimal("1"))],
+                INVALID: ["abc"],
+            },
+            DOUBLE: {
+                VALID: [("1.234", 1.234)],
+                INVALID: ["bat"],
+            },
+            EMAIL: {
+                VALID: [("alice@example.com", "alice@example.com")],
+                INVALID: ["alice-example.com"]
+            },
+            FLOAT: {
+                VALID: [("1.234", 1.234)],
+                INVALID: ["bat"],
+            },
+            INTEGER: {
+                VALID: [("432", 432)],
+                INVALID: ["1.2234"]
+            },
+            INTERVAL: {
+                VALID: [
+                    ("1 day", timedelta(days=1)),
+                    ("1 week", timedelta(days=7)),
+                    ("3:30", timedelta(hours=3, minutes=30)),
+                    ("00:03:30", timedelta(minutes=3, seconds=30)),
+                ],
+                INVALID: ["1 potato", "3"],
+            },
+            MONEY: {
+                VALID: [("1234", {money.VALUE: 1234, money.CURRENCY: "USD"})],
+                INVALID: ["nanumb"],
+            },
+            NUMERIC: {
+                VALID: [
+                    ("1.2", Decimal("1.2")),
+                    ("1", Decimal("1")),
+                ],
+                INVALID: ["not a number"],
+            },
+            REAL: {
+                VALID: [("1.234", 1.234)],
+                INVALID: ["real"]
+            },
+            SMALLINT: {
+                VALID: [("432", 432)],
+                INVALID: ["1.2234"]
+            },
+            TEXT: {VALID: [("a string", "a string")]},
             VARCHAR: {VALID: [("a string", "a string")]},
         }
     }
@@ -619,9 +772,13 @@ def test_alter_column_casts_data_gen(
     table_oid = get_oid_from_table(TABLE_NAME, schema, engine)
     actual_default = get_column_default(table_oid, 0, engine)
     # TODO This needs to be sorted out by fixing how server_default is set.
+    # Also, we cannot support (currently) defaults for CHAR type columns, since
+    # these are always function expressions
     if all([
-        source_type != get_qualified_name(MathesarCustomType.MONEY.value),
-        target_type != MathesarCustomType.MONEY.value
+            source_type != get_qualified_name(MathesarCustomType.MONEY.value),
+            target_type != MathesarCustomType.MONEY.value,
+            source_type != PostgresType.CHARACTER.value,
+            target_type != "char",
     ]):
         assert actual_default == out_val
 
@@ -774,5 +931,4 @@ expect_cast_tuples = [
 def test_get_full_cast_map(engine_with_types, source_type, expect_target_types):
     actual_cast_map = cast_operations.get_full_cast_map(engine_with_types)
     actual_target_types = actual_cast_map[source_type]
-    assert len(actual_target_types) == len(expect_target_types)
     assert sorted(actual_target_types) == sorted(expect_target_types)

--- a/db/tests/types/operations/test_cast.py
+++ b/db/tests/types/operations/test_cast.py
@@ -134,7 +134,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
             DOUBLE: {VALID: [("1", 1)], INVALID: ["b"]},
             EMAIL: {VALID: [], INVALID: ["a"]},
             FLOAT: {VALID: [("1", 1.0)], INVALID: ["b"]},
-            INTEGER: {VALID: [("4", 4)], INVALID: ["j"] },
+            INTEGER: {VALID: [("4", 4)], INVALID: ["j"]},
             INTERVAL: {VALID: []},
             MONEY: {
                 VALID: [("1", {money.VALUE: 1, money.CURRENCY: "USD"})],
@@ -142,7 +142,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
             },
             NUMERIC: {VALID: [("1", Decimal("1"))], INVALID: ["a"]},
             REAL: {VALID: [("1", 1.0)], INVALID: ["b"]},
-            SMALLINT: {VALID: [("4", 4)], INVALID: ["j"] },
+            SMALLINT: {VALID: [("4", 4)], INVALID: ["j"]},
             DATE: {VALID: [], INVALID: ["n"]},
             TEXT: {VALID: [("a", "a")]},
             VARCHAR: {VALID: [("a", "a")]},
@@ -610,6 +610,9 @@ type_test_list = [
 ] + [
     (val[ISCHEMA_NAME], "decimal", {"precision": 5, "scale": 3}, "NUMERIC(5, 3)")
     for val in MASTER_DB_TYPE_MAP_SPEC.values() if DECIMAL in val[TARGET_DICT]
+] + [
+    (val[ISCHEMA_NAME], "char", {"length": 5}, "CHAR(5)")
+    for val in MASTER_DB_TYPE_MAP_SPEC.values() if CHAR in val[TARGET_DICT]
 ]
 
 
@@ -654,6 +657,7 @@ def test_alter_column_type_alters_column_type(
         autoload_with=engine
     ).columns[COLUMN_NAME]
     actual_type = actual_column.type.compile(dialect=engine.dialect)
+    expect_type = expect_type + '(1)' if expect_type == CHAR else expect_type
     assert actual_type == expect_type
 
 

--- a/db/tests/types/operations/test_cast.py
+++ b/db/tests/types/operations/test_cast.py
@@ -328,7 +328,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 VALID: [(1, True), (0, False), (1.0, True), (0.0, False)],
                 INVALID: [42, -1]
             },
-            CHAR: {VALID: [(3, "3")]},
+            CHAR: {VALID: [(3, "3")], INVALID: [1234, 1.2]},
             DECIMAL: {VALID: [(1, 1.0)]},
             DOUBLE: {VALID: [(1, 1.0), (1.5, 1.5)]},
             FLOAT: {VALID: [(1, 1.0), (1.5, 1.5)]},
@@ -356,7 +356,7 @@ MASTER_DB_TYPE_MAP_SPEC = {
                 VALID: [(1.0, True), (0.0, False)],
                 INVALID: [42, -1]
             },
-            CHAR: {VALID: [(3, "3")]},
+            CHAR: {VALID: [(3, "3")], INVALID: [234, 5.78]},
             DECIMAL: {VALID: [(1, 1.0)]},
             DOUBLE: {VALID: [(1, 1.0), (1.5, 1.5)]},
             FLOAT: {VALID: [(1, 1.0), (1.5, 1.5)]},
@@ -661,6 +661,7 @@ type_test_data_args_list = [
     # test that rounding is as intended
     (Numeric, "numeric", {"precision": 5, "scale": 2}, 1.235, Decimal("1.24")),
     (String, "numeric", {"precision": 5, "scale": 2}, "500.134", Decimal("500.13")),
+    (String, "char", {"length": 5}, "abcde", "abcde"),
 ]
 
 

--- a/db/types/base.py
+++ b/db/types/base.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine
 from db import constants
 
 
+CHAR = 'char'
 STRING = 'string'
 VARCHAR = 'varchar'
 

--- a/db/types/operations/cast.py
+++ b/db/types/operations/cast.py
@@ -506,26 +506,13 @@ def _get_textual_type_body_map(engine, target_type_str=VARCHAR):
     """
     supported_types = get_supported_alter_column_db_types(engine)
 
-    cast_loss_exception_str = (
-        f"RAISE EXCEPTION '% cannot be cast to {target_type_str} without loss', $1;"
-    )
-
-    def _get_no_truncating_cast_to_text_type():
-        return f"""
-        DECLARE text_res {target_type_str};
+    text_cast_str = f"""
         BEGIN
-          SELECT $1::{target_type_str} INTO text_res;
-          IF text_res = $1::TEXT THEN
-            RETURN text_res;
-          END IF;
-          {cast_loss_exception_str}
+          RETURN $1::TEXT;
         END;
-        """
+    """
 
-    return {
-        source_type_str: _get_no_truncating_cast_to_text_type()
-        for source_type_str in supported_types
-    }
+    return {type_: text_cast_str for type_ in supported_types}
 
 
 def _get_date_type_body_map():

--- a/db/types/operations/cast.py
+++ b/db/types/operations/cast.py
@@ -506,7 +506,7 @@ def _get_textual_type_body_map(engine, target_type_str=VARCHAR):
     """
     supported_types = get_supported_alter_column_db_types(engine)
 
-    text_cast_str = f"""
+    text_cast_str = """
         BEGIN
           RETURN $1::TEXT;
         END;

--- a/db/types/operations/cast.py
+++ b/db/types/operations/cast.py
@@ -358,6 +358,7 @@ def _get_interval_type_body_map():
                            to an interval.
     """
     source_text_types = TEXT_TYPES
+
     def _get_text_interval_type_body_map():
         # We need to check that a string isn't a valid number before
         # casting to intervals (since a number is more likely)
@@ -370,7 +371,6 @@ def _get_interval_type_body_map():
               RETURN $1::{INTERVAL};
         END;
         """
-
 
     type_body_map = {
         INTERVAL: """

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -18,6 +18,7 @@ class InputValueField(serializers.CharField):
 
 
 class TypeOptionSerializer(serializers.Serializer):
+    length = serializers.IntegerField(required=False)
     precision = serializers.IntegerField(required=False)
     scale = serializers.IntegerField(required=False)
 

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -53,9 +53,9 @@ def test_column_list(column_test_table, client):
             'primary_key': True,
             'default': None,
             'valid_target_types': [
-                'BIGINT', 'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT',
-                'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
-                'SMALLINT', 'VARCHAR',
+                'BIGINT', 'BOOLEAN', 'CHAR', 'DECIMAL', 'DOUBLE PRECISION',
+                'FLOAT', 'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
+                'SMALLINT', 'TEXT', 'VARCHAR',
             ],
         },
         {
@@ -67,9 +67,9 @@ def test_column_list(column_test_table, client):
             'primary_key': False,
             'default': None,
             'valid_target_types': [
-                'BIGINT', 'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT',
-                'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
-                'SMALLINT', 'VARCHAR',
+                'BIGINT', 'BOOLEAN', 'CHAR', 'DECIMAL', 'DOUBLE PRECISION',
+                'FLOAT', 'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
+                'SMALLINT', 'TEXT', 'VARCHAR',
             ],
         },
         {
@@ -81,9 +81,9 @@ def test_column_list(column_test_table, client):
             'primary_key': False,
             'default': 5,
             'valid_target_types': [
-                'BIGINT', 'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT',
-                'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
-                'SMALLINT', 'VARCHAR',
+                'BIGINT', 'BOOLEAN', 'CHAR', 'DECIMAL', 'DOUBLE PRECISION',
+                'FLOAT', 'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
+                'SMALLINT', 'TEXT', 'VARCHAR',
             ],
         },
         {
@@ -94,10 +94,10 @@ def test_column_list(column_test_table, client):
             'nullable': True,
             'primary_key': False,
             'valid_target_types': [
-                'BIGINT', 'BOOLEAN', 'DATE', 'DECIMAL', 'DOUBLE PRECISION',
-                'FLOAT', 'INTEGER', 'INTERVAL', 'MATHESAR_TYPES.EMAIL',
-                'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL', 'SMALLINT',
-                'VARCHAR',
+                'BIGINT', 'BOOLEAN', 'CHAR', 'DATE', 'DECIMAL',
+                'DOUBLE PRECISION', 'FLOAT', 'INTEGER', 'INTERVAL',
+                'MATHESAR_TYPES.EMAIL', 'MATHESAR_TYPES.MONEY', 'NUMERIC',
+                'REAL', 'SMALLINT', 'TEXT', 'VARCHAR',
             ],
             'default': None,
         }
@@ -119,9 +119,9 @@ def test_column_list(column_test_table, client):
                 'primary_key': True,
                 'default': None,
                 'valid_target_types': [
-                    'BIGINT', 'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT',
-                    'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
-                    'SMALLINT', 'VARCHAR',
+                    'BIGINT', 'BOOLEAN', 'CHAR', 'DECIMAL', 'DOUBLE PRECISION',
+                    'FLOAT', 'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC',
+                    'REAL', 'SMALLINT', 'TEXT', 'VARCHAR',
                 ],
             },
         ),
@@ -136,9 +136,9 @@ def test_column_list(column_test_table, client):
                 'primary_key': False,
                 'default': 5,
                 'valid_target_types': [
-                    'BIGINT', 'BOOLEAN', 'DECIMAL', 'DOUBLE PRECISION', 'FLOAT',
-                    'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
-                    'SMALLINT', 'VARCHAR',
+                    'BIGINT', 'BOOLEAN', 'CHAR', 'DECIMAL', 'DOUBLE PRECISION',
+                    'FLOAT', 'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC',
+                    'REAL', 'SMALLINT', 'TEXT', 'VARCHAR',
                 ],
             },
         ),

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -230,10 +230,16 @@ def test_column_create_invalid_default(column_test_table, client):
     assert f'default "{data["default"]}" is invalid for type' in response.json()[0]
 
 
-def test_column_create_retrieve_options(column_test_table, client):
+@pytest.mark.parametrize(
+    "type_,type_options",
+    [
+        ("NUMERIC", {"precision": 5, "scale": 3}),
+        ("VARCHAR", {"length": 5}),
+        ("CHAR", {"length": 5}),
+    ]
+)
+def test_column_create_retrieve_options(column_test_table, client, type_, type_options):
     name = "anewcolumn"
-    type_ = "NUMERIC"
-    type_options = {"precision": 5, "scale": 3}
     cache.clear()
     num_columns = len(column_test_table.sa_columns)
     data = {
@@ -259,6 +265,7 @@ invalid_type_options = [
     {"precision": 5, "scale": 8},
     {"precision": "asd"},
     {"nonoption": 34},
+    {"length": "two"},
 ]
 
 

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -415,6 +415,26 @@ def test_column_update_type_options(column_test_table, client):
     assert response.json()["type_options"] == type_options
 
 
+def test_column_update_type_options_no_type(column_test_table, client):
+    cache.clear()
+    type_ = "NUMERIC"
+    data = {"type": type_}
+    client.patch(
+        f"/api/v0/tables/{column_test_table.id}/columns/3/",
+        data,
+        format='json'
+    )
+    type_options = {"precision": 3, "scale": 1}
+    type_option_data = {"type_options": type_options}
+    response = client.patch(
+        f"/api/v0/tables/{column_test_table.id}/columns/3/",
+        type_option_data,
+        format='json'
+    )
+    assert response.json()["type"] == type_
+    assert response.json()["type_options"] == type_options
+
+
 def test_column_update_invalid_type(create_table, client, engine_email_type):
     table = create_table('Column Invalid Type')
     body = {"type": "BIGINT"}


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #404 
Fixes #405 
Fixes #407 

<!-- Concisely describe what the pull request does. -->

This PR adds support for `TEXT`, `CHAR`, AND `VARCHAR` types in the back end.  One can now change columns to these types and restrict the length for `CHAR` and `VARCHAR` types using a `length` type option.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

  The server default handling is not quite working for `CHAR` type (and sometimes `VARCHAR`), and will be fixed in #681 and #682 . 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
