### PR TITLE
UI changes for column ids in records API

### DIFF
--- a/mathesar_ui/src/api/tables/records.ts
+++ b/mathesar_ui/src/api/tables/records.ts
@@ -1,6 +1,6 @@
 export interface Grouping {
-  /** Each string is a column name */
-  columns: string[];
+  /** Each string is a column id */
+  columns: number[];
   mode: GroupingMode;
   /**
    * When `mode` === 'distinct', `num_groups` will always be `null`.
@@ -15,15 +15,15 @@ export interface Grouping {
 
 export type SortDirection = 'asc' | 'desc';
 export interface SortingEntry {
-  /** column name */
-  field: string;
+  /** column id */
+  field: number;
   direction: SortDirection;
 }
 export type FilterCombination = 'and' | 'or';
 export type FilterOperation = 'eq' | 'ne' | 'get_duplicates';
 export interface FilterCondition {
-  /** column name */
-  field: string;
+  /** column id */
+  field: number;
   op: FilterOperation;
   value: unknown;
 }
@@ -45,7 +45,7 @@ export interface GetRequestParams {
 export type ResultValue = string | number | boolean | null;
 
 export interface Result {
-  /** keys are column names */
+  /** keys are stringified column ids */
   [k: string]: ResultValue;
 }
 

--- a/mathesar_ui/src/sections/table-view/display-options/DisplayGroup.svelte
+++ b/mathesar_ui/src/sections/table-view/display-options/DisplayGroup.svelte
@@ -10,12 +10,12 @@
   export let columns: Column[];
 
   /** Columns which are not already used as a grouping entry */
-  $: availableColumns = columns.filter((column) => !$grouping.has(column.name));
+  $: availableColumns = columns.filter((column) => !$grouping.has(column.id));
   $: [newGroupColumn] = availableColumns;
   let addNew = false;
 
   function addGroupColumn() {
-    grouping.update((g) => g.with(newGroupColumn.name));
+    grouping.update((g) => g.with(newGroupColumn.id));
     addNew = false;
   }
 </script>
@@ -31,12 +31,14 @@
   </div>
   <div class="content">
     <table>
-      {#each [...$grouping] as columnName (columnName)}
+      {#each [...$grouping] as columnId (columnId)}
         <tr>
-          <td class="groupcolumn">{columnName}</td>
+          <td class="groupcolumn">
+            {columns.find((c) => c.id === columnId)?.name}
+          </td>
           <td class="action">
             <Button
-              on:click={() => grouping.update((g) => g.without(columnName))}
+              on:click={() => grouping.update((g) => g.without(columnId))}
             >
               Clear
             </Button>

--- a/mathesar_ui/src/sections/table-view/display-options/DisplaySort.svelte
+++ b/mathesar_ui/src/sections/table-view/display-options/DisplaySort.svelte
@@ -12,13 +12,13 @@
   export let columns: Column[];
 
   /** Columns which are not already used as a sorting entry */
-  $: availableColumns = columns.filter((column) => !$sorting.has(column.name));
+  $: availableColumns = columns.filter((column) => !$sorting.has(column.id));
   $: [newSortColumn] = availableColumns;
   let newSortDirection = SortDirection.A;
   let addNew = false;
 
   function addSortColumn() {
-    sorting.update((s) => s.with(newSortColumn.name, newSortDirection));
+    sorting.update((s) => s.with(newSortColumn.id, newSortDirection));
     addNew = false;
   }
 </script>
@@ -34,21 +34,19 @@
   </div>
   <div class="content">
     <table>
-      {#each [...$sorting] as [columnName, sortDirection] (columnName)}
+      {#each [...$sorting] as [columnId, sortDirection] (columnId)}
         <tr>
-          <td class="column">{columnName}</td>
+          <td class="column">{columns.find((c) => c.id === columnId)?.name}</td>
           <td class="dir">
             <SelectSortDirection
               value={sortDirection}
               onChange={(direction) => {
-                sorting.update((s) => s.with(columnName, direction));
+                sorting.update((s) => s.with(columnId, direction));
               }}
             />
           </td>
           <td class="action">
-            <Button
-              on:click={() => sorting.update((s) => s.without(columnName))}
-            >
+            <Button on:click={() => sorting.update((s) => s.without(columnId))}>
               Clear
             </Button>
           </td>

--- a/mathesar_ui/src/sections/table-view/header/Header.svelte
+++ b/mathesar_ui/src/sections/table-view/header/Header.svelte
@@ -33,9 +33,9 @@
 
   function getColumnPosition(
     _columnPositionMap: ColumnPositionMap,
-    _name: Column['name'],
+    _id: Column['id'],
   ): ColumnPosition | undefined {
-    return _columnPositionMap.get(_name);
+    return _columnPositionMap.get(_id);
   }
 
   onMount(() => {
@@ -61,13 +61,13 @@
 <div bind:this={headerRef} class="header">
   <div class="cell row-control" style="width:{ROW_CONTROL_COLUMN_WIDTH}px;" />
 
-  {#each $columnsDataStore.columns as column (column.name)}
+  {#each $columnsDataStore.columns as column (column.id)}
     <HeaderCell
       {column}
       {meta}
       {columnsDataStore}
       {constraintsDataStore}
-      columnPosition={getColumnPosition($columnPositionMap, column.name)}
+      columnPosition={getColumnPosition($columnPositionMap, column.id)}
     />
   {/each}
 

--- a/mathesar_ui/src/sections/table-view/header/header-cell/DefaultOptions.svelte
+++ b/mathesar_ui/src/sections/table-view/header/header-cell/DefaultOptions.svelte
@@ -30,8 +30,8 @@
   let isRequestingToggleAllowDuplicates = false;
 
   $: ({ sorting, grouping } = meta);
-  $: sortDirection = $sorting.get(column.name);
-  $: hasGrouping = $grouping.has(column.name);
+  $: sortDirection = $sorting.get(column.id);
+  $: hasGrouping = $grouping.has(column.id);
 
   $: allowsNull = column.nullable;
   $: ({ uniqueColumns } = constraintsDataStore);
@@ -39,18 +39,18 @@
 
   function handleSort(order: SortDirection) {
     if (sortDirection === order) {
-      sorting.update((s) => s.without(column.name));
+      sorting.update((s) => s.without(column.id));
     } else {
-      sorting.update((s) => s.with(column.name, order));
+      sorting.update((s) => s.with(column.id, order));
     }
     dispatch('close');
   }
 
   function toggleGroup() {
     if (hasGrouping) {
-      grouping.update((g) => g.without(column.name));
+      grouping.update((g) => g.without(column.id));
     } else {
-      grouping.update((g) => g.with(column.name));
+      grouping.update((g) => g.with(column.id));
     }
     dispatch('close');
   }

--- a/mathesar_ui/src/sections/table-view/row/GroupHeader.svelte
+++ b/mathesar_ui/src/sections/table-view/row/GroupHeader.svelte
@@ -9,10 +9,10 @@
   export let group: Group;
   export let rowWidth: number;
 
-  $: ({ columns } = grouping);
+  $: ({ columnIds } = grouping);
 
-  $: cellValue = (column: string) =>
-    row.__groupValues ? row.__groupValues[column] : undefined;
+  $: cellValue = (columnId: number) =>
+    row.__groupValues ? row.__groupValues[columnId] : undefined;
 </script>
 
 <div
@@ -25,8 +25,10 @@
   style="left:{ROW_CONTROL_COLUMN_WIDTH}px;width:{rowWidth -
     ROW_CONTROL_COLUMN_WIDTH}px"
 >
-  {#each columns as column (column)}
-    <span class="tag">{column}: <CellValue value={cellValue(column)} /></span>
+  {#each columnIds as columnId (columnId)}
+    <span class="tag"
+      >{columnId}: <CellValue value={cellValue(columnId)} /></span
+    >
   {/each}
   <span class="tag count"><span class="label">count:</span> {group.count}</span>
 </div>

--- a/mathesar_ui/src/sections/table-view/row/Row.svelte
+++ b/mathesar_ui/src/sections/table-view/row/Row.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { getContext } from 'svelte';
-  import { getModificationState } from '@mathesar/stores/table-data';
+  import {
+    getModificationState,
+    ROW_POSITION_INDEX,
+  } from '@mathesar/stores/table-data';
   import type {
     ColumnPosition,
     ColumnPositionMap,
@@ -30,7 +33,7 @@
     if (!_style) {
       return '';
     }
-    const totalWidth = _columnPositionMap.get('__row')?.width || 0;
+    const totalWidth = _columnPositionMap.get(ROW_POSITION_INDEX)?.width || 0;
     return (
       `position:${_style.position};left:${_style.left}px;` +
       `top:${_style.top}px;height:${_style.height}px;` +
@@ -42,19 +45,21 @@
 
   function getColumnPosition(
     _columnPositionMap: ColumnPositionMap,
-    _name: Column['name'],
+    _id: Column['id'],
   ): ColumnPosition | undefined {
-    return _columnPositionMap.get(_name);
+    return _columnPositionMap.get(_id);
   }
 
-  $: ({ primaryKey } = $columnsDataStore);
-  $: isSelected = primaryKey && $selectedRecords.has(row[primaryKey]);
+  $: ({ primaryKeyColumnId } = $columnsDataStore);
+  $: isSelected =
+    primaryKeyColumnId && $selectedRecords.has(row[primaryKeyColumnId]);
   $: modificationState = getModificationState(
     $recordModificationState,
     row,
-    primaryKey,
+    primaryKeyColumnId,
   );
-  $: rowWidth = getColumnPosition($columnPositionMap, '__row')?.width || 0;
+  $: rowWidth =
+    getColumnPosition($columnPositionMap, ROW_POSITION_INDEX)?.width || 0;
 
   function checkAndCreateEmptyRow() {
     if (row.__isAddPlaceholder) {
@@ -77,16 +82,16 @@
   {:else if row.__isGroupHeader && $grouping && row.__group}
     <GroupHeader {row} {rowWidth} grouping={$grouping} group={row.__group} />
   {:else}
-    <RowControl primaryKeyColumn={primaryKey} {row} {meta} {recordsData} />
+    <RowControl {primaryKeyColumnId} {row} {meta} {recordsData} />
 
-    {#each $columnsDataStore.columns as column (column.name)}
+    {#each $columnsDataStore.columns as column (column.id)}
       <RowCell
         {display}
         {row}
-        bind:value={row[column.name]}
+        bind:value={row[column.id]}
         {column}
         {recordsData}
-        columnPosition={getColumnPosition($columnPositionMap, column.name)}
+        columnPosition={getColumnPosition($columnPositionMap, column.id)}
       />
     {/each}
   {/if}

--- a/mathesar_ui/src/sections/table-view/row/RowControl.svelte
+++ b/mathesar_ui/src/sections/table-view/row/RowControl.svelte
@@ -11,7 +11,7 @@
     TableRecord,
   } from '@mathesar/stores/table-data/types';
 
-  export let primaryKeyColumn: string | undefined = undefined;
+  export let primaryKeyColumnId: number | undefined = undefined;
   export let row: TableRecord;
   export let meta: Meta;
   export let recordsData: RecordsData;
@@ -19,12 +19,12 @@
   $: ({ selectedRecords, recordModificationState, pagination } = meta);
   $: ({ savedRecords, newRecords, totalCount } = recordsData);
 
-  $: primaryKeyValue = primaryKeyColumn ? row[primaryKeyColumn] : undefined;
+  $: primaryKeyValue = primaryKeyColumnId ? row[primaryKeyColumnId] : undefined;
   $: isRowSelected = ($selectedRecords as Set<unknown>).has(primaryKeyValue);
   $: genericModificationStatus = getGenericModificationStatus(
     $recordModificationState,
     row,
-    primaryKeyColumn,
+    primaryKeyColumnId,
   );
 
   function selectionChanged(event: CustomEvent<{ checked: boolean }>) {

--- a/mathesar_ui/src/stores/table-data/columns.ts
+++ b/mathesar_ui/src/stores/table-data/columns.ts
@@ -31,7 +31,7 @@ export interface ColumnsData {
   state: States;
   error?: string;
   columns: Column[];
-  primaryKey?: string;
+  primaryKeyColumnId?: number;
 }
 
 function preprocessColumns(response?: Column[]): Column[] {
@@ -144,7 +144,7 @@ export class ColumnsDataStore
       const storeData: ColumnsData = {
         state: States.Done,
         columns: columnResponse,
-        primaryKey: pkColumn?.name,
+        primaryKeyColumnId: pkColumn?.id,
       };
       this.set(storeData);
       this.fetchCallback?.(storeData);
@@ -154,7 +154,7 @@ export class ColumnsDataStore
         state: States.Error,
         error: err instanceof Error ? err.message : undefined,
         columns: [],
-        primaryKey: undefined,
+        primaryKeyColumnId: undefined,
       });
     } finally {
       this.promise = undefined;

--- a/mathesar_ui/src/stores/table-data/display.ts
+++ b/mathesar_ui/src/stores/table-data/display.ts
@@ -32,12 +32,21 @@ const movementKeys = new Set([
 ]);
 
 /**
- * I don't understand what this is but I had to create it during a refactor.
- * This value is used as a key in a ColumnPositionMap where column ids are also
- * used, so should have the same type as a column id but needs to have a value
- * that no column id will ever have. That's why we're using -1. If you
- * understand this design and can suggest a better name for this variable, then
- * please do so.
+ * This value is used as a key in a `ColumnPositionMap` where each entry
+ * corresponds to the position of the column, as indexed by the column id.
+ * However, the entry indexed by `ROW_POSITION_INDEX` consists of the total
+ * width & left values (i.e the position) of the row. It's placed within
+ * `ColumnPositionMap` in order to avoid calculation within the component, which
+ * will run for each row. Thus, `ROW_POSITION_INDEX` should have the same type
+ * as a column id but needs to have a value that no column id will ever have.
+ * That's why we're using -1.
+ *
+ * We could use a dedicated store for it or even a new class containing both
+ * columnPosition and row width.
+ *
+ * Pavish put it within ColumnPositionMap because we were passing around a lot
+ * of props to the child components and he wanted to reduce the number of props.
+ * Now, it is all passed down using context, so that's no longer an issue.
  */
 export const ROW_POSITION_INDEX = -1;
 

--- a/mathesar_ui/src/stores/table-data/filtering.ts
+++ b/mathesar_ui/src/stores/table-data/filtering.ts
@@ -20,24 +20,24 @@ export const filterConditions: FilterCondition[] = [
 export const defaultFilterCondition = filterConditions[0];
 
 export interface FilterEntry {
-  readonly columnName: string;
+  readonly columnId: number;
   readonly condition: FilterCondition;
   readonly value: string;
 }
 
 function makeApiFilterCondition(filterEntry: FilterEntry): ApiFilterCondition {
   return {
-    field: filterEntry.columnName,
+    field: filterEntry.columnId,
     op: filterEntry.condition.id,
     value: filterEntry.value,
   };
 }
 
-/** [ columnName, operation, value ] */
-type TerseFilterEntry = [string, FilterOperation, string];
+/** [ columnId, operation, value ] */
+type TerseFilterEntry = [number, FilterOperation, string];
 
 function makeTerseFilterEntry(filterEntry: FilterEntry): TerseFilterEntry {
-  return [filterEntry.columnName, filterEntry.condition.id, filterEntry.value];
+  return [filterEntry.columnId, filterEntry.condition.id, filterEntry.value];
 }
 
 function makeFilterEntry(terseFilterEntry: TerseFilterEntry): FilterEntry {
@@ -48,7 +48,7 @@ function makeFilterEntry(terseFilterEntry: TerseFilterEntry): FilterEntry {
     condition = defaultFilterCondition;
   }
   return {
-    columnName: terseFilterEntry[0],
+    columnId: terseFilterEntry[0],
     condition,
     value: terseFilterEntry[2],
   };

--- a/mathesar_ui/src/stores/table-data/grouping.ts
+++ b/mathesar_ui/src/stores/table-data/grouping.ts
@@ -1,11 +1,11 @@
 import type { GetRequestParams } from '@mathesar/api/tables/records';
 import { ImmutableSet } from '@mathesar/component-library';
 
-/** Each value is a column name */
-export type TerseGrouping = string[];
+/** Each value is a column id */
+export type TerseGrouping = number[];
 
-/** Each value is a column name. */
-export class Grouping extends ImmutableSet<string> {
+/** Each value is a column id. */
+export class Grouping extends ImmutableSet<number> {
   recordsRequestParams(): Pick<GetRequestParams, 'grouping'> {
     if (!this.size) {
       return {};

--- a/mathesar_ui/src/stores/table-data/index.ts
+++ b/mathesar_ui/src/stores/table-data/index.ts
@@ -7,6 +7,7 @@ export {
   scrollBasedOnActiveCell,
   ROW_CONTROL_COLUMN_WIDTH,
   DEFAULT_ROW_RIGHT_PADDING,
+  ROW_POSITION_INDEX,
 } from './display';
 export {
   filterCombinations,

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -55,7 +55,7 @@ export interface Group {
 }
 
 export interface Grouping {
-  columns: string[];
+  columnIds: number[];
   mode: GroupingMode;
   groups: Group[];
 }
@@ -71,7 +71,7 @@ function buildGroup(apiGroup: ApiGroup): Group {
 
 function buildGrouping(apiGrouping: ApiGrouping): Grouping {
   return {
-    columns: apiGrouping.columns,
+    columnIds: apiGrouping.columns,
     mode: apiGrouping.mode,
     groups: apiGrouping.groups.map(buildGroup),
   };
@@ -102,10 +102,10 @@ export interface TableRecordsData {
 
 export function getRowKey(
   row: TableRecord,
-  primaryKeyColumn?: Column['name'],
+  primaryKeyColumnId?: Column['id'],
 ): unknown {
   // @ts-ignore: https://github.com/centerofci/mathesar/issues/1055
-  let key: unknown = row?.[primaryKeyColumn];
+  let key: unknown = row?.[primaryKeyColumnId];
   if (!key && row?.__isNew) {
     key = row?.__identifier;
   }
@@ -135,8 +135,8 @@ function preprocessRecords(
   records?: TableRecordInResponse[],
   grouping?: Grouping,
 ): TableRecord[] {
-  const groupingColumnNames = grouping?.columns ?? [];
-  const isResultGrouped = groupingColumnNames.length > 0;
+  const groupingColumnIds = grouping?.columnIds ?? [];
+  const isResultGrouped = groupingColumnIds.length > 0;
   const combinedRecords: TableRecord[] = [];
   let index = 0;
   let groupIndex = 0;
@@ -154,8 +154,8 @@ function preprocessRecords(
           isGroup = true;
         } else {
           // eslint-disable-next-line no-restricted-syntax
-          for (const column of groupingColumnNames) {
-            if (records[index - 1][column] !== records[index][column]) {
+          for (const id of groupingColumnIds) {
+            if (records[index - 1][id] !== records[index][id]) {
               isGroup = true;
               break;
             }
@@ -373,7 +373,10 @@ export class RecordsData {
           let retained = existing.filter(
             (entry) =>
               !successSet.has(
-                getRowKey(entry, this.columnsDataStore.get()?.primaryKey),
+                getRowKey(
+                  entry,
+                  this.columnsDataStore.get()?.primaryKeyColumnId,
+                ),
               ),
           );
           if (retained.length === existing.length) {
@@ -403,63 +406,91 @@ export class RecordsData {
     }
   }
 
-  // TODO: Handle states where cell update and row update happen in parallel
+  /**
+   * TODO:
+   * - Handle states where cell update and row update happen in parallel
+   * - Reduce code duplication between `updateCell` and `updateRecord`
+   */
   async updateCell(row: TableRecord, column: Column): Promise<void> {
-    const { primaryKey } = this.columnsDataStore.get();
-    if (primaryKey && row[primaryKey]) {
-      const rowKey = getRowKey(row, primaryKey);
-      // @ts-ignore: https://github.com/centerofci/mathesar/issues/1055
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-      const rowKeyString: string = rowKey.toString();
-      const cellKey = `${rowKeyString}::${column.name}`;
-      this.meta.setCellUpdateState(rowKey, cellKey, 'update');
-      this.updatePromises?.get(cellKey)?.cancel();
-      const promise = patchAPI<unknown>(
-        `${this.url}${row[primaryKey] as string}/`,
-        { [column.name]: row[column.name] },
+    const { primaryKeyColumnId } = this.columnsDataStore.get();
+    if (!primaryKeyColumnId) {
+      // eslint-disable-next-line no-console
+      console.error('Unable to update record for a row without a primary key');
+      return;
+    }
+    const primaryKeyValue = row[primaryKeyColumnId];
+    if (primaryKeyValue === undefined) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Unable to update record for a row with a missing primary key value',
       );
-      if (!this.updatePromises) {
-        this.updatePromises = new Map();
-      }
-      this.updatePromises.set(cellKey, promise);
+      return;
+    }
+    const rowKey = getRowKey(row, primaryKeyColumnId);
+    const rowKeyString = String(rowKey);
+    const cellKey = `${rowKeyString}::${column.id}`;
+    this.meta.setCellUpdateState(rowKey, cellKey, 'update');
+    this.updatePromises?.get(cellKey)?.cancel();
+    const promise = patchAPI<unknown>(
+      `${this.url}${String(row[primaryKeyColumnId])}/`,
+      { [column.id]: row[column.id] },
+    );
+    if (!this.updatePromises) {
+      this.updatePromises = new Map();
+    }
+    this.updatePromises.set(cellKey, promise);
 
-      try {
-        await promise;
-        this.meta.setCellUpdateState(rowKey, cellKey, 'updated');
-      } catch (err) {
-        this.meta.setCellUpdateState(rowKey, cellKey, 'updateFailed');
-      } finally {
-        if (this.updatePromises.get(cellKey) === promise) {
-          this.updatePromises.delete(cellKey);
-        }
+    try {
+      await promise;
+      this.meta.setCellUpdateState(rowKey, cellKey, 'updated');
+    } catch (err) {
+      this.meta.setCellUpdateState(rowKey, cellKey, 'updateFailed');
+    } finally {
+      if (this.updatePromises.get(cellKey) === promise) {
+        this.updatePromises.delete(cellKey);
       }
     }
   }
 
+  /**
+   * TODO:
+   * - Reduce code duplication between `updateCell` and `updateRecord`
+   */
   async updateRecord(row: TableRecord): Promise<void> {
-    const { primaryKey } = this.columnsDataStore.get();
-    if (primaryKey && row[primaryKey]) {
-      const rowKey = getRowKey(row, primaryKey);
-      this.meta.setRecordModificationState(rowKey, 'update');
-      this.updatePromises?.get(rowKey)?.cancel();
-      const promise = patchAPI<unknown>(
-        `${this.url}${row[primaryKey] as string}/`,
-        prepareRowForRequest(row),
+    const { primaryKeyColumnId } = this.columnsDataStore.get();
+    if (!primaryKeyColumnId) {
+      // eslint-disable-next-line no-console
+      console.error('Unable to update record for a row without a primary key');
+      return;
+    }
+    const primaryKeyValue = row[primaryKeyColumnId];
+    if (primaryKeyValue === undefined) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Unable to update record for a row with a missing primary key value',
       );
-      if (!this.updatePromises) {
-        this.updatePromises = new Map();
-      }
-      this.updatePromises.set(rowKey, promise);
+      return;
+    }
+    const rowKey = getRowKey(row, primaryKeyColumnId);
+    this.meta.setRecordModificationState(rowKey, 'update');
+    this.updatePromises?.get(rowKey)?.cancel();
+    const promise = patchAPI<unknown>(
+      `${this.url}${row[primaryKeyColumnId] as string}/`,
+      prepareRowForRequest(row),
+    );
+    if (!this.updatePromises) {
+      this.updatePromises = new Map();
+    }
+    this.updatePromises.set(rowKey, promise);
 
-      try {
-        await promise;
-        this.meta.setRecordModificationState(rowKey, 'updated');
-      } catch (err) {
-        this.meta.setRecordModificationState(rowKey, 'updateFailed');
-      } finally {
-        if (this.updatePromises.get(rowKey) === promise) {
-          this.updatePromises.delete(rowKey);
-        }
+    try {
+      await promise;
+      this.meta.setRecordModificationState(rowKey, 'updated');
+    } catch (err) {
+      this.meta.setRecordModificationState(rowKey, 'updateFailed');
+    } finally {
+      if (this.updatePromises.get(rowKey) === promise) {
+        this.updatePromises.delete(rowKey);
       }
     }
   }
@@ -484,7 +515,7 @@ export class RecordsData {
   }
 
   async createRecord(row: TableRecord): Promise<void> {
-    const { primaryKey } = this.columnsDataStore.get();
+    const { primaryKeyColumnId: primaryKey } = this.columnsDataStore.get();
     const rowKey = getRowKey(row, primaryKey);
     this.meta.setRecordModificationState(rowKey, 'create');
     this.createPromises?.get(rowKey)?.cancel();
@@ -523,7 +554,7 @@ export class RecordsData {
   }
 
   async createOrUpdateRecord(row: TableRecord, column?: Column): Promise<void> {
-    const { primaryKey } = this.columnsDataStore.get();
+    const { primaryKeyColumnId: primaryKey } = this.columnsDataStore.get();
 
     // Row may not have been updated yet in view when additional request is made.
     // So check current values to ensure another row has not been created.

--- a/mathesar_ui/src/stores/table-data/sorting.ts
+++ b/mathesar_ui/src/stores/table-data/sorting.ts
@@ -38,12 +38,12 @@ export function getDirectionLabel(direction: SortDirection): string {
 }
 
 /**
- * [columnName, sortDirection]
+ * [columnId, sortDirection]
  */
-export type TerseSorting = [string, SortDirection][];
+export type TerseSorting = [number, SortDirection][];
 
-export class Sorting extends ImmutableMap<string, SortDirection> {
-  constructor(entries: Iterable<[string, SortDirection]> = []) {
+export class Sorting extends ImmutableMap<number, SortDirection> {
+  constructor(entries: Iterable<[number, SortDirection]> = []) {
     [...entries].forEach(([, sortDirection]) => {
       // Even though TS will catch build-time errors with SortDirection, we also
       // want runtime validation because new sorting entries are created from
@@ -57,8 +57,8 @@ export class Sorting extends ImmutableMap<string, SortDirection> {
 
   private recordsRequestParams(): Pick<GetRequestParams, 'order_by'> {
     const sortingEntries: ApiSortingEntry[] = [...this].map(
-      ([columnName, sortDirection]) => ({
-        field: columnName,
+      ([columnId, sortDirection]) => ({
+        field: columnId,
         direction: getApiSortDirection(sortDirection),
       }),
     );
@@ -83,15 +83,15 @@ export class Sorting extends ImmutableMap<string, SortDirection> {
   }
 
   terse(): TerseSorting {
-    return [...this].map(([columnName, sortDirection]) => [
-      columnName,
+    return [...this].map(([columnId, sortDirection]) => [
+      columnId,
       sortDirection,
     ]);
   }
 
   static fromTerse(t: TerseSorting): Sorting {
     return new Sorting(
-      t.map(([columnName, sortDirection]) => [columnName, sortDirection]),
+      t.map(([columnId, sortDirection]) => [columnId, sortDirection]),
     );
   }
 }

--- a/mathesar_ui/src/stores/table-data/utils.ts
+++ b/mathesar_ui/src/stores/table-data/utils.ts
@@ -14,7 +14,7 @@ import type { TableRecord } from './records';
 export function getGenericModificationStatus(
   recordModificationState: ModificationStateMap,
   row: TableRecord,
-  primaryKeyColumn?: Column['name'],
+  primaryKeyColumn?: Column['id'],
 ): ModificationStatus {
   const key = getRowKey(row, primaryKeyColumn);
   return getGenericModificationStatusByPK(recordModificationState, key);
@@ -23,7 +23,7 @@ export function getGenericModificationStatus(
 export function getModificationState(
   recordModificationState: ModificationStateMap,
   row: TableRecord,
-  primaryKeyColumn?: Column['name'],
+  primaryKeyColumn?: Column['id'],
 ): ModificationType | undefined {
   const key = getRowKey(row, primaryKeyColumn);
   return recordModificationState.get(key)?.get(RECORD_COMBINED_STATE_KEY);

--- a/mathesar_ui/src/stores/tabs/__tests__/tabDataSaver.test.ts
+++ b/mathesar_ui/src/stores/tabs/__tests__/tabDataSaver.test.ts
@@ -35,16 +35,16 @@ test('round trip serialization, complex case', () => {
             combination: { id: 'and', label: 'and' },
             entries: [
               {
-                columnName: 'Foo',
+                columnId: 99,
                 condition: { id: 'eq', label: 'equals' },
                 value: 'This is a column value',
               },
             ],
           }),
-          grouping: new Grouping(['Column 1', 'Column 2']),
+          grouping: new Grouping([127, 91]),
           sorting: new Sorting([
-            ['My Column name', SortDirection.A],
-            ['Your column name', SortDirection.D],
+            [876, SortDirection.A],
+            [108, SortDirection.D],
           ]),
           pagination: new Pagination({ page: 2, size: 100 }),
         },


### PR DESCRIPTION
These are the front end changes for #1047.

I put them in a separate PR to aid review. I figure we can merge this first (into `#1047`), then merge `#1047`.

## Issues

- Grouping is broken because the response from the records API is still using column names within the `grouping` properties.

    Here's the GET response with grouping.

    ```json5
    {
      count: 10,
      grouping: {
        columns: ["country"], // <-- column name here
        mode: "distinct",
        num_groups: null,
        ranged: false,
        groups: [
          {
            count: 1,
            first_value: { country: "Bhutan" }, // <-- column name here
            last_value: { country: "Bhutan" }, // <-- column name here
            result_indices: [0],
          },
          // ...
        ],
      },
      results: [
        //...
      ],
    }
    ```

    I'm not sure how we want to handle this. I _thought_ I tested this when I reviewed `#1047` initially, but it may have slipped through the cracks. Or it may be a regression from changes pushed to that PR more recently. @silentninja any thoughts?

    I'd lean towards getting all of this work merged into `master` (thereby breaking the grouping feature temporarily) and fixing it with subsequent issues/PRs. My understanding is that some of the grouping API stuff is about to change anyway.

    We don't have any E2E tests for grouping yet which is why you don't see test failures.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

