### PR TITLE
Utilize existing ComponentAndProps type

### DIFF
--- a/mathesar_ui/src/component-library/common/types/ComponentAndProps.d.ts
+++ b/mathesar_ui/src/component-library/common/types/ComponentAndProps.d.ts
@@ -2,5 +2,5 @@ import type { SvelteComponent } from 'svelte';
 
 export interface ComponentAndProps {
   component: typeof SvelteComponent;
-  props?: unknown;
+  props?: Record<string, unknown>;
 }

--- a/mathesar_ui/src/components/cell/Cell.svelte
+++ b/mathesar_ui/src/components/cell/Cell.svelte
@@ -10,7 +10,7 @@
   export let state: 'loading' | 'error' | 'ready' = 'ready';
 
   // TODO (IMPORTANT): Calculate this at a higher level, instead of calculating on each cell instance
-  $: [cellComponent, cellProps] = getCellComponentWithProps(column);
+  $: ({ component, props } = getCellComponentWithProps(column));
 </script>
 
 <!--
@@ -19,8 +19,8 @@
 -->
 <div class="sheet-cell">
   <svelte:component
-    this={cellComponent}
-    {...cellProps}
+    this={component}
+    {...props}
     {isActive}
     readonly={column.primary_key}
     bind:value

--- a/mathesar_ui/src/components/cell/utils.ts
+++ b/mathesar_ui/src/components/cell/utils.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
-import type { SvelteComponent } from 'svelte';
 import type { Column } from '@mathesar/stores/table-data/types.d';
+import type { ComponentAndProps } from '@mathesar/component-library/types';
 import {
   currentDbAbstractTypes,
   getAbstractTypeForDbType,
@@ -20,10 +20,8 @@ function getInputConfiguration(
   return abstractTypeOfColumn?.input ?? null;
 }
 
-function getStringCellComponentAndProps(
-  column: Column,
-): [typeof SvelteComponent, Record<string, unknown>] {
-  const typeOptions = column.type_options;
+function getStringCellComponentAndProps(column: Column): ComponentAndProps {
+  const typeOptions = column.type_options ?? undefined;
   let component = TextBoxCell;
   if (
     !typeOptions ||
@@ -32,20 +30,16 @@ function getStringCellComponentAndProps(
   ) {
     component = TextAreaCell;
   }
-  return [component, typeOptions ?? {}];
+  return { component, props: typeOptions };
 }
 
-function getBooleanCellComponentAndProps(
-  column: Column,
-): [typeof SvelteComponent, Record<string, unknown>] {
-  const displayOptions = column.display_options;
+function getBooleanCellComponentAndProps(column: Column): ComponentAndProps {
+  const displayOptions = column.display_options ?? undefined;
   // TODO: Change to Select based on display option
-  return [CheckboxCell, displayOptions ?? {}];
+  return { component: CheckboxCell, props: displayOptions };
 }
 
-export function getCellComponentWithProps(
-  column: Column,
-): [typeof SvelteComponent, Record<string, unknown>] {
+export function getCellComponentWithProps(column: Column): ComponentAndProps {
   const inputOptions = getInputConfiguration(column);
   const inputDataType: string = inputOptions.type ?? 'string';
   switch (inputDataType) {
@@ -54,6 +48,6 @@ export function getCellComponentWithProps(
     case 'string':
       return getStringCellComponentAndProps(column);
     default:
-      return [TextBoxCell, {}];
+      return { component: TextBoxCell };
   }
 }


### PR DESCRIPTION
This is a follow up to #1080 (by @pavish) instead of review feedback.

This PR:

- Changes the type `[typeof SvelteComponent, Record<string, unknown>]` to the type we already had defined called `ComponentAndProps`.
- Improves `ComponentAndProps` by changing `unknown` to `Record<string, unknown>` which makes more sense.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

