### PR TITLE
Use new schema for Number display_options

### DIFF
--- a/mathesar_ui/src/stores/abstract-types/type-configs/number.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/number.ts
@@ -198,7 +198,7 @@ function constructDbFormValuesFromTypeOptions(
 
 interface NumberDisplayOptions {
   show_as_percentage?: boolean | null;
-  locale?: string | null;
+  number_format?: string | null;
 }
 
 const displayForm: AbstractTypeConfigForm = {
@@ -207,9 +207,9 @@ const displayForm: AbstractTypeConfigForm = {
       type: 'boolean',
       default: false,
     },
-    format: {
+    numberFormat: {
       type: 'string',
-      enum: ['none', 'af', 'ar-DZ', 'bg', 'bn', 'de-CH'],
+      enum: ['none', 'english', 'german', 'french', 'hindi', 'swiss'],
       default: 'none',
     },
   },
@@ -223,15 +223,15 @@ const displayForm: AbstractTypeConfigForm = {
       },
       {
         type: 'input',
-        variable: 'format',
+        variable: 'numberFormat',
         label: 'Format',
         options: {
           none: { label: 'Use browser locale' },
-          af: { label: '1,234,567.89' },
-          'ar-DZ': { label: '1.234.567,89' },
-          bg: { label: '1 234 567,89' },
-          bn: { label: '12,34,567.89' },
-          'de-CH': { label: "1'234'567.89" },
+          english: { label: '1,234,567.89' },
+          german: { label: '1.234.567,89' },
+          french: { label: '1 234 567,89' },
+          hindi: { label: '12,34,567.89' },
+          swiss: { label: "1'234'567.89" },
         },
       },
     ],
@@ -244,8 +244,8 @@ function determineDisplayOptions(
   const displayOptions: Column['display_options'] = {
     show_as_percentage: dispFormValues.showAsPercentage,
   };
-  if (dispFormValues.format !== 'none') {
-    displayOptions.locale = dispFormValues.format;
+  if (dispFormValues.numberFormat !== 'none') {
+    displayOptions.number_format = dispFormValues.numberFormat;
   }
   return displayOptions;
 }
@@ -256,7 +256,7 @@ function constructDisplayFormValuesFromDisplayOptions(
   const displayOptions = columnDisplayOpts as NumberDisplayOptions | null;
   const dispFormValues: FormValues = {
     showAsPercentage: displayOptions?.show_as_percentage ?? false,
-    format: displayOptions?.locale ?? 'none',
+    numberFormat: displayOptions?.number_format ?? 'none',
   };
   return dispFormValues;
 }


### PR DESCRIPTION
Changes to follow [new specs](https://github.com/centerofci/mathesar/discussions/1243#discussioncomment-2519195)

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

