### PR TITLE
Add test for list scrolls automatically to display the currently selected option

### DIFF
--- a/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
+++ b/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
@@ -182,8 +182,8 @@ test('hide select dropdown by pressing ESC', async () => {
 });
 
 test('list scrolls automatically to display the currently selected option', async () => {
-  const options: Object[] = [];
-  for (let i = 1; i < 18; i += 1) {
+  const options = [];
+  for (let i = 1; i < 10; i += 1) {
     options.push({ id: i, label: `Option ${i}` });
   }
 
@@ -206,13 +206,13 @@ test('list scrolls automatically to display the currently selected option', asyn
   const optionElementList = getAllByRole('option');
 
   // scrolling through the list to reach second last element
-  for (let i = 1; i < 17; i += 1) {
-    fireEvent.keyDown(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
-    fireEvent.keyUp(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
-  }
+  Array(7).forEach(async () => {
+    await fireEvent.keyDown(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
+    await fireEvent.keyUp(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
+  });
 
   // second last element obtained
-  const optionElement = optionElementList[16];
+  const optionElement = optionElementList[7];
 
   // select the option.
   await fireEvent.keyDown(selectBtn, { key: 'Enter', code: 'Enter' });

--- a/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
+++ b/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
@@ -184,7 +184,7 @@ test('hide select dropdown by pressing ESC', async () => {
 test('list scrolls automatically to display the currently selected option', async () => {
   const options: Object[] = [];
   for (let i = 1; i < 18; i += 1) {
-    options.push({ id: i, label: `Option ${i}` })
+    options.push({ id: i, label: `Option ${i}` });
   }
 
   const { getByRole, getAllByRole } = render(Select, {
@@ -202,9 +202,9 @@ test('list scrolls automatically to display the currently selected option', asyn
   const selectUl = getByRole('listbox');
   const dropdownContainer: any = selectUl.parentElement;
 
-  // list of options obtained 
+  // list of options obtained
   const optionElementList = getAllByRole('option');
-  
+
   // scrolling through the list to reach second last element
   for (let i = 1; i < 17; i += 1) {
     await fireEvent.keyDown(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
@@ -221,8 +221,12 @@ test('list scrolls automatically to display the currently selected option', asyn
   // Reopen the dropdown
   await fireEvent.click(selectBtn);
 
-  expect(optionElement.offsetTop).toBeGreaterThanOrEqual(dropdownContainer.scrollTop);
-  expect(optionElement.offsetTop + optionElement.clientHeight).toBeLessThanOrEqual(
+  expect(optionElement.offsetTop).toBeGreaterThanOrEqual(
+    dropdownContainer.scrollTop,
+  );
+  expect(
+    optionElement.offsetTop + optionElement.clientHeight,
+  ).toBeLessThanOrEqual(
     dropdownContainer.scrollTop + dropdownContainer.clientHeight,
   );
 });

--- a/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
+++ b/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
@@ -200,19 +200,19 @@ test('list scrolls automatically to display the currently selected option', asyn
 
   // dropdown container obtained
   const selectUl = getByRole('listbox');
-  const dropdownContainer: any = selectUl.parentElement;
+  const dropdownContainer: HTMLElement | null = selectUl?.parentElement;
 
   // list of options obtained
   const optionElementList = getAllByRole('option');
 
   // scrolling through the list to reach second last element
   for (let i = 1; i < 17; i += 1) {
-    await fireEvent.keyDown(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
-    await fireEvent.keyUp(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
+    fireEvent.keyDown(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
+    fireEvent.keyUp(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
   }
 
   // second last element obtained
-  let optionElement = optionElementList[16];
+  const optionElement = optionElementList[16];
 
   // select the option.
   await fireEvent.keyDown(selectBtn, { key: 'Enter', code: 'Enter' });
@@ -222,11 +222,13 @@ test('list scrolls automatically to display the currently selected option', asyn
   await fireEvent.click(selectBtn);
 
   expect(optionElement.offsetTop).toBeGreaterThanOrEqual(
-    dropdownContainer.scrollTop,
+    dropdownContainer ? dropdownContainer.scrollTop : 0,
   );
   expect(
     optionElement.offsetTop + optionElement.clientHeight,
   ).toBeLessThanOrEqual(
-    dropdownContainer.scrollTop + dropdownContainer.clientHeight,
+    dropdownContainer
+      ? dropdownContainer.scrollTop + dropdownContainer.clientHeight
+      : 0,
   );
 });

--- a/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
+++ b/mathesar_ui/src/component-library/select/__meta__/Select.test.ts
@@ -180,3 +180,49 @@ test('hide select dropdown by pressing ESC', async () => {
   const selectOption2 = queryByRole('listbox');
   expect(selectOption2).not.toBeInTheDocument();
 });
+
+test('list scrolls automatically to display the currently selected option', async () => {
+  const options: Object[] = [];
+  for (let i = 1; i < 18; i += 1) {
+    options.push({ id: i, label: `Option ${i}` })
+  }
+
+  const { getByRole, getAllByRole } = render(Select, {
+    props: {
+      options,
+      triggerAppearance: 'default',
+    },
+  });
+
+  // options are only rendered when the button is clicked
+  const selectBtn = getByRole('button');
+  await fireEvent.click(selectBtn);
+
+  // dropdown container obtained
+  const selectUl = getByRole('listbox');
+  const dropdownContainer: any = selectUl.parentElement;
+
+  // list of options obtained 
+  const optionElementList = getAllByRole('option');
+  
+  // scrolling through the list to reach second last element
+  for (let i = 1; i < 17; i += 1) {
+    await fireEvent.keyDown(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
+    await fireEvent.keyUp(selectBtn, { key: 'ArrowDown', code: 'ArrowDown' });
+  }
+
+  // second last element obtained
+  let optionElement = optionElementList[16];
+
+  // select the option.
+  await fireEvent.keyDown(selectBtn, { key: 'Enter', code: 'Enter' });
+  await fireEvent.keyUp(selectBtn, { key: 'Enter', code: 'Enter' });
+
+  // Reopen the dropdown
+  await fireEvent.click(selectBtn);
+
+  expect(optionElement.offsetTop).toBeGreaterThanOrEqual(dropdownContainer.scrollTop);
+  expect(optionElement.offsetTop + optionElement.clientHeight).toBeLessThanOrEqual(
+    dropdownContainer.scrollTop + dropdownContainer.clientHeight,
+  );
+});


### PR DESCRIPTION
Fixes #376 

Adds a test for checking whether the select component scrolls automatically to display the currently selected option

**Screenshots**
<img width="515" alt="image" src="https://user-images.githubusercontent.com/43414361/160254274-56c1644d-0efc-420a-8bcb-9ffe562fdfb5.png">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
