### PR TITLE
Backend email filtering

### DIFF
--- a/db/filters/base.py
+++ b/db/filters/base.py
@@ -339,8 +339,9 @@ class Contains(ReliesOnLike, SingleParameter, Leaf, Predicate):
 
 
 @frozen_dataclass
-class AppliesToEmail:
-    pass
+class AppliesToEmail(ReliesOnLike):
+    # Emails are case-insensitive
+    case_sensitive: bool = static(False)
 
 
 def applies_to_email(predicate_subclass: Type[Predicate]) -> bool:

--- a/db/filters/base.py
+++ b/db/filters/base.py
@@ -339,17 +339,17 @@ class Contains(ReliesOnLike, SingleParameter, Leaf, Predicate):
 
 
 @frozen_dataclass
-class AppliesToEmail(ReliesOnLike):
+class AppliesOnlyToEmail(ReliesOnLike):
     # Emails are case-insensitive
     case_sensitive: bool = static(False)
 
 
-def applies_to_email(predicate_subclass: Type[Predicate]) -> bool:
-    return issubclass(predicate_subclass, AppliesToEmail)
+def applies_only_to_email(predicate_subclass: Type[Predicate]) -> bool:
+    return issubclass(predicate_subclass, AppliesOnlyToEmail)
 
 
 @frozen_dataclass
-class EmailDomainContains(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
+class EmailDomainContains(AppliesOnlyToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
     id: LeafPredicateId = static(LeafPredicateId.EMAIL_DOMAIN_CONTAINS)
     name: str = static("Email domain contains")
 
@@ -360,7 +360,7 @@ class EmailDomainContains(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, P
 
 
 @frozen_dataclass
-class EmailDomainEquals(AppliesToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
+class EmailDomainEquals(AppliesOnlyToEmail, ReliesOnLike, SingleParameter, Leaf, Predicate):
     id: LeafPredicateId = static(LeafPredicateId.EMAIL_DOMAIN_EQUALS)
     name: str = static("Email domain equals")
 

--- a/db/tests/filters/operations/test_serialize.py
+++ b/db/tests/filters/operations/test_serialize.py
@@ -1,7 +1,7 @@
 import pytest
 
 from db.filters.operations.serialize import get_SA_filter_spec_from_predicate
-from db.filters.base import And, Or, Not, Equal, Empty, In, StartsWith, EndsWith, Contains
+from db.filters.base import And, Or, Not, Equal, Empty, In, StartsWith, EndsWith, Contains, EmailDomainEquals
 
 valid_cases = [
     [
@@ -29,11 +29,13 @@ valid_cases = [
             EndsWith(column="col1", parameter="end%"),
             # NOTE: below line tests case sensitivity setting
             Contains(column="col1", parameter="contained\\", case_sensitive=False),
+            EmailDomainEquals(column="col1", parameter="domain.com"),
         ]),
         {'or': [
             {'field': 'col1', 'op': 'like', 'value': 'start\\_%'},
             {'field': 'col1', 'op': 'like', 'value': '%end\\%'},
             {'field': 'col1', 'op': 'ilike', 'value': '%contained\\\\%'},
+            {'field': 'col1', 'op': 'ilike', 'value': '%@domain.com'},
         ]}
     ],
 ]

--- a/mathesar/api/filters.py
+++ b/mathesar/api/filters.py
@@ -19,9 +19,9 @@ def get_filter_options_for_database(database):
     ]
     return [
         {
-            "identifier": predicate.type.value,
+            "identifier": predicate.id.value,
             "name": predicate.name,
-            "position": predicate.super_type.value,
+            "position": predicate.position.value,
             "parameter_count": predicate.parameter_count.value,
             "ma_types": [
                 ma_type.value

--- a/mathesar/database/types.py
+++ b/mathesar/database/types.py
@@ -5,7 +5,7 @@ Mathesar data types are shown in the UI.
 from enum import Enum
 
 from db.types.base import PostgresType, MathesarCustomType, get_available_types, get_qualified_name, get_db_type_name
-from db.filters.base import Predicate, relies_on_comparability, relies_on_like, applies_to_email
+from db.filters.base import Predicate, relies_on_comparability, relies_on_like, applies_only_to_email
 
 from typing import Type
 
@@ -55,10 +55,10 @@ def _is_ma_type_an_email_string(ma_type: MathesarTypeIdentifier) -> bool:
 def is_ma_type_supported_by_predicate(ma_type: MathesarTypeIdentifier, predicate: Type[Predicate]):
     if relies_on_comparability(predicate):
         return _is_ma_type_comparable(ma_type)
+    elif applies_only_to_email(predicate):
+        return _is_ma_type_an_email_string(ma_type)
     elif relies_on_like(predicate):
         return _is_ma_type_supported_by_like(ma_type)
-    elif applies_to_email(predicate):
-        return _is_ma_type_an_email_string(ma_type)
     else:
         return True
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #410

Implements `EmailDomainEquals` and `EmailDomainContains` string matching predicates that are applyable only to email Mathesar types.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
