### PR TITLE
Server default setting and getting improvements

### DIFF
--- a/db/columns/exceptions.py
+++ b/db/columns/exceptions.py
@@ -12,3 +12,7 @@ class InvalidTypeOptionError(Exception):
 
 class DagCycleError(Exception):
     pass
+
+
+class DynamicDefaultWarning(Warning):
+    pass

--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -3,6 +3,7 @@ import warnings
 from pglast import Node, parse_sql
 from sqlalchemy import Table, MetaData, and_, select, text, func
 
+from db.columns.exceptions import DynamicDefaultWarning
 from db.tables.operations.select import reflect_table_from_oid
 from db.utils import execute_statement
 
@@ -39,7 +40,10 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None):
     if column.server_default is None:
         return None
     elif _is_default_expr_dynamic(column.server_default):
-        return None
+        warnings.warn(
+            "Dynamic column defaults are not implemented", DynamicDefaultWarning
+        )
+        return str(column.server_default.arg)
 
     default_textual_sql = str(column.server_default.arg)
     # Defaults are stored as text with SQL casts appended

--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -45,13 +45,13 @@ def get_column_default_dict(table_oid, column_index, engine, connection_to_use=N
         default_dict = {
             "server_default": column.server_default,
             "is_dynamic": _is_default_expr_dynamic(column.server_default),
-            "default_textual_sql": str(column.server_default.arg)
+            "sql_text": str(column.server_default.arg)
         }
     else:
         return
     if default_dict.get("is_dynamic"):
         warnings.warn(
-            "Dynamic column defaults are not implemented", DynamicDefaultWarning
+            "Dynamic column defaults are read only", DynamicDefaultWarning
         )
     else:
         # Defaults are stored as text with SQL casts appended
@@ -60,7 +60,7 @@ def get_column_default_dict(table_oid, column_index, engine, connection_to_use=N
         default_dict.update(
             executed_constant=execute_statement(
                 engine,
-                select(text(default_dict['default_textual_sql'])),
+                select(text(default_dict['sql_text'])),
                 connection_to_use
             ).first()[0]
         )
@@ -76,7 +76,7 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None):
     else:
         executed_constant = default_dict.get('executed_constant')
 
-    return executed_constant if executed_constant is not None else default_dict['default_textual_sql']
+    return executed_constant if executed_constant is not None else default_dict['sql_text']
 
 
 def _is_default_expr_dynamic(server_default):

--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -41,7 +41,7 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None):
     elif _is_default_expr_dynamic(column.server_default):
         return None
 
-    default_textual_sql = column.server_default.arg.text
+    default_textual_sql = str(column.server_default.arg)
     # Defaults are stored as text with SQL casts appended
     # Ex: "'test default string'::character varying" or "'2020-01-01'::date"
     # Here, we execute the cast to get the proper python value

--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -8,6 +8,9 @@ from db.tables.operations.select import reflect_table_from_oid
 from db.utils import execute_statement
 
 
+DYNAMIC_NODE_TAGS = {"SQLValueFunction", "FuncCall"}
+
+
 def get_column_index_from_name(table_oid, column_name, engine, connection_to_use=None):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Did not recognize type")
@@ -58,5 +61,4 @@ def _is_default_expr_dynamic(server_default):
     ast_nodes = {
         n.node_tag for n in expr_ast_root.traverse() if isinstance(n, Node)
     }
-    dynamic_node_tags = {"SQLValueFunction", "FuncCall"}
-    return not ast_nodes.isdisjoint(dynamic_node_tags)
+    return not ast_nodes.isdisjoint(DYNAMIC_NODE_TAGS)

--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -7,7 +7,13 @@ from db.columns.exceptions import DynamicDefaultWarning
 from db.tables.operations.select import reflect_table_from_oid
 from db.utils import execute_statement
 
-
+# These tags define which nodes in the AST built by pglast we consider to be
+# "dynamic" when found in a column default clause.  The nodes are best
+# documented by C header files that define the underlying structs:
+# https://github.com/pganalyze/libpg_query/blob/13-latest/src/postgres/include/nodes/parsenodes.h
+# https://github.com/pganalyze/libpg_query/blob/13-latest/src/postgres/include/nodes/primnodes.h
+# It's possible that more dynamic nodes will be found.  Their tags should be
+# added to this set.
 DYNAMIC_NODE_TAGS = {"SQLValueFunction", "FuncCall"}
 
 

--- a/db/tests/columns/operations/test_select.py
+++ b/db/tests/columns/operations/test_select.py
@@ -1,10 +1,12 @@
+import warnings
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 import pytest
 from sqlalchemy import (
-    String, Integer, Column, Table, MetaData, Sequence, DateTime, func, text, DefaultClause
+    String, Integer, Column, Table, MetaData, DateTime, func, text, DefaultClause
 )
 
+from db.columns.exceptions import DynamicDefaultWarning
 from db.columns.operations.select import (
     get_column_default, get_column_index_from_name, _is_default_expr_dynamic
 )
@@ -115,7 +117,6 @@ def test_get_column_default(engine_with_schema, filler, col_type):
 
 get_column_generated_default_test_list = [
     Column("generated_default_col", Integer, primary_key=True),
-    Column("generated_default_col", Integer, Sequence("test_id")),
     Column("generated_default_col", DateTime, server_default=func.now()),
     Column("generated_default_col", DateTime, server_default=func.current_timestamp())
 ]
@@ -132,12 +133,9 @@ def test_get_column_generated_default(engine_with_schema, col):
     )
     table.create()
     table_oid = get_oid_from_table(table_name, schema, engine)
-    default = get_column_default(table_oid, 0, engine)
-    created_default = get_default(engine, table)
-
-    # We shouldn't evaluate generated defaults
-    assert default is None
-    assert default != created_default
+    with warnings.catch_warnings(), pytest.raises(DynamicDefaultWarning):
+        warnings.filterwarnings("error", category=DynamicDefaultWarning)
+        get_column_default(table_oid, 0, engine)
 
 
 default_expression_test_list = [
@@ -153,6 +151,7 @@ default_expression_test_list = [
     ("'abcde'::CHAR(3)", False),
     ("'abcde'::CHAR(5)", False),
 ]
+
 
 @pytest.mark.parametrize("default_expr,is_dynamic", default_expression_test_list)
 def test_is_default_expr_dynamic(default_expr, is_dynamic):

--- a/db/tests/columns/operations/test_select.py
+++ b/db/tests/columns/operations/test_select.py
@@ -112,7 +112,8 @@ def test_get_column_default(engine_with_schema, filler, col_type):
 get_column_generated_default_test_list = [
     Column("generated_default_col", Integer, primary_key=True),
     Column("generated_default_col", Integer, Sequence("test_id")),
-    Column("generated_default_col", DateTime, server_default=func.now())
+    Column("generated_default_col", DateTime, server_default=func.now()),
+    Column("generated_default_col", DateTime, server_default=func.current_timestamp())
 ]
 
 

--- a/db/tests/columns/utils.py
+++ b/db/tests/columns/utils.py
@@ -1,13 +1,16 @@
 from datetime import date
 
-from sqlalchemy import String, Integer, Boolean, Date, select, Table, MetaData
+from sqlalchemy import (
+    CHAR, String, Integer, Boolean, Date, select, Table, MetaData
+)
 
 
 column_test_dict = {
     Integer: {"start": "0", "set": "5", "expt": 5},
     String: {"start": "default", "set": "test", "expt": "test"},
     Boolean: {"start": "false", "set": "true", "expt": True},
-    Date: {"start": "2019-01-01", "set": "2020-01-01", "expt": date(2020, 1, 1)}
+    Date: {"start": "2019-01-01", "set": "2020-01-01", "expt": date(2020, 1, 1)},
+    CHAR: {"start": "a", "set": "b", "expt": "b"}
 }
 
 

--- a/db/tests/types/operations/test_cast.py
+++ b/db/tests/types/operations/test_cast.py
@@ -770,13 +770,9 @@ def test_alter_column_casts_data_gen(
     table_oid = get_oid_from_table(TABLE_NAME, schema, engine)
     actual_default = get_column_default(table_oid, 0, engine)
     # TODO This needs to be sorted out by fixing how server_default is set.
-    # Also, we cannot support (currently) defaults for CHAR type columns, since
-    # these are always function expressions
     if all([
             source_type != get_qualified_name(MathesarCustomType.MONEY.value),
             target_type != MathesarCustomType.MONEY.value,
-            source_type != PostgresType.CHARACTER.value,
-            target_type != "char",
     ]):
         assert actual_default == out_val
 

--- a/mathesar/api/viewsets/columns.py
+++ b/mathesar/api/viewsets/columns.py
@@ -1,10 +1,13 @@
+import warnings
 from psycopg2.errors import DuplicateColumn, UndefinedFunction
 from rest_framework import status, viewsets
 from rest_framework.exceptions import NotFound, ValidationError, APIException
 from rest_framework.response import Response
 from sqlalchemy.exc import ProgrammingError
 
-from db.columns.exceptions import InvalidDefaultError, InvalidTypeOptionError, InvalidTypeError
+from db.columns.exceptions import (
+    DynamicDefaultWarning, InvalidDefaultError, InvalidTypeOptionError, InvalidTypeError
+)
 from mathesar.api.pagination import ColumnLimitOffsetPagination
 from mathesar.api.serializers.columns import ColumnSerializer
 from mathesar.api.utils import get_table_or_404
@@ -81,32 +84,40 @@ class ColumnViewSet(viewsets.ViewSet):
         table = get_table_or_404(table_pk)
         serializer = ColumnSerializer(data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
-        try:
-            column = table.alter_column(pk, serializer.validated_data)
-        except ProgrammingError as e:
-            if type(e.orig) == UndefinedFunction:
-                raise ValidationError('This type cast is not implemented')
-            else:
-                raise ValidationError
-        except IndexError:
-            raise NotFound
-        except TypeError:
-            raise ValidationError("Unknown type_option passed")
-        except InvalidDefaultError:
-            raise ValidationError(
-                f'default "{request.data["default"]}" is'
-                f' invalid for this column'
-            )
-        except InvalidTypeOptionError:
-            type_options = request.data.get('type_options', '')
-            raise ValidationError(
-                f'parameter dict {type_options} is'
-                f' invalid for type {request.data["type"]}'
-            )
-        except InvalidTypeError:
-            raise ValidationError('This type casting is invalid.')
-        except Exception as e:
-            raise APIException(e)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=DynamicDefaultWarning)
+            try:
+                column = table.alter_column(pk, serializer.validated_data)
+            except ProgrammingError as e:
+                if type(e.orig) == UndefinedFunction:
+                    raise ValidationError('This type cast is not implemented')
+                else:
+                    raise ValidationError
+            except IndexError:
+                raise NotFound
+            except TypeError:
+                raise ValidationError("Unknown type_option passed")
+            except InvalidDefaultError:
+                raise ValidationError(
+                    f'default "{request.data["default"]}" is'
+                    f' invalid for this column'
+                )
+            except DynamicDefaultWarning:
+                raise ValidationError(
+                    'Changing type of columns with dynamically-generated'
+                    ' defaults is not supported.'
+                    ' Delete or change the default first.'
+                )
+            except InvalidTypeOptionError:
+                type_options = request.data.get('type_options', '')
+                raise ValidationError(
+                    f'parameter dict {type_options} is'
+                    f' invalid for type {request.data["type"]}'
+                )
+            except InvalidTypeError:
+                raise ValidationError('This type casting is invalid.')
+            except Exception as e:
+                raise APIException(e)
         out_serializer = ColumnSerializer(column)
         return Response(out_serializer.data)
 

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -352,6 +352,16 @@ def test_column_update_default_invalid_cast(column_test_table, client):
     assert response.status_code == 400
 
 
+def test_column_update_type_dynamic_default(column_test_table, client):
+    cache.clear()
+    type_ = "NUMERIC"
+    data = {"type": type_}
+    response = client.patch(
+        f"/api/v0/tables/{column_test_table.id}/columns/0/", data=data
+    )
+    assert response.status_code == 400
+
+
 def test_column_update_type(column_test_table, client):
     cache.clear()
     type_ = "BOOLEAN"

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -51,7 +51,7 @@ def test_column_list(column_test_table, client):
             'index': 0,
             'nullable': False,
             'primary_key': True,
-            'default': None,
+            'default': """nextval('"Patents".anewtable_mycolumn0_seq'::regclass)""",
             'valid_target_types': [
                 'BIGINT', 'BOOLEAN', 'CHAR', 'DECIMAL', 'DOUBLE PRECISION',
                 'FLOAT', 'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC', 'REAL',
@@ -117,7 +117,7 @@ def test_column_list(column_test_table, client):
                 'index': 0,
                 'nullable': False,
                 'primary_key': True,
-                'default': None,
+                'default': """nextval('"Patents".anewtable_mycolumn0_seq'::regclass)""",
                 'valid_target_types': [
                     'BIGINT', 'BOOLEAN', 'CHAR', 'DECIMAL', 'DOUBLE PRECISION',
                     'FLOAT', 'INTEGER', 'MATHESAR_TYPES.MONEY', 'NUMERIC',

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ django-filter==2.4.0
 django-property-filter==1.1.0
 djangorestframework==3.12.4
 drf-nested-routers==0.93.3
+pglast==3.4
 psycopg2==2.8.6
 python-decouple==3.4
 requests==2.20.0


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #682 
Fixes #681 

<!-- Concisely describe what the pull request does. -->

This changes the way we handle server defaults so that we
- correctly handle more of the constant values, and 
- avoid silently passing over dynamic values, instead raising a warning and returning the default-defining string when reading.
- refuse to alter a column type if it has a dynamic default value, since we can't currently do that properly.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

We actually don't attempt to specifically identify constant default settings anymore.  Rather, we identify known dynamic default settings which we can't properly handle, and treat them differently.  Unfortunately, the identification of these dynamic defaults depends on the node types in the Abstract Syntax Tree given for the expression using the `pglast` package.  The only good documentation of what those node types are is in a pair of C header files that the `pglast` project uses:
- https://github.com/pganalyze/libpg_query/blob/13-latest/src/postgres/include/nodes/parsenodes.h , and
- https://github.com/pganalyze/libpg_query/blob/13-latest/src/postgres/include/nodes/primnodes.h

I was only able to find two tags that are guaranteed to appear in any dynamic default setting for a column.  It's possible more exist.  These would need to be added to the `db.columns.operations.select._is_default_expr_dynamic` function when found.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
