### PR TITLE
Fixed linting errors with script.

### DIFF
--- a/.github/actions/project_update/project_update.py
+++ b/.github/actions/project_update/project_update.py
@@ -1,8 +1,9 @@
-import argparse, json, os
+import argparse
+import json
+import os
 from string import Template
 
 import requests
-from github import Github
 
 
 GITHUB_TOKEN = os.environ['MATHESAR_ORG_GITHUB_TOKEN']
@@ -26,7 +27,7 @@ def run_graphql(graphql):
         print(f'\tResult of query:\n\t\t{result}')
         return result
     else:
-        raise Exception("Query failed to run by returning code of {}. {}".format(request.status_code, query))
+        raise Exception(f'\tQuery failed to run by returning code of {request.status_code}.\n\t\t{graphql}')
 
 
 def get_project_data():
@@ -130,6 +131,7 @@ def get_arguments():
     parser.add_argument("--status", help="Status to set ")
     parser.add_argument("--priority", help="Priority to set ")
     return parser.parse_args()
+
 
 if __name__ == '__main__':
     args = get_arguments()

--- a/.github/actions/project_update/requirements.txt
+++ b/.github/actions/project_update/requirements.txt
@@ -1,2 +1,1 @@
-PyGithub
 requests

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -27,7 +27,7 @@ jobs:
           MATHESAR_ORG_GITHUB_TOKEN: ${{secrets.MATHESAR_ORG_GITHUB_TOKEN}}
         run: |
           cd .github/actions/project_update/
-          python project_update.py ${{ github.event.pull_request.node_id }} --priority Active
+          python project_update.py ${{ github.event.pull_request.node_id }} --status Started --priority Active
 
       - name: Add issue to project
         if: github.event_name == 'issues'
@@ -35,4 +35,4 @@ jobs:
           MATHESAR_ORG_GITHUB_TOKEN: ${{secrets.MATHESAR_ORG_GITHUB_TOKEN}}
         run: |
           cd .github/actions/project_update/
-          python project_update.py ${{ github.event.issue.node_id }} --priority Backlog
+          python project_update.py ${{ github.event.issue.node_id }} --status Triage --priority Backlog


### PR DESCRIPTION
Related to #685

This PR fixes linting errors with the new GitHub workflow automation. It also serves to test the new workflow.

I've been committing most changes directly to `master` because I needed it to be on `master` to test the workflow. I don't think it needs review since it's not related to Mathesar's code, but all three new files I added are in this PR so they can be looked through in full if desired. I did not modify any other files in `master`.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
