### PR TITLE
Boolean DB type casting extension

### DIFF
--- a/db/tests/types/operations/test_cast.py
+++ b/db/tests/types/operations/test_cast.py
@@ -531,7 +531,9 @@ MASTER_DB_TYPE_MAP_SPEC = {
             },
             BOOLEAN: {
                 VALID: [
-                    ("true", True), ("false", False), ("t", True), ("f", False)
+                    ("true", True), ("false", False), ("t", True), ("f", False),
+                    ("yes", True), ("y", True), ("no", False), ("n", False),
+                    ("on", True), ("off", False),
                 ],
                 INVALID: ["cat"],
             },
@@ -670,7 +672,9 @@ MASTER_DB_TYPE_MAP_SPEC = {
             },
             BOOLEAN: {
                 VALID: [
-                    ("true", True), ("false", False), ("t", True), ("f", False)
+                    ("true", True), ("false", False), ("t", True), ("f", False),
+                    ("yes", True), ("y", True), ("no", False), ("n", False),
+                    ("on", True), ("off", False),
                 ],
                 INVALID: ["cat"],
             },


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #387 

<!-- Concisely describe what the pull request does. -->

This adds some strings that can be cast to boolean:
- yes -> true
- no -> false
- y -> true
- n -> false
- on -> true
- off -> false

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

Note that this does _not_ restrict columns to have only two values for inferring boolean.  So, a column with '0', '1', 'true', 'TRUE', 'yes', 'off', ... would be inferred to be of boolean DB type.  This seems like the best compromise to make at the moment.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
