### PR TITLE
Add db type alias information to db types endpoint

### DIFF
--- a/db/types/aliases.py
+++ b/db/types/aliases.py
@@ -1,0 +1,34 @@
+from frozendict import frozendict
+
+
+# Copied (and reordered) from table in
+# https://www.postgresql.org/docs/11/datatype.html
+canonical_to_aliases = frozendict(
+    {
+        'boolean': ['bool'],
+        'bit varying': ['varbit'],
+        'smallint': ['int2'],
+        'integer': ['int', 'int4'],
+        'bigint': ['int8'],
+        'smallserial': ['serial2'],
+        'serial': ['serial4'],
+        'bigserial': ['serial8'],
+        'real': ['float4'],
+        'double precision': ['float8'],
+        'numeric': ['decimal'],
+        'character': ['char'],
+        'character varying': ['varchar'],
+        'time with timezone': ['timetz'],
+        'timestamp with timezone': ['timestamptz'],
+    }
+)
+
+alias_to_canonical = frozendict(
+    {
+        alias: canonical
+        for canonical, aliases
+        in canonical_to_aliases.items()
+        for alias
+        in aliases
+    }
+)

--- a/db/types/base.py
+++ b/db/types/base.py
@@ -3,7 +3,7 @@ from enum import Enum
 from sqlalchemy import create_engine
 
 from db import constants
-
+from db.types.aliases import canonical_to_aliases, alias_to_canonical
 from db.functions import hints
 
 from frozendict import frozendict
@@ -14,7 +14,21 @@ STRING = 'string'
 VARCHAR = 'varchar'
 
 
-class PostgresType(Enum):
+class DatabaseType:
+    @property
+    def is_canonical(self):
+        return self.value not in aliases
+
+    @property
+    def aliases(self):
+        return canonical_to_aliases.get(self.value, [])
+
+    @property
+    def alias_of(self):
+        return alias_to_canonical.get(self.value)
+
+
+class PostgresType(DatabaseType, Enum):
     """
     This only includes built-in Postgres types that SQLAlchemy supports.
     SQLAlchemy doesn't support XML. See zzzeek's comment on:
@@ -66,7 +80,7 @@ class PostgresType(Enum):
     UUID = 'uuid'
 
 
-class MathesarCustomType(Enum):
+class MathesarCustomType(DatabaseType, Enum):
     """
     This is a list of custom Mathesar DB types.
     Keys returned by get_available_types are of the format 'mathesar_types.VALUE'

--- a/db/types/base.py
+++ b/db/types/base.py
@@ -17,7 +17,7 @@ VARCHAR = 'varchar'
 class DatabaseType:
     @property
     def is_canonical(self):
-        return self.value not in aliases
+        return self.value in canonical_to_aliases
 
     @property
     def aliases(self):

--- a/mathesar/api/serializers/db_types.py
+++ b/mathesar/api/serializers/db_types.py
@@ -8,7 +8,14 @@ class DBTypeSerializer(serializers.Serializer):
     hints = serializers.ListField(child=serializers.DictField())
 
     def to_representation(self, db_type):
+        # TODO solve db type casing holistically
+        # https://github.com/centerofci/mathesar/issues/1036
+        uppercase_id = db_type.value.upper()
+        uppercased_aliases = [db_type_id.upper() for db_type_id in db_type.aliases]
+        uppercased_alias_of = db_type.alias_of.upper() if db_type.alias_of else None
         return {
-            "id": db_type.value,
+            "id": uppercase_id,
+            "aliases": uppercased_aliases,
+            "alias_of": uppercased_alias_of,
             "hints": db_types_hinted.get(db_type, None),
         }


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1037 

This adds database type alias information to the `/api/db/v0/databases/1/types/` endpoint.

**Technical details**

Alias information copied from table in https://www.postgresql.org/docs/11/datatype.html.

Adds two new fields to objects in the `types/` endpoint output: `aliases` (contains aliases for this type, if this type is canonical and has known aliases) and `alias_of` (contains the canonical alias for this type, if this type is known to be a non-canonical alias).

So, for example, if `alias_for` is `null`, according to the information in PG's documentation, it's a canonical.

Mentioned endpoint's output after changes:

```json
[
  {
    "id": "_ARRAY",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "BIGINT",
    "aliases": [
      "INT8"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "BIT VARYING",
    "aliases": [
      "VARBIT"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "BIT",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "BOOLEAN",
    "aliases": [
      "BOOL"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "boolean"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "BYTEA",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "\"CHAR\"",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "string_like"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "CHARACTER VARYING",
    "aliases": [
      "VARCHAR"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "string_like"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "CHARACTER",
    "aliases": [
      "CHAR"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "string_like"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "CIDR",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "DATE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "point_in_time"
      },
      {
        "id": "date"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "DATERANGE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "DECIMAL",
    "aliases": [],
    "alias_of": "NUMERIC",
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "DOUBLE PRECISION",
    "aliases": [
      "FLOAT8"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "FLOAT",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "HSTORE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "INET",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "INT4RANGE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "INT8RANGE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "INTEGER",
    "aliases": [
      "INT",
      "INT4"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "INTERVAL",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "duration"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "JSON",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "JSONB",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "MACADDR",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "MONEY",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "NAME",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "string_like"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "NUMERIC",
    "aliases": [
      "DECIMAL"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "NUMRANGE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "OID",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "REAL",
    "aliases": [
      "FLOAT4"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "REGCLASS",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "SMALLINT",
    "aliases": [
      "INT2"
    ],
    "alias_of": null,
    "hints": [
      {
        "id": "comparable"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "TEXT",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "string_like"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "TIME",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      },
      {
        "id": "comparable"
      },
      {
        "id": "time"
      },
      {
        "id": "point_in_time"
      }
    ]
  },
  {
    "id": "TIME WITH TIME ZONE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      },
      {
        "id": "comparable"
      },
      {
        "id": "time"
      },
      {
        "id": "point_in_time"
      }
    ]
  },
  {
    "id": "TIME WITHOUT TIME ZONE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      },
      {
        "id": "comparable"
      },
      {
        "id": "time"
      },
      {
        "id": "point_in_time"
      }
    ]
  },
  {
    "id": "TIMESTAMP",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "time"
      },
      {
        "id": "date"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "TIMESTAMP WITH TIME ZONE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "time"
      },
      {
        "id": "date"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "TIMESTAMP WITHOUT TIME ZONE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "time"
      },
      {
        "id": "date"
      },
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "TSRANGE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "TSTZRANGE",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "TSVECTOR",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  },
  {
    "id": "UUID",
    "aliases": [],
    "alias_of": null,
    "hints": [
      {
        "id": "any"
      }
    ]
  }
]

```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
