### PR TITLE
Use composition not inheritance for EventHandler

### DIFF
--- a/mathesar_ui/src/component-library/common/utils/EventHandler.ts
+++ b/mathesar_ui/src/component-library/common/utils/EventHandler.ts
@@ -1,5 +1,5 @@
 export default class EventHandler {
-  protected listeners: Map<string, Set<(value?: unknown) => unknown>>;
+  private listeners: Map<string, Set<(value?: unknown) => unknown>>;
 
   constructor() {
     this.listeners = new Map();
@@ -15,7 +15,7 @@ export default class EventHandler {
     };
   }
 
-  protected dispatch(eventName: string, value: unknown): void {
+  dispatch(eventName: string, value: unknown): void {
     this.listeners?.get(eventName)?.forEach((entry) => {
       try {
         entry?.(value);
@@ -25,7 +25,7 @@ export default class EventHandler {
     });
   }
 
-  protected destroy(): void {
+  destroy(): void {
     this.listeners.clear();
   }
 }

--- a/mathesar_ui/src/stores/table-data/columns.ts
+++ b/mathesar_ui/src/stores/table-data/columns.ts
@@ -8,11 +8,10 @@ import {
 } from '@mathesar/utils/api';
 import { TabularType } from '@mathesar/App.d';
 import { intersection } from '@mathesar/utils/language';
-import { EventHandler } from '@mathesar-component-library';
 
 import type { Writable, Updater, Subscriber, Unsubscriber } from 'svelte/store';
 import type { PaginatedResponse } from '@mathesar/utils/api';
-import type { CancellablePromise } from '@mathesar-component-library';
+import { CancellablePromise, EventHandler } from '@mathesar-component-library';
 import type { DBObjectEntry, DbType } from '@mathesar/App.d';
 import type {
   AbstractTypesMap,
@@ -69,10 +68,7 @@ function api(url: string) {
   };
 }
 
-export class ColumnsDataStore
-  extends EventHandler
-  implements Writable<ColumnsData>
-{
+export class ColumnsDataStore implements Writable<ColumnsData> {
   private type: TabularType;
 
   private parentId: DBObjectEntry['id'];
@@ -87,13 +83,14 @@ export class ColumnsDataStore
 
   private fetchCallback: (storeData: ColumnsData) => void;
 
+  eventHandler = new EventHandler();
+
   constructor(
     type: TabularType,
     parentId: number,
     meta: Meta,
     fetchCallback: (storeData: ColumnsData) => void = () => {},
   ) {
-    super();
     this.type = type;
     this.parentId = parentId;
     this.store = writable({
@@ -190,7 +187,7 @@ export class ColumnsDataStore
   ): Promise<Partial<Column>> {
     const column = await this.api.update(columnId, { type });
     await this.fetch();
-    this.dispatch('columnPatched', column);
+    this.eventHandler.dispatch('columnPatched', column);
     return column;
   }
 
@@ -230,7 +227,7 @@ export class ColumnsDataStore
   destroy(): void {
     this.promise?.cancel();
     this.promise = undefined;
-    super.destroy();
+    this.eventHandler.destroy();
   }
 
   async deleteColumn(columnId: Column['id']): Promise<void> {

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -244,7 +244,7 @@ export class RecordsData {
         void this.fetch();
       },
     );
-    this.columnPatchUnsubscriber = this.columnsDataStore.on(
+    this.columnPatchUnsubscriber = this.columnsDataStore.eventHandler.on(
       'columnPatched',
       () => {
         void this.fetch();

--- a/mathesar_ui/src/stores/table-data/tabularData.ts
+++ b/mathesar_ui/src/stores/table-data/tabularData.ts
@@ -18,7 +18,7 @@ export type TabularDataParams = [
   ...MetaParams
 ];
 
-export class TabularData extends EventHandler {
+export class TabularData {
   type: TabularType;
 
   id: DBObjectEntry['id'];
@@ -33,6 +33,8 @@ export class TabularData extends EventHandler {
 
   display: Display;
 
+  eventHandler = new EventHandler();
+
   private metaParametersUnsubscriber: Unsubscriber;
 
   constructor(
@@ -40,7 +42,6 @@ export class TabularData extends EventHandler {
     id: DBObjectEntry['id'],
     params?: TabularDataParams,
   ) {
-    super();
     this.type = type;
     this.id = id;
     this.meta = new Meta(type, id, params?.slice(2) as MetaParams);
@@ -61,7 +62,7 @@ export class TabularData extends EventHandler {
     );
 
     this.metaParametersUnsubscriber = this.meta.metaParameters.subscribe(() => {
-      this.dispatch('paramsUpdated', this.parameterize());
+      this.eventHandler.dispatch('paramsUpdated', this.parameterize());
     });
   }
 
@@ -91,7 +92,7 @@ export class TabularData extends EventHandler {
     this.recordsData.destroy();
     this.constraintsDataStore.destroy();
     this.columnsDataStore.destroy();
-    super.destroy();
+    this.eventHandler.destroy();
   }
 }
 

--- a/mathesar_ui/src/stores/tabs/tabList.ts
+++ b/mathesar_ui/src/stores/tabs/tabList.ts
@@ -191,14 +191,20 @@ export class TabList {
   }
 
   addParamListenerToTab(tab: MathesarTab): void {
+    if (!tab.tabularData) {
+      return;
+    }
     /**
      * We do not have to explicity unlisten to this event.
      * When tabularData is removed through `removeTabularContent` in remove method,
      * all listeners for that tabularData are cleared.
      */
-    tab.tabularData?.on('paramsUpdated', (params: TabularDataParams) => {
-      syncSingleTabularParamToURL(this.dbName, this.schemaId, params);
-    });
+    tab.tabularData.eventHandler.on(
+      'paramsUpdated',
+      (params: TabularDataParams) => {
+        syncSingleTabularParamToURL(this.dbName, this.schemaId, params);
+      },
+    );
   }
 
   add(tab: MathesarTab, options?: TabAddOptions): void {


### PR DESCRIPTION
I wanted to start using some of the EventHandler code in continuing on #976 but I found the mental model of `ColumnsDataStore` _being_ an `EventHandler` to be quite unintuitive. This is a quick stab at converting that code to use composition instead of inheritance.

@pavish what do you think of this? We can scrap it if you're attached to using inheritance. I know we already discussed this topic previously (not able to find the link quickly). But I figured it would be easiest to continue the discussion by looking at something concrete. I recall you saying you were concerned that we'd need to "duplicate methods on different classes" or something to that effect. This PR demonstrates that we don't need to do that.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>




