### PR TITLE
Record videos for all e2e tests, stringify errors before joining

### DIFF
--- a/.github/workflows/run-e2e-integ-tests.yml
+++ b/.github/workflows/run-e2e-integ-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: docker exec -w /code/mathesar_ui mathesar_service npx vite build
 
       - name: Run integ tests with pytest
-        run: docker exec mathesar_service pytest --browser chromium --browser webkit --browser firefox mathesar/tests/integration/
+        run: docker exec mathesar_service pytest --browser chromium --browser webkit --browser firefox --video="on" --output="./videos/" mathesar/tests/integration/
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() || success() }}

--- a/mathesar_ui/src/utils/api.ts
+++ b/mathesar_ui/src/utils/api.ts
@@ -58,7 +58,9 @@ function sendXHRRequest<T>(
             // TODO: Follow a proper error message structure
             const message = JSON.parse(request.response) as string | string[];
             if (Array.isArray(message)) {
-              errorMessage = message.join(', ');
+              errorMessage = message
+                .map((msg) => JSON.stringify(msg))
+                .join(', ');
             } else if (typeof message === 'string') {
               errorMessage = message;
             } else if (message) {


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
This PR:
* Configures e2e tests to record videos
* Stringifies errors in array before joining

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
