### PR TITLE
Small improvements to Select component

### DIFF
--- a/mathesar_ui/src/component-library/common/utils/formatUtils.ts
+++ b/mathesar_ui/src/component-library/common/utils/formatUtils.ts
@@ -24,5 +24,8 @@ export function getLabel(v: unknown, labelKey = 'label'): string {
   if (hasStringProperty(v, labelKey)) {
     return v[labelKey];
   }
+  if (v === undefined) {
+    return '';
+  }
   return String(v);
 }

--- a/mathesar_ui/src/component-library/dropdown/Dropdown.scss
+++ b/mathesar_ui/src/component-library/dropdown/Dropdown.scss
@@ -12,6 +12,10 @@ button.dropdown.trigger {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    box-sizing: content-box;
+    line-height: 1.4;
+    min-height: 1.4em;
+    min-width: 2ch;
   }
 
   > .arrow {

--- a/mathesar_ui/src/component-library/list-box/ListBox.scss
+++ b/mathesar_ui/src/component-library/list-box/ListBox.scss
@@ -8,6 +8,9 @@ ul.list-box-options {
     position: relative;
     padding: 6px 12px;
     cursor: default;
+    box-sizing: content-box;
+    line-height: 1.2;
+    min-height: 1.2em;
 
     &:hover {
       background: #f3f4f5;

--- a/mathesar_ui/src/component-library/list-box/ListBox.scss
+++ b/mathesar_ui/src/component-library/list-box/ListBox.scss
@@ -12,6 +12,14 @@ ul.list-box-options {
     line-height: 1.2;
     min-height: 1.2em;
 
+    // Disable text selection. Without this, if I inadvertently drag my mouse
+    // over some blank space in the option, then I select text outside the
+    // ListBox.
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
     &:hover {
       background: #f3f4f5;
     }

--- a/mathesar_ui/src/component-library/list-box/ListBox.svelte
+++ b/mathesar_ui/src/component-library/list-box/ListBox.svelte
@@ -34,7 +34,7 @@
   export let getLabel: DefinedProps['getLabel'] = defaultGetLabel;
   export let checkEquality: DefinedProps['checkEquality'] = (
     opt: Option,
-    opt2: Option | undefined,
+    opt2: Option,
   ) => opt === opt2;
   export let checkIfOptionIsDisabled: DefinedProps['checkIfOptionIsDisabled'] =
     () => false;

--- a/mathesar_ui/src/component-library/list-box/ListBoxTypes.ts
+++ b/mathesar_ui/src/component-library/list-box/ListBoxTypes.ts
@@ -7,10 +7,7 @@ export interface ListBoxStaticContextProps<Option> {
   getLabel: (value: Option, labelKey?: string) => string;
   searchable: boolean;
   disabled: boolean;
-  checkEquality: (
-    option: Option,
-    optionToCompare: Option | undefined,
-  ) => boolean;
+  checkEquality: (option: Option, optionToCompare: Option) => boolean;
   checkIfOptionIsDisabled: (optionToCheck: Option) => boolean;
 }
 

--- a/mathesar_ui/src/component-library/select/Select.svelte
+++ b/mathesar_ui/src/component-library/select/Select.svelte
@@ -29,6 +29,8 @@
    */
   export let options: Option[] = [];
 
+  export let prependBlank = false;
+
   export let value: Option | undefined = undefined;
 
   /**
@@ -51,8 +53,10 @@
    */
   export let ariaLabel: string | undefined = undefined;
 
-  export let getLabel: (value: Option, labelKey?: string) => string =
-    defaultGetLabel;
+  export let getLabel: (
+    value: Option | undefined,
+    labelKey?: string,
+  ) => string = defaultGetLabel;
 
   /**
    * By default, options will be compared by equality. If you're using objects as
@@ -65,11 +69,11 @@
    * ```
    */
   export let valuesAreEqual: (
-    optionToCompare: Option,
+    optionToCompare: Option | undefined,
     selectedOption: Option | undefined,
   ) => boolean = (a, b) => a === b;
 
-  function setValueFromArray(values: Option[]) {
+  function setValueFromArray(values: (Option | undefined)[]) {
     [value] = values;
     dispatch('change', value);
   }
@@ -84,6 +88,7 @@
     }
   }
 
+  $: fullOptions = prependBlank ? [undefined, ...options] : options;
   $: setValueOnOptionChange(options);
 </script>
 
@@ -91,7 +96,7 @@
 
 <ListBox
   selectionType="single"
-  {options}
+  options={fullOptions}
   value={typeof value !== 'undefined' ? [value] : []}
   on:change={(e) => setValueFromArray(e.detail)}
   {labelKey}
@@ -114,11 +119,7 @@
     on:keydown={(e) => api.handleKeyDown(e)}
   >
     <svelte:fragment slot="trigger">
-      {#if typeof value !== 'undefined'}
-        {getLabel(value, labelKey)}
-      {:else}
-        No option selected
-      {/if}
+      {getLabel(value, labelKey)}
     </svelte:fragment>
 
     <svelte:fragment slot="content">

--- a/mathesar_ui/src/components/SelectColumn.svelte
+++ b/mathesar_ui/src/components/SelectColumn.svelte
@@ -9,6 +9,6 @@
 <Select
   options={columns}
   labelKey="name"
-  valuesAreEqual={(a, b) => a.id === b?.id}
+  valuesAreEqual={(a, b) => a?.id === b?.id}
   bind:value={column}
 />

--- a/mathesar_ui/src/stores/table-data/sorting.ts
+++ b/mathesar_ui/src/stores/table-data/sorting.ts
@@ -33,8 +33,10 @@ const directionLabels = new Map([
   [SortDirection.A, 'asc'],
   [SortDirection.D, 'desc'],
 ]);
-export function getDirectionLabel(direction: SortDirection): string {
-  return directionLabels.get(direction) ?? '';
+export function getDirectionLabel(
+  direction: SortDirection | undefined,
+): string {
+  return direction ? directionLabels.get(direction) ?? '' : '';
 }
 
 /**


### PR DESCRIPTION
## Motivation

- For #947 I need a form with a Select that is empty by default (for the user to choose a table).
- Without this PR, it's hard to make a Select that works well with an empty default. It shows the text "No option selected", which is confusing because it's not stylized any differently from the actual options. And if I explicitly label my `undefined` option as as empty string, then the height of the option and of the Dropdown trigger become very small.

## Changes

- This PR adds a new prop `prependBlank` to `Select`. When true, an `undefined` option will be inserted before all the supplied options, and its label will be blank.
- I also added some CSS to disable text selection on the options because I found I was getting other text in the page selected sometimes while playing with the `Select` (if my mouse would move a pixel or so when clicking the option).

## Preview

![Peek 2022-04-22 10-52](https://user-images.githubusercontent.com/42411/164739460-fe2fe58d-7963-47f8-bcb3-4accaf3d9b93.gif)

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

