### PR TITLE
Add E2E test for trying to to rename a table to the name of another table

### DIFF
--- a/mathesar/tests/integration/test_tables.py
+++ b/mathesar/tests/integration/test_tables.py
@@ -9,3 +9,18 @@ def test_create_empty_table(page, base_schema_url):
     page.click("[aria-label='New Table']")
     page.click("button:has-text('Empty Table')")
     expect(get_table_entry(page, "Table 0")).to_be_visible()
+
+def test_rename_table_of_another_table(page, base_schema_url):
+    page.goto(base_schema_url)
+    expect(get_tables_list(page)).to_be_empty()
+    page.click("[aria-label='New Table']")
+    page.click("button:has-text('Empty Table')")
+    expect(get_table_entry(page, "Table 0")).to_be_visible()
+    page.click("[aria-label='New Table']")
+    page.click("button:has-text('Empty Table')")
+    expect(get_table_entry(page, "Table 1")).to_be_visible()
+    page.click("[aria-label='Table']")
+    page.click("text=Rename")
+    page.press("[aria-label='name']", "ArrowRight")
+    page.fill("[aria-label='name']", "Table 0")
+    page.locator("text=A table with that name already exists.")

--- a/mathesar/tests/integration/test_tables.py
+++ b/mathesar/tests/integration/test_tables.py
@@ -10,6 +10,7 @@ def test_create_empty_table(page, base_schema_url):
     page.click("button:has-text('Empty Table')")
     expect(get_table_entry(page, "Table 0")).to_be_visible()
 
+
 def test_rename_table_of_another_table(page, base_schema_url):
     page.goto(base_schema_url)
     expect(get_tables_list(page)).to_be_empty()

--- a/mathesar/tests/integration/test_tables.py
+++ b/mathesar/tests/integration/test_tables.py
@@ -24,4 +24,5 @@ def test_rename_table_of_another_table(page, base_schema_url):
     page.click("text=Rename")
     page.press("[aria-label='name']", "ArrowRight")
     page.fill("[aria-label='name']", "Table 0")
-    page.locator("text=A table with that name already exists.")
+    expect(page.locator("text=A table with that name already exists.")).to_be_visible()
+    expect(page.locator("button:has-text('Save')")).to_be_disabled()


### PR DESCRIPTION
Fixes #1125 

Added e2e tests for renaming a table name with the existing table names.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
