### PR TITLE
Added integration tests for changing column type from text to number

### DIFF
--- a/mathesar/tests/integration/test_columns.py
+++ b/mathesar/tests/integration/test_columns.py
@@ -11,9 +11,9 @@ def test_add_column(page, go_to_patents_data_table):
 
 
 def test_convert_text_column_to_number(page, go_to_patents_data_table):
-    page.click("button:has-text('T Center')")
-    page.click("button:has-text('Text')")
-    page.click("text=# Number")
+    page.click(".table-content .header .cell:has-text('Center')")
+    page.click(".dropdown button:has-text('Text')")
+    page.click(".type-list button:has-text('Number')")
     page.click("button:has-text('Save')")
     error_message = "Unable to change column"
     toast_box = f".toast-presenter .toast-item .message:has-text('{error_message}')"

--- a/mathesar/tests/integration/test_columns.py
+++ b/mathesar/tests/integration/test_columns.py
@@ -8,3 +8,13 @@ def test_add_column(page, go_to_patents_data_table):
     page.click("button:has-text('Add')")
     column_header = f".table-content .header .cell .name:has-text('{column_name}')"
     expect(page.locator(column_header)).to_be_visible()
+
+
+def test_convert_text_column_to_number(page, go_to_patents_data_table):
+    page.click("button:has-text('T Center')")
+    page.click("button:has-text('Text')")
+    page.click("text=# Number")
+    page.click("button:has-text('Save')")
+    error_message = "Unable to change column"
+    toast_box = f".toast-presenter .toast-item .message:has-text('{error_message}')"
+    expect(page.locator(toast_box)).to_be_visible()


### PR DESCRIPTION
Fixes #1129

**Technical details**
Added integration tests for trying to convert a text column of words to number column.

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
