### PR TITLE
Fix `MathesarErrorMessageMixin` to convert exception objects

### DIFF
--- a/mathesar/api/exceptions/mixins.py
+++ b/mathesar/api/exceptions/mixins.py
@@ -20,7 +20,7 @@ class MathesarErrorMessageMixin(FriendlyErrorMessagesMixin):
         """
         pretty = []
         if self.is_pretty(errors):
-            # DRF serializers supports error any of the following format, error string, list of error strings or {'field': [error strings]}
+            # DRF serializers supports exceptions in any of the following format, error string, list of error strings or {'field': [error strings]}
             # Since our exception is an object instead of a string, the object properties are mistaken to be fields of a serializer,
             # and it gets converted into {'field': [error strings]} by DRF
             # We need to convert it to dictionary of list of object and return it instead of passing it down the line

--- a/mathesar/api/exceptions/mixins.py
+++ b/mathesar/api/exceptions/mixins.py
@@ -19,6 +19,13 @@ class MathesarErrorMessageMixin(FriendlyErrorMessagesMixin):
         2. Add field to the pretty exception body if raised by field validation method
         """
         pretty = []
+        if self.is_pretty(errors):
+            # DRF serializers supports error any of the following format, error string, list of error strings or {'field': [error strings]}
+            # Since our exception is an object instead of a string, the object properties are mistaken to be fields of a serializer,
+            # and it gets converted into {'field': [error strings]} by DRF
+            # We need to convert it to dictionary of list of object and return it instead of passing it down the line
+            scalar_errors = dict(map(lambda item: (item[0], item[1][0] if type(item[1]) == list else item[1]), errors.items()))
+            return [scalar_errors]
         for error_type in errors:
             error = errors[error_type]
             if error_type == 'non_field_errors':

--- a/mathesar/api/serializers/shared_serializers.py
+++ b/mathesar/api/serializers/shared_serializers.py
@@ -103,7 +103,7 @@ DISPLAY_OPTIONS_SERIALIZER_MAPPING_KEY = 'db_type'
 
 
 class BooleanDisplayOptionSerializer(MathesarErrorMessageMixin, OverrideRootPartialMixin, serializers.Serializer):
-    input = serializers.ChoiceField(choices=[("dropdown", 1), ("checkbox", 2)])
+    input = serializers.ChoiceField(choices=[("dropdown", "dropdown"), ("checkbox", "checkbox")], default="checkbox")
     custom_labels = CustomBooleanLabelSerializer(required=False)
 
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1228 

Adds support for raising Custom Exception with an object as error body inside DRF serializer. 

**Technical details**
DRF serializers support exceptions in any of the following formats, error string, list of error strings or {'field': [error strings]}. But our custom validation exceptions use objects as the error body, which gets treated as `{'field': [error strings]}` by DRF serializer. This PR adds support to bypass the conversion if the exception body already has a proper format according to our spec.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
