### PR TITLE
Add E2E test for converting a boolean column to text column fixes #1127

### DIFF
--- a/mathesar/tests/integration/test_columns.py
+++ b/mathesar/tests/integration/test_columns.py
@@ -8,3 +8,17 @@ def test_add_column(page, go_to_patents_data_table):
     page.click("button:has-text('Add')")
     column_header = f".table-content .header .cell .name:has-text('{column_name}')"
     expect(page.locator(column_header)).to_be_visible()
+
+def test_convert_boolean_col_to_text_col(page, base_schema_url):
+    page.goto(base_schema_url)
+    page.click("[aria-label='New Table']")
+    page.click("button:has-text('Import Data')")
+    page.click("text=Copy and Paste Text")
+    page.fill("textarea", "foo,bar\ntrue,false")
+    page.click("button:has-text('Continue')")
+    page.click("button:has-text('Finish Import')")
+    page.click("button:has-text('foo')")
+    page.click("button:has-text('Boolean')")
+    page.click("text=T Text")
+    page.click("button:has-text('Save')")
+    page.locator(".dropdown .container .section .btn:has-text('Text')")


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1127 

<!-- Concisely describe what the pull request does. -->
Added e2e test to convert boolean column to text column.
**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
