### PR TITLE
Use compiled type strings in types endpoint

### DIFF
--- a/db/tests/columns/operations/test_alter.py
+++ b/db/tests/columns/operations/test_alter.py
@@ -455,7 +455,7 @@ def test_batch_update_column_types(engine_email_type):
     table_oid = get_oid_from_table(table.name, schema, engine)
 
     column_data = _get_pizza_column_data()
-    column_data[0]['plain_type'] = 'INTEGER'
+    column_data[0]['plain_type'] = 'DOUBLE PRECISION'
     column_data[2]['plain_type'] = 'BOOLEAN'
 
     batch_update_columns(table_oid, engine, column_data)

--- a/db/tests/columns/operations/test_alter.py
+++ b/db/tests/columns/operations/test_alter.py
@@ -436,8 +436,8 @@ def test_batch_update_column_names(engine_email_type):
     table_oid = get_oid_from_table(table.name, schema, engine)
 
     column_data = _get_pizza_column_data()
-    column_data[1]['name'] == 'Pizza Style'
-    column_data[2]['name'] == 'Eaten Recently?'
+    column_data[1]['name'] = 'Pizza Style'
+    column_data[2]['name'] = 'Eaten Recently?'
 
     batch_update_columns(table_oid, engine, column_data)
     updated_table = reflect_table(table.name, schema, engine)
@@ -455,8 +455,8 @@ def test_batch_update_column_types(engine_email_type):
     table_oid = get_oid_from_table(table.name, schema, engine)
 
     column_data = _get_pizza_column_data()
-    column_data[0]['plain_type'] == 'INTEGER'
-    column_data[2]['plain_type'] == 'BOOLEAN'
+    column_data[0]['plain_type'] = 'INTEGER'
+    column_data[2]['plain_type'] = 'BOOLEAN'
 
     batch_update_columns(table_oid, engine, column_data)
     updated_table = reflect_table(table.name, schema, engine)
@@ -474,10 +474,10 @@ def test_batch_update_column_names_and_types(engine_email_type):
     table_oid = get_oid_from_table(table.name, schema, engine)
 
     column_data = _get_pizza_column_data()
-    column_data[0]['name'] == 'Pizza ID'
-    column_data[0]['plain_type'] == 'INTEGER'
-    column_data[1]['name'] == 'Pizza Style'
-    column_data[2]['plain_type'] == 'BOOLEAN'
+    column_data[0]['name'] = 'Pizza ID'
+    column_data[0]['plain_type'] = 'INTEGER'
+    column_data[1]['name'] = 'Pizza Style'
+    column_data[2]['plain_type'] = 'BOOLEAN'
 
     batch_update_columns(table_oid, engine, column_data)
     updated_table = reflect_table(table.name, schema, engine)

--- a/db/tests/columns/operations/test_alter.py
+++ b/db/tests/columns/operations/test_alter.py
@@ -425,7 +425,7 @@ def test_batch_update_columns_no_changes(engine_email_type):
 
     assert len(table.columns) == len(updated_table.columns)
     for index, column in enumerate(table.columns):
-        new_column_type = get_db_type_name(updated_table.columns[index].type, engine_email_type)
+        new_column_type = get_db_type_name(updated_table.columns[index].type, engine)
         assert new_column_type == 'VARCHAR'
         assert updated_table.columns[index].name == table.columns[index].name
 
@@ -444,7 +444,7 @@ def test_batch_update_column_names(engine_email_type):
 
     assert len(table.columns) == len(updated_table.columns)
     for index, column in enumerate(table.columns):
-        new_column_type = get_db_type_name(updated_table.columns[index].type, engine_email_type)
+        new_column_type = get_db_type_name(updated_table.columns[index].type, engine)
         assert new_column_type == column_data[index]['plain_type']
         assert updated_table.columns[index].name == column_data[index]['name']
 
@@ -463,7 +463,7 @@ def test_batch_update_column_types(engine_email_type):
 
     assert len(table.columns) == len(updated_table.columns)
     for index, column in enumerate(table.columns):
-        new_column_type = get_db_type_name(updated_table.columns[index].type, engine_email_type)
+        new_column_type = get_db_type_name(updated_table.columns[index].type, engine)
         assert new_column_type == column_data[index]['plain_type']
         assert updated_table.columns[index].name == column_data[index]['name']
 
@@ -484,7 +484,7 @@ def test_batch_update_column_names_and_types(engine_email_type):
 
     assert len(table.columns) == len(updated_table.columns)
     for index, column in enumerate(table.columns):
-        new_column_type = get_db_type_name(updated_table.columns[index].type, engine_email_type)
+        new_column_type = get_db_type_name(updated_table.columns[index].type, engine)
         assert new_column_type == column_data[index]['plain_type']
         assert updated_table.columns[index].name == column_data[index]['name']
 
@@ -503,7 +503,7 @@ def test_batch_update_column_drop_columns(engine_email_type):
 
     assert len(updated_table.columns) == len(table.columns) - 2
     for index, column in enumerate(updated_table.columns):
-        new_column_type = get_db_type_name(updated_table.columns[index].type, engine_email_type)
+        new_column_type = get_db_type_name(updated_table.columns[index].type, engine)
         assert new_column_type == column_data[index - 2]['plain_type']
         assert updated_table.columns[index].name == column_data[index - 2]['name']
 
@@ -525,6 +525,6 @@ def test_batch_update_column_all_operations(engine_email_type):
 
     assert len(updated_table.columns) == len(table.columns) - 1
     for index, column in enumerate(updated_table.columns):
-        new_column_type = get_db_type_name(updated_table.columns[index].type, engine_email_type)
+        new_column_type = get_db_type_name(updated_table.columns[index].type, engine)
         assert new_column_type == column_data[index]['plain_type']
         assert updated_table.columns[index].name == column_data[index]['name']

--- a/db/types/base.py
+++ b/db/types/base.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from inspect import isclass
 
 from sqlalchemy import create_engine
 
@@ -88,9 +87,8 @@ def get_available_types(engine):
 
 
 def get_db_type_name(sa_type, engine):
-    USER_DEFINED_STR = 'user_defined'
-    sa_type = sa_type() if isclass(sa_type) else sa_type
-    db_type = sa_type.compile(dialect=engine.dialect)
-    if db_type == USER_DEFINED_STR:
-        db_type = sa_type.compile(engine.dialect)
+    try:
+        db_type = sa_type.compile(dialect=engine.dialect)
+    except TypeError:
+        db_type = sa_type().compile(dialect=engine.dialect)
     return db_type

--- a/db/types/base.py
+++ b/db/types/base.py
@@ -88,7 +88,7 @@ def get_available_types(engine):
 
 def get_db_type_name(sa_type, engine):
     USER_DEFINED_STR = 'user_defined'
-    db_type = sa_type.__visit_name__
+    db_type = sa_type().compile(dialect=engine.dialect)
     if db_type == USER_DEFINED_STR:
         db_type = sa_type().compile(engine.dialect)
     return db_type

--- a/db/types/base.py
+++ b/db/types/base.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from inspect import isclass
 
 from sqlalchemy import create_engine
 
@@ -88,7 +89,8 @@ def get_available_types(engine):
 
 def get_db_type_name(sa_type, engine):
     USER_DEFINED_STR = 'user_defined'
-    db_type = sa_type().compile(dialect=engine.dialect)
+    sa_type = sa_type() if isclass(sa_type) else sa_type
+    db_type = sa_type.compile(dialect=engine.dialect)
     if db_type == USER_DEFINED_STR:
-        db_type = sa_type().compile(engine.dialect)
+        db_type = sa_type.compile(engine.dialect)
     return db_type

--- a/mathesar/database/types.py
+++ b/mathesar/database/types.py
@@ -123,6 +123,10 @@ def _ignore_type(sa_type_name):
     return False
 
 
+import logging
+logger = logging.getLogger(__name__)
+
+
 def get_types(engine):
     types = []
     installed_types = get_available_types(engine)
@@ -138,6 +142,7 @@ def get_types(engine):
             if sa_type_name in installed_types and (not _ignore_type(sa_type_name)):
                 sa_type = installed_types[sa_type_name]
                 db_type = get_db_type_name(sa_type, engine)
+                logger.warn(f"sa_type_name {sa_type_name}\ndb_type      {db_type}")
                 sa_type_info = {
                     'sa_type_name': sa_type_name,
                     'sa_type': sa_type,

--- a/mathesar/database/types.py
+++ b/mathesar/database/types.py
@@ -123,10 +123,6 @@ def _ignore_type(sa_type_name):
     return False
 
 
-import logging
-logger = logging.getLogger(__name__)
-
-
 def get_types(engine):
     types = []
     installed_types = get_available_types(engine)
@@ -142,7 +138,6 @@ def get_types(engine):
             if sa_type_name in installed_types and (not _ignore_type(sa_type_name)):
                 sa_type = installed_types[sa_type_name]
                 db_type = get_db_type_name(sa_type, engine)
-                logger.warn(f"sa_type_name {sa_type_name}\ndb_type      {db_type}")
                 sa_type_info = {
                     'sa_type_name': sa_type_name,
                     'sa_type': sa_type,


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #932 

<!-- Concisely describe what the pull request does. -->

This modifies the `db.types.base.get_db_type_name` to use the compiled type string instead of `__visit_name__`.  The effect in the API is that now all types reported by the types endpoint have the name they actually have in the DB (according to SQLAlchemy).

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This means that the function in question will not return type parameters (this is desired where it's currently called).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
