### PR TITLE
Check for TypeScript errors in our CI workflow

### DIFF
--- a/.github/workflows/run-lint-audit-tests-ui.yml
+++ b/.github/workflows/run-lint-audit-tests-ui.yml
@@ -49,6 +49,29 @@ jobs:
       - run: npm install --no-audit --prefer-offline
       - run: npm run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+    # We only want to run on external PRs, since internal PRs are covered by "push"
+    # This prevents this from running twice on internal PRs
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    defaults:
+      run:
+        working-directory: ./mathesar_ui
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - id: npm-cache-dir
+        run: echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+      - run: npm install --no-audit --prefer-offline
+      - run: npm run typecheck
+
   audit:
     runs-on: ubuntu-latest
     # We only want to run on external PRs, since internal PRs are covered by "push"

--- a/mathesar_ui/package.json
+++ b/mathesar_ui/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "lint": "eslint .",
-    "typecheck": "svelte-check",
+    "typecheck": "svelte-check --tsconfig tsconfig.json --threshold error .",
     "build": "vite build",
     "test": "jest",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
Fixes #877

## Before

Code with type errors like the following would pass through our CI workflow without any failures.

```ts
const thisIsNotANumber: number = 'nope';
```

## After

Type errors are caught in `*.svelte` and `*.ts` files.



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
