### PR TITLE
Added fixture for `custom_types_schema` for the e2e test integrations to work properly

### DIFF
--- a/mathesar/tests/conftest.py
+++ b/mathesar/tests/conftest.py
@@ -168,3 +168,9 @@ def create_table(csv_filename, create_schema):
         schema_model = create_schema(schema)
         return create_table_from_csv(data_file, table_name, schema_model)
     return _create_table
+
+
+@pytest.fixture
+def custom_types_schema(test_db_model):
+    engine = create_mathesar_engine(test_db_model.name)
+    install.install_mathesar_on_database(engine)

--- a/mathesar/tests/conftest.py
+++ b/mathesar/tests/conftest.py
@@ -182,6 +182,7 @@ def create_column():
 
 
 @pytest.fixture
-def custom_types_schema(test_db_model):
+def custom_types_schema(test_db_model, schema, live_server):
     engine = create_mathesar_engine(test_db_model.name)
     install.install_mathesar_on_database(engine)
+    return f"{live_server}/{schema.database.name}/{schema.id}"

--- a/mathesar/tests/conftest.py
+++ b/mathesar/tests/conftest.py
@@ -185,4 +185,6 @@ def create_column():
 def custom_types_schema(test_db_model, schema, live_server):
     engine = create_mathesar_engine(test_db_model.name)
     install.install_mathesar_on_database(engine)
-    return f"{live_server}/{schema.database.name}/{schema.id}"
+    yield f"{live_server}/{schema.database.name}/{schema.id}"
+    with engine.begin() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS {base.SCHEMA} CASCADE;'))

--- a/mathesar/tests/conftest.py
+++ b/mathesar/tests/conftest.py
@@ -182,7 +182,7 @@ def create_column():
 
 
 @pytest.fixture
-def custom_types_schema(test_db_model, schema, live_server):
+def custom_types_schema_url(test_db_model, schema, live_server):
     engine = create_mathesar_engine(test_db_model.name)
     install.install_mathesar_on_database(engine)
     yield f"{live_server}/{schema.database.name}/{schema.id}"


### PR DESCRIPTION
Fixes #1168 

**Technical details**
Added a fixture which returns a schema with custom types installed. 

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
