### PR TITLE
Add more column default details

### DIFF
--- a/db/columns/base.py
+++ b/db/columns/base.py
@@ -148,7 +148,7 @@ class MathesarColumn(Column):
         if default_dict:
             return {
                 'is_dynamic': default_dict['is_dynamic'],
-                'default_value': default_dict['default_value']
+                'value': default_dict['value']
             }
 
     @property

--- a/db/columns/operations/alter.py
+++ b/db/columns/operations/alter.py
@@ -19,7 +19,7 @@ def alter_column(engine, table_oid, column_index, column_data):
     TYPE_OPTIONS_KEY = 'type_options'
     NULLABLE_KEY = NULLABLE
     DEFAULT_DICT = 'column_default_dict'
-    DEFAULT_KEY = 'default_value'
+    DEFAULT_KEY = 'value'
     NAME_KEY = NAME
 
     table = reflect_table_from_oid(table_oid, engine)

--- a/db/columns/operations/alter.py
+++ b/db/columns/operations/alter.py
@@ -18,6 +18,7 @@ def alter_column(engine, table_oid, column_index, column_data):
     TYPE_KEY = 'plain_type'
     TYPE_OPTIONS_KEY = 'type_options'
     NULLABLE_KEY = NULLABLE
+    DEFAULT_DICT = 'column_default_dict'
     DEFAULT_KEY = 'default_value'
     NAME_KEY = NAME
 
@@ -40,8 +41,9 @@ def alter_column(engine, table_oid, column_index, column_data):
         if NULLABLE_KEY in column_data:
             nullable = column_data[NULLABLE_KEY]
             change_column_nullable(table, column_index, engine, conn, nullable)
-        if DEFAULT_KEY in column_data:
-            default = column_data[DEFAULT_KEY]
+        if DEFAULT_DICT in column_data:
+            default_dict = column_data[DEFAULT_DICT]
+            default = default_dict[DEFAULT_KEY] if default_dict is not None else None
             set_column_default(table, column_index, engine, conn, default)
         if NAME_KEY in column_data:
             # Name always needs to be the last item altered

--- a/db/columns/operations/create.py
+++ b/db/columns/operations/create.py
@@ -22,7 +22,7 @@ def create_column(engine, table_oid, column_data):
     column_type = column_data.get(TYPE, column_data.get("type"))
     column_type_options = column_data.get("type_options", {})
     column_nullable = column_data.get(NULLABLE, True)
-    default_value = column_data.get(DEFAULT, {}).get('default_value')
+    default_value = column_data.get(DEFAULT, {}).get('value')
     prepared_default_value = str(default_value) if default_value is not None else None
     supported_types = get_supported_alter_column_types(
         engine, friendly_names=False,

--- a/db/columns/operations/create.py
+++ b/db/columns/operations/create.py
@@ -22,6 +22,7 @@ def create_column(engine, table_oid, column_data):
     column_type = column_data.get(TYPE, column_data.get("type"))
     column_type_options = column_data.get("type_options", {})
     column_nullable = column_data.get(NULLABLE, True)
+    column_default_value = str(column_data.get(DEFAULT, {}).get('default_value'))
     supported_types = get_supported_alter_column_types(
         engine, friendly_names=False,
     )
@@ -35,7 +36,7 @@ def create_column(engine, table_oid, column_data):
     try:
         column = MathesarColumn(
             column_data[NAME], sa_type(**column_type_options), nullable=column_nullable,
-            server_default=column_data.get(DEFAULT, None)
+            server_default=column_default_value,
         )
     except DataError as e:
         if type(e.orig) == InvalidTextRepresentation:

--- a/db/columns/operations/create.py
+++ b/db/columns/operations/create.py
@@ -22,7 +22,8 @@ def create_column(engine, table_oid, column_data):
     column_type = column_data.get(TYPE, column_data.get("type"))
     column_type_options = column_data.get("type_options", {})
     column_nullable = column_data.get(NULLABLE, True)
-    column_default_value = str(column_data.get(DEFAULT, {}).get('default_value'))
+    default_value = column_data.get(DEFAULT, {}).get('default_value')
+    prepared_default_value = str(default_value) if default_value is not None else None
     supported_types = get_supported_alter_column_types(
         engine, friendly_names=False,
     )
@@ -36,7 +37,7 @@ def create_column(engine, table_oid, column_data):
     try:
         column = MathesarColumn(
             column_data[NAME], sa_type(**column_type_options), nullable=column_nullable,
-            server_default=column_default_value,
+            server_default=prepared_default_value,
         )
     except DataError as e:
         if type(e.orig) == InvalidTextRepresentation:

--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -104,7 +104,7 @@ def get_column_default_dict(table_oid, column_index, engine, connection_to_use=N
             select(text(sql_text)),
             connection_to_use
         ).first()[0]
-    return {"default_value": default_value, "is_dynamic": is_dynamic}
+    return {"value": default_value, "is_dynamic": is_dynamic}
 
 
 def get_column_default(table_oid, column_index, engine, connection_to_use=None):
@@ -112,7 +112,7 @@ def get_column_default(table_oid, column_index, engine, connection_to_use=None):
         table_oid, column_index, engine, connection_to_use=connection_to_use
     )
     if default_dict is not None:
-        return default_dict['default_value']
+        return default_dict['value']
 
 
 def _is_default_expr_dynamic(server_default):

--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -94,7 +94,7 @@ def get_column_default_dict(table_oid, column_index, engine, connection_to_use=N
         warnings.warn(
             "Dynamic column defaults are read only", DynamicDefaultWarning
         )
-        default_value = str(column.server_default.arg)
+        default_value = sql_text
     else:
         # Defaults are stored as text with SQL casts appended
         # Ex: "'test default string'::character varying" or "'2020-01-01'::date"

--- a/db/tests/columns/operations/test_alter.py
+++ b/db/tests/columns/operations/test_alter.py
@@ -79,7 +79,7 @@ def _get_pizza_column_data():
         ({"plain_type": "blah"}, "retype_column"),
         ({"type_options": {"blah": "blah"}}, "retype_column"),
         ({"nullable": True}, "change_column_nullable"),
-        ({"default_value": 1}, "set_column_default"),
+        ({"column_default_dict": {"default_value": 1}}, "set_column_default"),
     ]
 )
 def test_alter_column_chooses_wisely(column_dict, func_name, engine_with_schema):

--- a/db/tests/columns/operations/test_alter.py
+++ b/db/tests/columns/operations/test_alter.py
@@ -79,7 +79,7 @@ def _get_pizza_column_data():
         ({"plain_type": "blah"}, "retype_column"),
         ({"type_options": {"blah": "blah"}}, "retype_column"),
         ({"nullable": True}, "change_column_nullable"),
-        ({"column_default_dict": {"default_value": 1}}, "set_column_default"),
+        ({"column_default_dict": {"value": 1}}, "set_column_default"),
     ]
 )
 def test_alter_column_chooses_wisely(column_dict, func_name, engine_with_schema):

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -72,7 +72,7 @@ class SimpleColumnSerializer(serializers.ModelSerializer):
 
 
 class ColumnDefaultSerializer(serializers.Serializer):
-    default_value = InputValueField()
+    value = InputValueField()
     is_dynamic = serializers.BooleanField(read_only=True)
 
 

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -71,6 +71,11 @@ class SimpleColumnSerializer(serializers.ModelSerializer):
         return super().to_internal_value(data)
 
 
+class ColumnDefaultSerializer(serializers.Serializer):
+    default_value = serializers.CharField()
+    is_dynamic = serializers.BooleanField(read_only=True)
+
+
 class ColumnSerializer(SimpleColumnSerializer):
     class Meta(SimpleColumnSerializer.Meta):
         fields = SimpleColumnSerializer.Meta.fields + (
@@ -100,9 +105,7 @@ class ColumnSerializer(SimpleColumnSerializer):
     # Read only fields
     index = serializers.IntegerField(source='column_index', read_only=True)
     valid_target_types = serializers.ListField(read_only=True)
-    default = InputValueField(
-        source='default_value', read_only=False, default=None, allow_null=True
-    )
+    default = ColumnDefaultSerializer(source='column_default_dict')
 
     def validate(self, data):
         if not self.partial:

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -96,6 +96,9 @@ class ColumnSerializer(SimpleColumnSerializer):
     type = serializers.CharField(source='plain_type', required=False)
     nullable = serializers.BooleanField(default=True)
     primary_key = serializers.BooleanField(default=False)
+    default = ColumnDefaultSerializer(
+        source='column_default_dict', required=False, default=None
+    )
 
     # From duplication fields
     source_column = serializers.IntegerField(required=False, write_only=True)
@@ -105,7 +108,6 @@ class ColumnSerializer(SimpleColumnSerializer):
     # Read only fields
     index = serializers.IntegerField(source='column_index', read_only=True)
     valid_target_types = serializers.ListField(read_only=True)
-    default = ColumnDefaultSerializer(source='column_default_dict', required=False)
 
     def validate(self, data):
         if not self.partial:

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -72,7 +72,7 @@ class SimpleColumnSerializer(serializers.ModelSerializer):
 
 
 class ColumnDefaultSerializer(serializers.Serializer):
-    default_value = serializers.CharField()
+    default_value = InputValueField()
     is_dynamic = serializers.BooleanField(read_only=True)
 
 
@@ -105,7 +105,7 @@ class ColumnSerializer(SimpleColumnSerializer):
     # Read only fields
     index = serializers.IntegerField(source='column_index', read_only=True)
     valid_target_types = serializers.ListField(read_only=True)
-    default = ColumnDefaultSerializer(source='column_default_dict')
+    default = ColumnDefaultSerializer(source='column_default_dict', required=False)
 
     def validate(self, data):
         if not self.partial:

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -97,7 +97,7 @@ class ColumnSerializer(SimpleColumnSerializer):
     nullable = serializers.BooleanField(default=True)
     primary_key = serializers.BooleanField(default=False)
     default = ColumnDefaultSerializer(
-        source='column_default_dict', required=False, default=None
+        source='column_default_dict', required=False, allow_null=True, default=None
     )
 
     # From duplication fields

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -85,7 +85,7 @@ def test_column_list(column_test_table, client):
             'primary_key': True,
             'display_options': None,
             'default': {
-                'default_value': """nextval('"Patents".anewtable_mycolumn0_seq'::regclass)""",
+                'value': """nextval('"Patents".anewtable_mycolumn0_seq'::regclass)""",
                 'is_dynamic': True
             },
             'valid_target_types': [
@@ -118,7 +118,7 @@ def test_column_list(column_test_table, client):
             'primary_key': False,
             'display_options': None,
             'default': {
-                'default_value': 5,
+                'value': 5,
                 'is_dynamic': False,
             },
             'valid_target_types': [
@@ -190,7 +190,7 @@ def test_column_create_default(
 ):
     cache.clear()
     name = "anewcolumn"
-    data = {"name": name, "type": type_, "default": {"default_value": default}}
+    data = {"name": name, "type": type_, "default": {"value": default}}
     response = client.post(
         f"/api/v0/tables/{column_test_table.id}/columns/",
         json.dumps(data), content_type='application/json'
@@ -202,7 +202,7 @@ def test_column_create_default(
         f"/api/v0/tables/{column_test_table.id}/columns/"
     )
     actual_new_col = new_columns_response.json()["results"][-1]
-    assert actual_new_col["default"]["default_value"] == expt_default
+    assert actual_new_col["default"]["value"] == expt_default
 
     # Ensure the correct date value is generated when inserting a new record
     sa_table = column_test_table._sa_table
@@ -218,7 +218,7 @@ def test_column_create_invalid_default(column_test_table, client):
     data = {
         "name": name,
         "type": "BOOLEAN",
-        "default": {"default_value": "Not a boolean"},
+        "default": {"value": "Not a boolean"},
     }
     response = client.post(
         f"/api/v0/tables/{column_test_table.id}/columns/",
@@ -417,7 +417,7 @@ def test_column_invalid_display_options_type_on_reflection(column_test_table_wit
 def test_column_update_default(column_test_table, client):
     cache.clear()
     expt_default = 5
-    data = {"default": {"default_value": expt_default}}  # Ensure we pass a int and not a str
+    data = {"default": {"value": expt_default}}  # Ensure we pass a int and not a str
     response = client.get(
         f"/api/v0/tables/{column_test_table.id}/columns/"
     )
@@ -429,7 +429,7 @@ def test_column_update_default(column_test_table, client):
         data=json.dumps(data),
         content_type="application/json",
     )
-    assert response.json()["default"]["default_value"] == expt_default
+    assert response.json()["default"]["value"] == expt_default
 
 
 def test_column_update_delete_default(column_test_table, client):
@@ -451,7 +451,7 @@ def test_column_update_delete_default(column_test_table, client):
 
 def test_column_update_default_invalid_cast(column_test_table, client):
     cache.clear()
-    data = {"default": {"default_value": "not an integer"}}
+    data = {"default": {"value": "not an integer"}}
     response = client.get(
         f"/api/v0/tables/{column_test_table.id}/columns/"
     )
@@ -543,7 +543,7 @@ def test_column_update_name_type_nullable_default(column_test_table, client):
         "type": type_,
         "name": new_name,
         "nullable": True,
-        "default": {"default_value": True},
+        "default": {"value": True},
     }
     response = client.get(
         f"/api/v0/tables/{column_test_table.id}/columns/"
@@ -559,7 +559,7 @@ def test_column_update_name_type_nullable_default(column_test_table, client):
     assert response.json()["type"] == type_
     assert response.json()["name"] == new_name
     assert response.json()["nullable"] is True
-    assert response.json()["default"]["default_value"] is True
+    assert response.json()["default"]["value"] is True
 
 
 def test_column_update_type_options(column_test_table, client):
@@ -625,7 +625,7 @@ def test_column_update_invalid_type(create_table, client, engine_email_type):
 def test_column_update_returns_table_dependent_fields(column_test_table, client):
     cache.clear()
     expt_default = 5
-    data = {"default": {"default_value": expt_default}}
+    data = {"default": {"value": expt_default}}
     response = client.get(
         f"/api/v0/tables/{column_test_table.id}/columns/"
     )


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #933 

<!-- Concisely describe what the pull request does. -->

Now, the form for the "default" value for columns is as follows:

```
...
"default": {
    "default_value": <some val>,
    "is_dynamic": <true|false>
}
...
```

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

This change also applies for setting the default when creating or updating columns.  The "is_dynamic" field is read-only and can't be set.  The "default_value" field is required whenever "default" is non-null.

Because this is a new form for the default value for columns, I expect this to be a breaking change.

Old form:

```
...
"default": <some_val>
...
```

The new form is above.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
