### PR TITLE
Raise timeout for test_import_from_file (fixes #1197)

### DIFF
--- a/mathesar/tests/integration/test_imports.py
+++ b/mathesar/tests/integration/test_imports.py
@@ -16,10 +16,12 @@ def test_import_from_clipboard(page, base_schema_url):
 
 
 def test_import_from_file(page, base_schema_url):
-    page.goto(base_schema_url)
+    # default timeout (5000ms) is too short for this function
+    page.set_default_timeout(10000)page.goto(base_schema_url)
     page.click("[aria-label='New Table']")
     page.click("button:has-text('Import Data')")
     page.set_input_files(".file-upload input", "/code/mathesar/tests/data/patents.csv")
     page.click("button:has-text('Finish Import')")
+    page.pause()
     # "1393 records" is part of the text shown below the table near the pager
     expect(page.locator("text=1393 records")).to_be_visible()

--- a/mathesar/tests/integration/test_imports.py
+++ b/mathesar/tests/integration/test_imports.py
@@ -17,11 +17,11 @@ def test_import_from_clipboard(page, base_schema_url):
 
 def test_import_from_file(page, base_schema_url):
     # default timeout (5000ms) is too short for this function
-    page.set_default_timeout(10000)page.goto(base_schema_url)
+    page.set_default_timeout(10000)
+    page.goto(base_schema_url)
     page.click("[aria-label='New Table']")
     page.click("button:has-text('Import Data')")
     page.set_input_files(".file-upload input", "/code/mathesar/tests/data/patents.csv")
     page.click("button:has-text('Finish Import')")
-    page.pause()
     # "1393 records" is part of the text shown below the table near the pager
     expect(page.locator("text=1393 records")).to_be_visible()


### PR DESCRIPTION
Fixes #1197

<!-- Concisely describe what the pull request does. -->
Raises timeout from 5000ms to 10000ms for test_import_from_file

**Screenshots**
<img width="948" alt="Screen Shot 2022-03-21 at 6 42 14 PM" src="https://user-images.githubusercontent.com/25706524/159390487-23fcc7a9-bdab-44e2-8fc0-b27af014fb94.png">

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
