### PR TITLE
Added e2e test for converting a text column of numbers to number column fixes #1128

### DIFF
--- a/mathesar/tests/integration/test_columns.py
+++ b/mathesar/tests/integration/test_columns.py
@@ -8,3 +8,26 @@ def test_add_column(page, go_to_patents_data_table):
     page.click("button:has-text('Add')")
     column_header = f".table-content .header .cell .name:has-text('{column_name}')"
     expect(page.locator(column_header)).to_be_visible()
+
+
+def test_convert_text_col_of_num_to_num_col(page, patent_schema, base_schema_url):
+    page.goto(base_schema_url)
+    page.click("[aria-label='New Table']")
+    page.click("button:has-text('Empty Table')")
+    page.click("[aria-label='New Column']")
+    page.fill(".new-column-dropdown input", 'foo')
+    page.click("button:has-text('Add')")
+    page.click(".sheet-cell .cell-wrapper.multi-line-truncate")
+    page.dblclick(".cell-wrapper.multi-line-truncate")
+    page.fill("textarea", '123')
+    page.click(".row.done.is-add-placeholder .cell.editable-cell .sheet-cell .cell-wrapper")
+    page.dblclick("text=NULL")
+    page.fill("textarea", '876')
+    all_changes_saved = page.locator("text=All changes saved")
+    expect(all_changes_saved).to_be_visible()
+    page.click("button:has-text('T foo')")
+    page.click("button:has-text('Text')")
+    page.click("text=# Number")
+    page.click("button:has-text('Save')")
+    page.click("button:has-text('# foo')")
+    page.locator(".dropdown .container .section .btn:has-text('Number')")


### PR DESCRIPTION
Fixes #1128 

Added an e2e test for converting a text column of numbers to number column.

**Technical details**


**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
