### PR TITLE
Backend text filtering

### DIFF
--- a/db/filters/base.py
+++ b/db/filters/base.py
@@ -42,6 +42,8 @@ class LeafPredicateId(Enum):
     STARTS_WITH = "starts_with"
     ENDS_WITH = "ends_with"
     CONTAINS = "contains"
+    EMAIL_DOMAIN_CONTAINS = "email_domain_contains"
+    EMAIL_DOMAIN_EQUALS = "email_domain_equals"
 
 
 class ParameterCount(Enum):
@@ -336,6 +338,37 @@ class Contains(ReliesOnLike, SingleParameter, Leaf, Predicate):
         return f"%{escaped_parameter}%"
 
 
+@frozen_dataclass
+class AppliesToEmail:
+    pass
+
+
+def applies_to_email(predicate_subclass: Type[Predicate]) -> bool:
+    return issubclass(predicate_subclass, AppliesToEmail)
+
+
+@frozen_dataclass
+class EmailDomainContains(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
+    id: LeafPredicateId = static(LeafPredicateId.EMAIL_DOMAIN_CONTAINS)
+    name: str = static("Email domain contains")
+
+    @property
+    def like_pattern(self) -> str:
+        escaped_parameter = self.escape(self.parameter)
+        return f"%@%{escaped_parameter}%"
+
+
+@frozen_dataclass
+class EmailDomainEquals(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
+    id: LeafPredicateId = static(LeafPredicateId.EMAIL_DOMAIN_EQUALS)
+    name: str = static("Email domain equals")
+
+    @property
+    def like_pattern(self) -> str:
+        escaped_parameter = self.escape(self.parameter)
+        return f"%@{escaped_parameter}"
+
+
 def get_predicate_subclass_by_id_str(predicate_id_str: str) -> Union[Type[LeafPredicateId], Type[BranchPredicateId]]:
     for subclass in all_predicates:
         if subclass.id.value == predicate_id_str:
@@ -365,6 +398,8 @@ all_predicates = [
     StartsWith,
     EndsWith,
     Contains,
+    EmailDomainContains,
+    EmailDomainEquals
 ]
 
 

--- a/db/filters/base.py
+++ b/db/filters/base.py
@@ -227,7 +227,7 @@ class Or(MultiParameter, Branch, Predicate):
 
 
 @frozen_dataclass
-class BasedOnLike(ABC):
+class ReliesOnLike(ABC):
     """Some predicates represent specific patterns applied with the SQL LIKE expression.
     These will invariably operate on text."""
     
@@ -255,8 +255,12 @@ class BasedOnLike(ABC):
         return escaped_parameter
 
 
+def relies_on_like(predicate_subclass: Type[Predicate]) -> bool:
+    return issubclass(predicate_subclass, ReliesOnLike)
+
+
 @frozen_dataclass
-class StartsWith(BasedOnLike, SingleParameter, Leaf, Predicate):
+class StartsWith(ReliesOnLike, SingleParameter, Leaf, Predicate):
     type: LeafPredicateType = static(LeafPredicateType.STARTS_WITH)
     name: str = static("Starts with")
 
@@ -267,7 +271,7 @@ class StartsWith(BasedOnLike, SingleParameter, Leaf, Predicate):
 
 
 @frozen_dataclass
-class EndsWith(BasedOnLike, SingleParameter, Leaf, Predicate):
+class EndsWith(ReliesOnLike, SingleParameter, Leaf, Predicate):
     type: LeafPredicateType = static(LeafPredicateType.ENDS_WITH)
     name: str = static("Ends with")
 
@@ -278,7 +282,7 @@ class EndsWith(BasedOnLike, SingleParameter, Leaf, Predicate):
 
 
 @frozen_dataclass
-class Contains(BasedOnLike, SingleParameter, Leaf, Predicate):
+class Contains(ReliesOnLike, SingleParameter, Leaf, Predicate):
     type: LeafPredicateType = static(LeafPredicateType.CONTAINS)
     name: str = static("Contains")
 
@@ -352,7 +356,7 @@ def assert_predicate_correct(predicate):
             assert not is_parameter_list, "This parameter cannot be a list."
             is_parameter_predicate = isinstance(parameter, Predicate)
             if isinstance(predicate, Leaf):
-                if isinstance(predicate, BasedOnLike):
+                if isinstance(predicate, ReliesOnLike):
                     is_parameter_string = isinstance(parameter, str)
                     assert is_parameter_string, "This parameter must be a string."
                 else:

--- a/db/filters/base.py
+++ b/db/filters/base.py
@@ -339,8 +339,9 @@ class Contains(ReliesOnLike, SingleParameter, Leaf, Predicate):
 
 
 @frozen_dataclass
-class AppliesToEmail:
-    pass
+class AppliesToEmail(ReliesOnLike):
+    # Emails are case-insensitive
+    case_sensitive: bool = static(False)
 
 
 def applies_to_email(predicate_subclass: Type[Predicate]) -> bool:

--- a/db/filters/base.py
+++ b/db/filters/base.py
@@ -339,17 +339,17 @@ class Contains(ReliesOnLike, SingleParameter, Leaf, Predicate):
 
 
 @frozen_dataclass
-class AppliesToEmail(ReliesOnLike):
+class AppliesOnlyToEmail(ReliesOnLike):
     # Emails are case-insensitive
     case_sensitive: bool = static(False)
 
 
-def applies_to_email(predicate_subclass: Type[Predicate]) -> bool:
-    return issubclass(predicate_subclass, AppliesToEmail)
+def applies_only_to_email(predicate_subclass: Type[Predicate]) -> bool:
+    return issubclass(predicate_subclass, AppliesOnlyToEmail)
 
 
 @frozen_dataclass
-class EmailDomainContains(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
+class EmailDomainContains(AppliesOnlyToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
     id: LeafPredicateId = static(LeafPredicateId.EMAIL_DOMAIN_CONTAINS)
     name: str = static("Email domain contains")
 
@@ -360,7 +360,7 @@ class EmailDomainContains(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, P
 
 
 @frozen_dataclass
-class EmailDomainEquals(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
+class EmailDomainEquals(AppliesOnlyToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
     id: LeafPredicateId = static(LeafPredicateId.EMAIL_DOMAIN_EQUALS)
     name: str = static("Email domain equals")
 

--- a/db/filters/operations/deserialize.py
+++ b/db/filters/operations/deserialize.py
@@ -10,27 +10,32 @@ def get_predicate_from_MA_filter_spec(spec: dict) -> Predicate:
     if not isinstance(spec, dict):
         raise BadFilterFormat("Parsing of Mathesar filter specification failed.")
     predicate_type_str = get_first_dict_key(spec)
-    predicate_subclass = get_predicate_subclass_by_type_str(predicate_type_str)
-    predicate_body = spec[predicate_type_str]
-    if issubclass(predicate_subclass, Leaf):
-        columnName = predicate_body['column']
-        if issubclass(predicate_subclass, SingleParameter):
-            return predicate_subclass(column=columnName, parameter=predicate_body['parameter'])
-        elif issubclass(predicate_subclass, MultiParameter):
-            return predicate_subclass(column=columnName, parameters=predicate_body['parameters'])
-        elif issubclass(predicate_subclass, NoParameter):
-            return predicate_subclass(column=columnName)
+    try:
+        predicate_subclass = get_predicate_subclass_by_type_str(predicate_type_str)
+        predicate_body = spec[predicate_type_str]
+        if issubclass(predicate_subclass, Leaf):
+            columnName = predicate_body['column']
+            if issubclass(predicate_subclass, SingleParameter):
+                return predicate_subclass(column=columnName, parameter=predicate_body['parameter'])
+            elif issubclass(predicate_subclass, MultiParameter):
+                return predicate_subclass(column=columnName, parameters=predicate_body['parameters'])
+            elif issubclass(predicate_subclass, NoParameter):
+                return predicate_subclass(column=columnName)
+            else:
+                raise Exception("This should never happen.")
+        elif issubclass(predicate_subclass, Branch):
+            if issubclass(predicate_subclass, SingleParameter):
+                parameter_predicate = get_predicate_from_MA_filter_spec(predicate_body)
+                return predicate_subclass(parameter=parameter_predicate)
+            elif issubclass(predicate_subclass, MultiParameter):
+                parameter_predicates = \
+                    [get_predicate_from_MA_filter_spec(parameter) for parameter in predicate_body]
+                return predicate_subclass(parameters=parameter_predicates)
+            else:
+                raise Exception("This should never happen.")
         else:
             raise Exception("This should never happen.")
-    elif issubclass(predicate_subclass, Branch):
-        if issubclass(predicate_subclass, SingleParameter):
-            parameter_predicate = get_predicate_from_MA_filter_spec(predicate_body)
-            return predicate_subclass(parameter=parameter_predicate)
-        elif issubclass(predicate_subclass, MultiParameter):
-            parameter_predicates = \
-                [get_predicate_from_MA_filter_spec(parameter) for parameter in predicate_body]
-            return predicate_subclass(parameters=parameter_predicates)
-        else:
-            raise Exception("This should never happen.")
-    else:
-        raise Exception("This should never happen.")
+    except KeyError as e:
+        # Raised when the objects in the spec don't have the right fields (e.g. column or parameter).
+        raise BadFilterFormat from e
+

--- a/db/filters/operations/deserialize.py
+++ b/db/filters/operations/deserialize.py
@@ -1,6 +1,6 @@
 from typing import Any
 from db.filters.base import (
-    Predicate, Leaf, SingleParameter, MultiParameter, NoParameter, Branch, get_predicate_subclass_by_type_str, BadFilterFormat
+    Predicate, Leaf, SingleParameter, MultiParameter, NoParameter, Branch, get_predicate_subclass_by_id_str, BadFilterFormat
 )
 
 
@@ -9,12 +9,12 @@ def get_predicate_from_MA_filter_spec(spec: dict) -> Predicate:
         return next(iter(dict))
     if not isinstance(spec, dict):
         raise BadFilterFormat("Parsing of Mathesar filter specification failed.")
-    predicate_type_str = get_first_dict_key(spec)
+    predicate_id_str = get_first_dict_key(spec)
     try:
-        predicate_subclass = get_predicate_subclass_by_type_str(predicate_type_str)
-        predicate_body = spec[predicate_type_str]
+        predicate_subclass = get_predicate_subclass_by_id_str(predicate_id_str)
+        predicate_body = spec[predicate_id_str]
         if issubclass(predicate_subclass, Leaf):
-            return predicate_subclass(*predicate_body)
+            return predicate_subclass(**predicate_body)
         elif issubclass(predicate_subclass, Branch):
             if issubclass(predicate_subclass, SingleParameter):
                 parameter_predicate = get_predicate_from_MA_filter_spec(predicate_body)
@@ -27,7 +27,7 @@ def get_predicate_from_MA_filter_spec(spec: dict) -> Predicate:
                 raise Exception("This should never happen.")
         else:
             raise Exception("This should never happen.")
-    except KeyError as e:
+    except (TypeError, KeyError) as e:
         # Raised when the objects in the spec don't have the right fields (e.g. column or parameter).
         raise BadFilterFormat from e
 

--- a/db/filters/operations/deserialize.py
+++ b/db/filters/operations/deserialize.py
@@ -14,15 +14,7 @@ def get_predicate_from_MA_filter_spec(spec: dict) -> Predicate:
         predicate_subclass = get_predicate_subclass_by_type_str(predicate_type_str)
         predicate_body = spec[predicate_type_str]
         if issubclass(predicate_subclass, Leaf):
-            columnName = predicate_body['column']
-            if issubclass(predicate_subclass, SingleParameter):
-                return predicate_subclass(column=columnName, parameter=predicate_body['parameter'])
-            elif issubclass(predicate_subclass, MultiParameter):
-                return predicate_subclass(column=columnName, parameters=predicate_body['parameters'])
-            elif issubclass(predicate_subclass, NoParameter):
-                return predicate_subclass(column=columnName)
-            else:
-                raise Exception("This should never happen.")
+            return predicate_subclass(*predicate_body)
         elif issubclass(predicate_subclass, Branch):
             if issubclass(predicate_subclass, SingleParameter):
                 parameter_predicate = get_predicate_from_MA_filter_spec(predicate_body)

--- a/db/filters/operations/serialize.py
+++ b/db/filters/operations/serialize.py
@@ -5,22 +5,22 @@ def get_SA_filter_spec_from_predicate(pred: Predicate) -> dict:
     if isinstance(pred, Leaf):
         if isinstance(pred, SingleParameter):
             if isinstance(pred, ReliesOnLike):
-                return {'field': pred.column, 'op': pred.saId(), 'value': pred.like_pattern}
+                return {'field': pred.column, 'op': pred.saId, 'value': pred.like_pattern}
             else:
-                return {'field': pred.column, 'op': pred.saId(), 'value': pred.parameter}
+                return {'field': pred.column, 'op': pred.saId, 'value': pred.parameter}
         elif isinstance(pred, MultiParameter):
-            return {'field': pred.column, 'op': pred.saId(), 'value': pred.parameters}
+            return {'field': pred.column, 'op': pred.saId, 'value': pred.parameters}
         elif isinstance(pred, NoParameter):
-            return {'field': pred.column, 'op': pred.saId()}
+            return {'field': pred.column, 'op': pred.saId}
         else:
             raise Exception("This should never happen.")
     elif isinstance(pred, Branch):
         if isinstance(pred, SingleParameter):
             subject = get_SA_filter_spec_from_predicate(pred.parameter)
-            return {pred.saId(): [subject]}
+            return {pred.saId: [subject]}
         elif isinstance(pred, MultiParameter):
             subjects = [get_SA_filter_spec_from_predicate(subject) for subject in pred.parameters]
-            return {pred.saId(): subjects}
+            return {pred.saId: subjects}
         else:
             raise Exception("This should never happen.")
     else:

--- a/db/filters/operations/serialize.py
+++ b/db/filters/operations/serialize.py
@@ -1,10 +1,10 @@
-from db.filters.base import Predicate, Leaf, SingleParameter, MultiParameter, NoParameter, Branch, BasedOnLike
+from db.filters.base import Predicate, Leaf, SingleParameter, MultiParameter, NoParameter, Branch, ReliesOnLike
 
 
 def get_SA_filter_spec_from_predicate(pred: Predicate) -> dict:
     if isinstance(pred, Leaf):
         if isinstance(pred, SingleParameter):
-            if isinstance(pred, BasedOnLike):
+            if isinstance(pred, ReliesOnLike):
                 return {'field': pred.column, 'op': pred.saId(), 'value': pred.like_pattern}
             else:
                 return {'field': pred.column, 'op': pred.saId(), 'value': pred.parameter}

--- a/db/filters/operations/serialize.py
+++ b/db/filters/operations/serialize.py
@@ -1,10 +1,13 @@
-from db.filters.base import Predicate, Leaf, SingleParameter, MultiParameter, NoParameter, Branch
+from db.filters.base import Predicate, Leaf, SingleParameter, MultiParameter, NoParameter, Branch, BasedOnLike
 
 
 def get_SA_filter_spec_from_predicate(pred: Predicate) -> dict:
     if isinstance(pred, Leaf):
         if isinstance(pred, SingleParameter):
-            return {'field': pred.column, 'op': pred.saId(), 'value': pred.parameter}
+            if isinstance(pred, BasedOnLike):
+                return {'field': pred.column, 'op': pred.saId(), 'value': pred.like_pattern}
+            else:
+                return {'field': pred.column, 'op': pred.saId(), 'value': pred.parameter}
         elif isinstance(pred, MultiParameter):
             return {'field': pred.column, 'op': pred.saId(), 'value': pred.parameters}
         elif isinstance(pred, NoParameter):

--- a/db/tests/filters/operations/test_serialize.py
+++ b/db/tests/filters/operations/test_serialize.py
@@ -1,7 +1,7 @@
 import pytest
 
 from db.filters.operations.serialize import get_SA_filter_spec_from_predicate
-from db.filters.base import And, Or, Not, Equal, Empty, In, StartsWith, EndsWith, Contains
+from db.filters.base import And, Or, Not, Equal, Empty, In, StartsWith, EndsWith, Contains, EmailDomainEquals
 
 valid_cases = [
     [
@@ -29,11 +29,13 @@ valid_cases = [
             EndsWith(column="col1", parameter="end%"),
             # NOTE: below line tests case sensitivity setting
             Contains(column="col1", parameter="contained\\", case_sensitive=False),
+            EmailDomainEquals(column="col1", parameter="domain.com"),
         ]),
         {'or': [
             {'field': 'col1', 'op': 'like', 'value': 'start\\_%'},
             {'field': 'col1', 'op': 'like', 'value': '%end\\%'},
             {'field': 'col1', 'op': 'ilike', 'value': '%contained\\\\%'},
+            {'field': 'col1', 'op': 'ilike', 'value': '%@domain.com'},
         ]}
     ],
 ]

--- a/db/tests/filters/operations/test_serialize.py
+++ b/db/tests/filters/operations/test_serialize.py
@@ -23,16 +23,17 @@ valid_cases = [
         ]}
     ],
     [
-        # Notice that escaping of _, % and \ is tested too:
+        # NOTE: escaping of _, % and \ is tested too:
         Or([
             StartsWith(column="col1", parameter="start_"),
             EndsWith(column="col1", parameter="end%"),
-            Contains(column="col1", parameter="contained\\"),
+            # NOTE: below line tests case sensitivity setting
+            Contains(column="col1", parameter="contained\\", case_sensitive=False),
         ]),
         {'or': [
             {'field': 'col1', 'op': 'like', 'value': 'start\\_%'},
             {'field': 'col1', 'op': 'like', 'value': '%end\\%'},
-            {'field': 'col1', 'op': 'like', 'value': '%contained\\\\%'},
+            {'field': 'col1', 'op': 'ilike', 'value': '%contained\\\\%'},
         ]}
     ],
 ]

--- a/db/tests/filters/operations/test_serialize.py
+++ b/db/tests/filters/operations/test_serialize.py
@@ -1,23 +1,43 @@
+import pytest
+
 from db.filters.operations.serialize import get_SA_filter_spec_from_predicate
-from db.filters.base import And, Or, Not, Equal, Empty, In
+from db.filters.base import And, Or, Not, Equal, Empty, In, StartsWith, EndsWith, Contains
 
-
-def test_serialization():
-    predicate = And([
-        Or([
-            In(column="col3", parameters=["value31", "value32"]),
-            Equal(column="col2", parameter="value2"),
+valid_cases = [
+    [
+        And([
+            Or([
+                In(column="col3", parameters=["value31", "value32"]),
+                Equal(column="col2", parameter="value2"),
+            ]),
+            Not(
+                Empty(column="col1")
+            ),
         ]),
-        Not(
-            Empty(column="col1")
-        ),
-    ])
-    expected_SA_filter_spec = {'and': [
+        {'and': [
+            {'or': [
+                {'field': 'col3', 'op': 'in', 'value': ['value31', 'value32']},
+                {'field': 'col2', 'op': 'eq', 'value': 'value2'}
+            ]},
+            {'not': [{'field': 'col1', 'op': 'is_null'}]}
+        ]}
+    ],
+    [
+        # Notice that escaping of _, % and \ is tested too:
+        Or([
+            StartsWith(column="col1", parameter="start_"),
+            EndsWith(column="col1", parameter="end%"),
+            Contains(column="col1", parameter="contained\\"),
+        ]),
         {'or': [
-            {'field': 'col3', 'op': 'in', 'value': ['value31', 'value32']},
-            {'field': 'col2', 'op': 'eq', 'value': 'value2'}
-        ]},
-        {'not': [{'field': 'col1', 'op': 'is_null'}]}
-    ]}
+            {'field': 'col1', 'op': 'like', 'value': 'start\\_%'},
+            {'field': 'col1', 'op': 'like', 'value': '%end\\%'},
+            {'field': 'col1', 'op': 'like', 'value': '%contained\\\\%'},
+        ]}
+    ],
+]
+
+@pytest.mark.parametrize("predicate, expected_SA_filter_spec", valid_cases)
+def test_serialization(predicate, expected_SA_filter_spec):
     sa_filter_spec = get_SA_filter_spec_from_predicate(predicate)
     assert sa_filter_spec == expected_SA_filter_spec

--- a/db/tests/filters/test_base.py
+++ b/db/tests/filters/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 from db.filters.base import (
-    all_predicates, Leaf, Branch, MultiParameter, SingleParameter, NoParameter, Empty, BadFilterFormat
+    all_predicates, Leaf, Branch, MultiParameter, SingleParameter, NoParameter, Empty, BadFilterFormat, BasedOnLike
 )
 
 
@@ -37,6 +37,10 @@ parametersSpec = {
         'single': {
             'valid': [1],
             'invalid': [None, [], someLeafPredicates[0]],
+            'based_on_like': {
+                'valid': ["abc"],
+                'invalid': [None, [], someLeafPredicates[0], 1],
+            },
         },
     },
     'branch': {
@@ -58,7 +62,10 @@ def get_spec_params(predicate_subclass, valid):
         if issubclass(predicate_subclass, MultiParameter):
             return parametersSpec['leaf']['multi'][validityKey]
         elif issubclass(predicate_subclass, SingleParameter):
-            return parametersSpec['leaf']['single'][validityKey]
+            if issubclass(predicate_subclass, BasedOnLike):
+                return parametersSpec['leaf']['single']['based_on_like'][validityKey]
+            else:
+                return parametersSpec['leaf']['single'][validityKey]
     elif issubclass(predicate_subclass, Branch):
         if issubclass(predicate_subclass, MultiParameter):
             return parametersSpec['branch']['multi'][validityKey]

--- a/db/tests/filters/test_base.py
+++ b/db/tests/filters/test_base.py
@@ -1,6 +1,6 @@
 import pytest
 from db.filters.base import (
-    all_predicates, Leaf, Branch, MultiParameter, SingleParameter, NoParameter, Empty, BadFilterFormat, BasedOnLike
+    all_predicates, Leaf, Branch, MultiParameter, SingleParameter, NoParameter, Empty, BadFilterFormat, ReliesOnLike
 )
 
 
@@ -62,7 +62,7 @@ def get_spec_params(predicate_subclass, valid):
         if issubclass(predicate_subclass, MultiParameter):
             return parametersSpec['leaf']['multi'][validityKey]
         elif issubclass(predicate_subclass, SingleParameter):
-            if issubclass(predicate_subclass, BasedOnLike):
+            if issubclass(predicate_subclass, ReliesOnLike):
                 return parametersSpec['leaf']['single']['based_on_like'][validityKey]
             else:
                 return parametersSpec['leaf']['single'][validityKey]

--- a/db/tests/records/operations/test_filter.py
+++ b/db/tests/records/operations/test_filter.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from sqlalchemy_filters.exceptions import BadFilterFormat, FilterFieldNotFound
 
 from db.records.operations.select import get_records
-from db.filters.base import MultiParameter, SingleParameter, get_predicate_subclass_by_type_str
+from db.filters.base import MultiParameter, SingleParameter, get_predicate_subclass_by_id_str
 
 
 def test_get_records_filters_using_col_str_names(roster_table_obj):
@@ -179,7 +179,7 @@ def test_get_records_filters_ops(
     filter_sort_table_obj, column, predicate_id, parameter, res_len
 ):
     filter_sort, engine = filter_sort_table_obj
-    predicate = get_predicate_subclass_by_type_str(predicate_id)
+    predicate = get_predicate_subclass_by_id_str(predicate_id)
     if issubclass(predicate, MultiParameter):
         filters = {predicate_id: {"column": column, "parameters": parameter}}
     elif issubclass(predicate, SingleParameter):
@@ -246,7 +246,7 @@ def test_get_records_filters_boolean_ops(
 ):
     filter_sort, engine = filter_sort_table_obj
 
-    predicate = get_predicate_subclass_by_type_str(op)
+    predicate = get_predicate_subclass_by_id_str(op)
     if issubclass(predicate, SingleParameter):
         filters = {op: [
             {"equal": {"column": column, "parameter": parameter}}

--- a/db/tests/records/operations/test_filter.py
+++ b/db/tests/records/operations/test_filter.py
@@ -26,6 +26,7 @@ def test_get_records_filters_using_col_str_names(roster_table_obj):
     )
 
 
+# TODO no: remove these tests
 @pytest.mark.skip(reason="should this be implemented?")
 def test_get_records_filters_using_col_objects(roster_table_obj):
     roster, engine = roster_table_obj
@@ -98,13 +99,16 @@ parameter_to_python_func = {
     # "like": _like,
     # "ilike": _ilike,
     # "not_ilike": lambda x, v: not _ilike(x, v),
+    "starts_with": lambda x, v: x.startswith(v),
+    "ends_with": lambda x, v: x.endswith(v),
+    "contains": lambda x, v: x.find(v) != -1,
     "in": lambda x, v: x in v,
     "not_in": lambda x, v: x not in v,
     # "any": lambda x, v: v in x,
     # "not_any": lambda x, v: v not in x,
     "and": lambda x: all(x),
     "or": lambda x: any(x),
-    "not": lambda x: not x[0]
+    "not": lambda x: not x[0],
 }
 
 
@@ -147,8 +151,14 @@ parameter_test_list = [
     ("date", "lesser_or_equal", "2099-01-01", 100),
     # like
     # ("varchar", "like", "%1", 10),
+    # ends_with
+    ("varchar", "ends_with", "1", 10),
     # ilike
     # ("varchar", "ilike", "STRING1%", 12),
+    # starts_with
+    ("varchar", "starts_with", "string1", 12),
+    # contains
+    ("varchar", "contains", "g1", 12),
     # not_ilike
     # ("varchar", "not_ilike", "STRING1%", 88),
     # in

--- a/mathesar/api/filters.py
+++ b/mathesar/api/filters.py
@@ -38,6 +38,11 @@ def _get_type_name(type) -> str:
 
 
 def _get_settings_for_predicate(predicate_class: Type[Predicate]) -> Optional[dict]:
+    """
+    Returns optional settings applicable to predicate. At the moment this is an adhoc
+    implementation: notice that instead of hardcoding, as done below, this can be automated
+    to find any non-standard fields and describe their defaults and types.
+    """
     if issubclass(predicate_class, ReliesOnLike):
         case_sensitive_field = tuple(
             field

--- a/mathesar/api/filters.py
+++ b/mathesar/api/filters.py
@@ -1,5 +1,5 @@
 from dataclasses import fields as dataclass_fields
-from typing import Optional, Type
+from typing import Optional, Type, List
 
 from django_filters import BooleanFilter, DateTimeFromToRangeFilter, OrderingFilter
 from django_property_filter import PropertyFilterSet, PropertyBaseInFilter, PropertyCharFilter, PropertyOrderingFilter
@@ -37,7 +37,11 @@ def _get_type_name(type) -> str:
     return type.__name__
 
 
-def _get_settings_for_predicate(predicate_class: Type[Predicate]) -> Optional[dict]:
+def _get_human_name_for_field(field) -> str:
+    return field.name.replace("_", " ").capitalize()
+
+
+def _get_settings_for_predicate(predicate_class: Type[Predicate]) -> Optional[List[dict]]:
     """
     Returns optional settings applicable to predicate. At the moment this is an adhoc
     implementation: notice that instead of hardcoding, as done below, this can be automated
@@ -49,12 +53,14 @@ def _get_settings_for_predicate(predicate_class: Type[Predicate]) -> Optional[di
             for field in dataclass_fields(predicate_class)
             if field.name == "case_sensitive"
         )[0]
-        return {
-            case_sensitive_field.name: {
+        return [
+            {
+                "identifier": case_sensitive_field.name,
+                "name": _get_human_name_for_field(case_sensitive_field),
                 "default": case_sensitive_field.default,
                 "type": _get_type_name(case_sensitive_field.type),
             }
-        }
+        ]
     else:
         return None
 

--- a/mathesar/api/filters.py
+++ b/mathesar/api/filters.py
@@ -19,9 +19,9 @@ def get_filter_options_for_database(database):
     ]
     return [
         {
-            "identifier": predicate.type.value,
+            "identifier": predicate.id.value,
             "name": predicate.name,
-            "position": predicate.super_type.value,
+            "position": predicate.position.value,
             "parameter_count": predicate.parameter_count.value,
             "ma_types": [
                 ma_type.value

--- a/mathesar/api/filters.py
+++ b/mathesar/api/filters.py
@@ -58,7 +58,7 @@ def _get_settings_for_predicate(predicate_class: Type[Predicate]) -> Optional[Li
                 "identifier": case_sensitive_field.name,
                 "name": _get_human_name_for_field(case_sensitive_field),
                 "default": case_sensitive_field.default,
-                "type": _get_type_name(case_sensitive_field.type),
+                "python_type": _get_type_name(case_sensitive_field.type),
             }
         ]
     else:

--- a/mathesar/api/serializers/databases.py
+++ b/mathesar/api/serializers/databases.py
@@ -33,4 +33,4 @@ class FilterSerializer(serializers.Serializer):
     position = serializers.CharField()
     parameter_count = serializers.CharField()
     ma_types = serializers.ListField(child=serializers.CharField())
-    settings = serializers.DictField(child=serializers.DictField(), allow_null=True)
+    settings = serializers.ListField(child=serializers.DictField(), allow_null=True)

--- a/mathesar/api/serializers/databases.py
+++ b/mathesar/api/serializers/databases.py
@@ -33,3 +33,4 @@ class FilterSerializer(serializers.Serializer):
     position = serializers.CharField()
     parameter_count = serializers.CharField()
     ma_types = serializers.ListField(child=serializers.CharField())
+    settings = serializers.DictField(child=serializers.DictField(), allow_null=True)

--- a/mathesar/database/types.py
+++ b/mathesar/database/types.py
@@ -5,7 +5,7 @@ Mathesar data types are shown in the UI.
 from enum import Enum
 
 from db.types.base import PostgresType, MathesarCustomType, get_available_types, get_qualified_name, get_db_type_name
-from db.filters.base import Predicate, relies_on_comparability
+from db.filters.base import Predicate, relies_on_comparability, relies_on_like
 
 from typing import Type
 
@@ -37,9 +37,22 @@ def _is_ma_type_comparable(ma_type: MathesarTypeIdentifier) -> bool:
     return ma_type in comparable_mathesar_types
 
 
+supported_by_like_mathesar_types = {
+    MathesarTypeIdentifier.EMAIL,
+    MathesarTypeIdentifier.TEXT,
+    MathesarTypeIdentifier.URI,
+}
+
+
+def _is_ma_type_supported_by_like(ma_type: MathesarTypeIdentifier) -> bool:
+    return ma_type in supported_by_like_mathesar_types
+
+
 def is_ma_type_supported_by_predicate(ma_type: MathesarTypeIdentifier, predicate: Type[Predicate]):
     if relies_on_comparability(predicate):
         return _is_ma_type_comparable(ma_type)
+    elif relies_on_like(predicate):
+        return _is_ma_type_supported_by_like(ma_type)
     else:
         return True
 

--- a/mathesar/database/types.py
+++ b/mathesar/database/types.py
@@ -5,7 +5,7 @@ Mathesar data types are shown in the UI.
 from enum import Enum
 
 from db.types.base import PostgresType, MathesarCustomType, get_available_types, get_qualified_name, get_db_type_name
-from db.filters.base import Predicate, relies_on_comparability, relies_on_like, applies_to_email
+from db.filters.base import Predicate, relies_on_comparability, relies_on_like, applies_only_to_email
 
 from typing import Type
 
@@ -55,10 +55,10 @@ def _is_ma_type_an_email_string(ma_type: MathesarTypeIdentifier) -> bool:
 def is_ma_type_supported_by_predicate(ma_type: MathesarTypeIdentifier, predicate: Type[Predicate]):
     if relies_on_comparability(predicate):
         return _is_ma_type_comparable(ma_type)
+    elif applies_only_to_email(predicate):
+        return _is_ma_type_an_email_string(ma_type)
     elif relies_on_like(predicate):
         return _is_ma_type_supported_by_like(ma_type)
-    elif applies_to_email(predicate):
-        return _is_ma_type_an_email_string(ma_type)
     else:
         return True
 

--- a/mathesar/database/types.py
+++ b/mathesar/database/types.py
@@ -5,7 +5,7 @@ Mathesar data types are shown in the UI.
 from enum import Enum
 
 from db.types.base import PostgresType, MathesarCustomType, get_available_types, get_qualified_name, get_db_type_name
-from db.filters.base import Predicate, relies_on_comparability, relies_on_like
+from db.filters.base import Predicate, relies_on_comparability, relies_on_like, applies_to_email
 
 from typing import Type
 
@@ -48,11 +48,17 @@ def _is_ma_type_supported_by_like(ma_type: MathesarTypeIdentifier) -> bool:
     return ma_type in supported_by_like_mathesar_types
 
 
+def _is_ma_type_an_email_string(ma_type: MathesarTypeIdentifier) -> bool:
+    return ma_type is MathesarTypeIdentifier.EMAIL
+
+
 def is_ma_type_supported_by_predicate(ma_type: MathesarTypeIdentifier, predicate: Type[Predicate]):
     if relies_on_comparability(predicate):
         return _is_ma_type_comparable(ma_type)
     elif relies_on_like(predicate):
         return _is_ma_type_supported_by_like(ma_type)
+    elif applies_to_email(predicate):
+        return _is_ma_type_an_email_string(ma_type)
     else:
         return True
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #406

Depends on previous filtering PR: #837 

Introduces `StartsWith`, `EndsWith` and `Contains` predicates for text types. These predicates accept a `case_sensitive` setting (defaults to `True`).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
