### PR TITLE
Upgrade Playwright to 0.2.3

### DIFF
--- a/Dockerfile.integ-tests
+++ b/Dockerfile.integ-tests
@@ -111,7 +111,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 RUN pip install playwright==1.18.2
-RUN pip install pytest-playwright==0.2.2
+RUN pip install pytest-playwright==0.2.3
 RUN playwright install
 RUN playwright install-deps
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pytest-env==0.6.2
 pytest-cov==3.0.0
 Sphinx==3.5.3
 playwright==1.18.1
-pytest-playwright==0.2.2
+pytest-playwright==0.2.3


### PR DESCRIPTION
## Before

I was hitting [this bug](https://github.com/microsoft/playwright-pytest/issues/89) from Playwright.

I don't know quite how it happened but my local machine got into a state where I was not able to run tests anymore, even when I would wipe my volume and rebuild the container.

I would run:

```txt
docker exec mathesar_service pytest -x --no-cov mathesar/tests/integration
```

<details>
<summary>I would get:</summary>

```txt
============================= test session starts ==============================
platform linux -- Python 3.9.8, pytest-6.2.3, py-1.11.0, pluggy-0.13.1
django: settings: config.settings (from ini)
rootdir: /code, configfile: setup.cfg
plugins: cov-3.0.0, env-0.6.2, django-4.2.0, base-url-1.4.2, playwright-0.2.2
collected 14 items
   
mathesar/tests/integration/test_base_page.py .                           [  7%]
mathesar/tests/integration/test_columns.py EE
   
==================================== ERRORS ====================================
_________________ ERROR at setup of test_add_column[chromium] __________________
   
page = <Page url='http://localhost:43985/mathesar_db_test/2/?t=W1tdLG51bGxd'>
create_table = <function create_table.<locals>._create_table at 0x7f668add7670>
schema_name = 'table_tests'
base_schema_url = 'http://localhost:43985/mathesar_db_test/2'
   
    @pytest.fixture
    def go_to_patents_data_table(page, create_table, schema_name, base_schema_url):
        """
        Imports the `patents.csv` data into a table named "patents" and navigates to
        the view of that table before starting the test.
        """
        table_name = "patents"
        table = create_table(table_name, schema_name)
        table.import_verified = True
        table.save()
        page.goto(base_schema_url)
>       get_table_entry(page, table_name).click()
   
mathesar/tests/integration/conftest.py:89:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/lib/python3.9/site-packages/playwright/sync_api/_generated.py:12152: in click
    self._sync(
/usr/local/lib/python3.9/site-packages/playwright/_impl/_sync_base.py:111: in _sync
    return task.result()
/usr/local/lib/python3.9/site-packages/playwright/_impl/_locator.py:129: in click
    return await self._frame.click(self._selector, strict=True, **params)
/usr/local/lib/python3.9/site-packages/playwright/_impl/_frame.py:460: in click
    await self._channel.send("click", locals_to_params(locals()))
/usr/local/lib/python3.9/site-packages/playwright/_impl/_connection.py:39: in send
    return await self.inner_send(method, params, False)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <playwright._impl._connection.Channel object at 0x7f6699d6e100>
method = 'click'
params = {'selector': "#sidebar li[aria-level='1']:has(button:has-text('Tables')) ul >> li:has-text('patents')", 'strict': True}
return_as_dict = False
   
    async def inner_send(
        self, method: str, params: Optional[Dict], return_as_dict: bool
    ) -> Any:
        if params is None:
            params = {}
        callback = self._connection._send_message_to_server(self._guid, method, params)
        if self._connection._error:
            error = self._connection._error
            self._connection._error = None
            raise error
        done, _ = await asyncio.wait(
            {
                self._connection._transport.on_error_future,
                callback.future,
            },
            return_when=asyncio.FIRST_COMPLETED,
        )
        if not callback.future.done():
            callback.future.cancel()
>       result = next(iter(done)).result()
E       playwright._impl._api_types.TimeoutError: Timeout 30000ms exceeded.
E       =========================== logs ===========================
E       waiting for selector "#sidebar li[aria-level='1']:has(button:has-text('Tables')) ul >> li:has-text('patents')"
E         selector resolved to visible <li role="none" class="nav-item">…</li>
E       attempting click action
E         waiting for element to be visible, enabled and stable
E       ============================================================

/usr/local/lib/python3.9/site-packages/playwright/_impl/_connection.py:63: TimeoutError
________________ ERROR at teardown of test_add_column[chromium] ________________

browser = <Browser type=<BrowserType name=chromium executable_path=/root/.cache/ms-playwright/chromium-956323/chrome-linux/chrome> version=99.0.4812.0>
browser_context_args = {}
pytestconfig = <_pytest.config.Config object at 0x7f669ef791c0>
request = <SubRequest 'context' for <Function test_add_column[chromium]>>

    @pytest.fixture
    def context(
        browser: Browser,
        browser_context_args: Dict,
        pytestconfig: Any,
        request: pytest.FixtureRequest,
    ) -> Generator[BrowserContext, None, None]:
        pages: List[Page] = []
        context = browser.new_context(**browser_context_args)
        context.on("page", lambda page: pages.append(page))
    
        tracing_option = pytestconfig.getoption("--tracing")
        capture_trace = tracing_option in ["on", "retain-on-failure"]
        if capture_trace:
            context.tracing.start(
                name=slugify(request.node.nodeid),
                screenshots=True,
                snapshots=True,
            )
    
        yield context
    
        if capture_trace:
            retain_trace = tracing_option == "on" or (
                request.node.rep_call.failed and tracing_option == "retain-on-failure"
            )
            if retain_trace:
                trace_path = _build_artifact_test_folder(pytestconfig, request, "trace.zip")
                context.tracing.stop(path=trace_path)
            else:
                context.tracing.stop()
    
        screenshot_option = pytestconfig.getoption("--screenshot")
        capture_screenshot = screenshot_option == "on" or (
>           request.node.rep_call.failed and screenshot_option == "only-on-failure"
        )
E       AttributeError: 'Function' object has no attribute 'rep_call'

/usr/local/lib/python3.9/site-packages/pytest_playwright/pytest_playwright.py:223: AttributeError
=============================== warnings summary ===============================
../usr/local/lib/python3.9/site-packages/django/utils/version.py:98
  /usr/local/lib/python3.9/site-packages/django/utils/version.py:98: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    loose_version = LooseVersion(version)

../usr/local/lib/python3.9/site-packages/rest_framework_friendly_errors/settings.py:18
  /usr/local/lib/python3.9/site-packages/rest_framework_friendly_errors/settings.py:18: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
    _('Validation Failed'))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================== short test summary info ============================
ERROR mathesar/tests/integration/test_columns.py::test_add_column[chromium]
ERROR mathesar/tests/integration/test_columns.py::test_add_column[chromium]
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 2 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
=================== 1 passed, 2 warnings, 2 errors in 34.91s ===================
```
</details>

## After

I can run E2E tests



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>









