### PR TITLE
Use more strict export for `proceed` function within `CancelOrProceedButtonPair` component

### DIFF
--- a/mathesar_ui/src/component-library/cancel-or-proceed-button-pair/CancelOrProceedButtonPair.svelte
+++ b/mathesar_ui/src/component-library/cancel-or-proceed-button-pair/CancelOrProceedButtonPair.svelte
@@ -38,12 +38,18 @@
   export let canProceed = true;
   export let canCancel = true;
   export let isProcessing = false;
-  /**
-   * Bind to this function if you want to be able to programmatically call the
-   * proceed function from within the parent component and show the loading
-   * spinner while the promise is resolving.
-   */
-  export let proceed: () => Promise<void> = async () => {};
+
+  let spinnerButtonProceed: () => Promise<void> = async () => {};
+
+  export function proceed(): Promise<void> {
+    // Why do we have `spinnerButtonProceed` and `proceed` separately?
+    //
+    // Because we want to export a const (`proceed` here) to make it clear to
+    // consuming components that they can't supply their own function. AND we
+    // need for _this_ component to be able to change the function in the
+    // process of binding to the value from lower down in the component tree.
+    return spinnerButtonProceed();
+  }
 
   $: fullCancelButton = { ...cancelButtonDefaults, ...cancelButton };
   $: fullProceedButton = { ...proceedButtonDefaults, ...proceedButton };
@@ -56,7 +62,7 @@
   </Button>
   <SpinnerButton
     bind:isProcessing
-    bind:proceed
+    bind:proceed={spinnerButtonProceed}
     onClick={onProceed}
     icon={fullProceedButton.icon}
     label={fullProceedButton.label}


### PR DESCRIPTION
This PR resolves a [small discussion in #868](https://github.com/centerofci/mathesar/pull/868#discussion_r769807447) by improving code quality in one Svelte component

@pavish said:

> it would be better to bind to the component and call the function using the component reference.

This PR offers a slightly different approach from your suggestion, but it should satisfy the same end goal of preventing consuming components from supplying their own `proceed` value.

I first tried binding to the component instance using `bind:this`. Having never before done that, I realized that the component instance only exposes _exported properties_ through the binding. Since we need to export something, I figured we might as well export a function. That way we don't need to bind to the component instance.

This still feels a tiny bit hacky, hence the code comment explaining the situation. I'm open to better suggestions, but this seems to do the trick.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
