### PR TITLE
Disable test_import_from_file test

### DIFF
--- a/mathesar/tests/integration/test_imports.py
+++ b/mathesar/tests/integration/test_imports.py
@@ -15,11 +15,13 @@ def test_import_from_clipboard(page, custom_types_schema_url):
     expect(get_table_entry(page, "Table 0")).to_be_visible()
 
 
-def test_import_from_file(page, custom_types_schema_url):
-    page.goto(custom_types_schema_url)
-    page.click("[aria-label='New Table']")
-    page.click("button:has-text('Import Data')")
-    page.set_input_files(".file-upload input", "/code/mathesar/tests/data/patents.csv")
-    page.click("button:has-text('Finish Import')")
-    # "1393 records" is part of the text shown below the table near the pager
-    expect(page.locator("text=1393")).to_be_visible()
+# # This test was too brittle so we disabled it for now.
+# # See https://github.com/centerofci/mathesar/issues/1285
+# def test_import_from_file(page, custom_types_schema_url):
+#     page.goto(custom_types_schema_url)
+#     page.click("[aria-label='New Table']")
+#     page.click("button:has-text('Import Data')")
+#     page.set_input_files(".file-upload input", "/code/mathesar/tests/data/patents.csv")
+#     page.click("button:has-text('Finish Import')")
+#     # "1393 records" is part of the text shown below the table near the pager
+#     expect(page.locator("text=1393")).to_be_visible()


### PR DESCRIPTION
## Notes

This test is slowing us down so I've commented it out and opened #1285 to track the work of fixing it.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

