### PR TITLE
Refactor props for RadioGroup and CheckboxGroup

### DIFF
--- a/mathesar_ui/src/component-library/checkbox-group/CheckboxGroup.svelte
+++ b/mathesar_ui/src/component-library/checkbox-group/CheckboxGroup.svelte
@@ -1,31 +1,54 @@
 <script lang="ts">
-  import type { Option } from '@mathesar-component-library-dir/types';
   import FieldsetGroup from '@mathesar-component-library-dir/fieldset-group/FieldsetGroup.svelte';
   import Checkbox from '@mathesar-component-library-dir/checkbox/Checkbox.svelte';
-  import ImmutableSet from '@mathesar-component-library-dir/common/utils/ImmutableSet';
+  import type { LabelGetter } from '@mathesar-component-library-dir/common/utils/formatUtils';
 
-  export let values: Option['value'][] = [];
+  type Option = $$Generic;
+
+  export let values: Option[] = [];
   export let isInline = false;
   export let options: Option[] = [];
   export let label: string | undefined = undefined;
+  export let checkboxLabelKey: string | undefined = undefined;
+  export let getCheckboxLabel: LabelGetter<Option> | undefined = undefined;
+  /**
+   * By default, options will be compared by equality. If you're using objects as
+   * options, you can supply a custom function here to compare them.
+   *
+   * For example:
+   *
+   * ```ts
+   * valuesAreEqual={(a, b) => a.id === b.id}
+   * ```
+   */
+  export let valuesAreEqual: (
+    optionToCompare: Option | undefined,
+    selectedOption: Option | undefined,
+  ) => boolean = (a, b) => a === b;
 
-  $: set = new ImmutableSet<Option['value']>(values);
-
-  function handleChange(
-    { value }: Option,
-    e: CustomEvent<{ checked: boolean }>,
-  ) {
-    const { checked } = e.detail;
-    set = checked ? set.with(value) : set.without(value);
-    values = [...set.values()];
+  function handleChange(option: Option, checked: boolean) {
+    if (checked) {
+      values = [...values, option];
+    } else {
+      values = values.filter((value) => !valuesAreEqual(value, option));
+    }
   }
 </script>
 
-<FieldsetGroup {isInline} {options} {label} let:option on:change>
+<FieldsetGroup
+  {isInline}
+  {options}
+  {label}
+  let:option
+  let:disabled
+  on:change
+  labelKey={checkboxLabelKey}
+  getLabel={getCheckboxLabel}
+>
   <Checkbox
-    on:change={(e) => handleChange(option, e)}
-    checked={set.has(option.value)}
-    disabled={option.disabled}
+    on:change={({ detail: checked }) => handleChange(option, checked)}
+    checked={values.some((o) => valuesAreEqual(o, option))}
+    {disabled}
   />
   <slot slot="label" />
 </FieldsetGroup>

--- a/mathesar_ui/src/component-library/checkbox-group/__meta__/CheckboxGroup.stories.svelte
+++ b/mathesar_ui/src/component-library/checkbox-group/__meta__/CheckboxGroup.stories.svelte
@@ -61,11 +61,11 @@
     bind:values={simpleValue}
     label="Simple options"
   />
-  <p>Values: [{simpleValue}]</p>
+  <p>Values: {JSON.stringify(simpleValue)}</p>
   <p>
     <Button
       on:click={() => {
-        simpleValue = [2];
+        simpleValue = [simpleOptions[1]];
       }}>Set to [2]</Button
     >
   </p>
@@ -86,6 +86,10 @@
     bind:values={richValue}
     isInline
     label="Rich text"
+    getCheckboxLabel={(o) => ({
+      component: o.labelComponent,
+      props: o.labelComponentProps,
+    })}
   />
 </Story>
 

--- a/mathesar_ui/src/component-library/checkbox/Checkbox.svelte
+++ b/mathesar_ui/src/component-library/checkbox/Checkbox.svelte
@@ -2,7 +2,7 @@
   import { createEventDispatcher } from 'svelte';
   import BaseInput from '@mathesar-component-library-dir/common/base-components/BaseInput.svelte';
 
-  const dispatch = createEventDispatcher();
+  const dispatch = createEventDispatcher<{ change: boolean }>();
 
   /**
    * When `allowIndeterminate={true}`, then setting `checked={null}` will put
@@ -28,12 +28,9 @@
 
   $: indeterminate = allowIndeterminate && checked === null;
 
-  function onChange(e: Event) {
+  function onChange() {
     checked = !checked;
-    dispatch('change', {
-      checked,
-      originalEvent: e,
-    });
+    dispatch('change', checked);
   }
 </script>
 

--- a/mathesar_ui/src/component-library/common/utils/formatUtils.ts
+++ b/mathesar_ui/src/component-library/common/utils/formatUtils.ts
@@ -1,3 +1,4 @@
+import type { ComponentAndProps } from '@mathesar-component-library-dir/common/types/ComponentAndPropsTypes';
 import { hasStringProperty } from './typeUtils';
 
 export function formatSize(sizeInBytes: number): string {
@@ -15,6 +16,8 @@ export function formatSize(sizeInBytes: number): string {
 
   return `${repValue.toFixed(2)} ${repUnit}B`;
 }
+
+export type LabelGetter<Option> = (value: Option) => string | ComponentAndProps;
 
 /**
  * If the given value has a label property and it is a string, return it.

--- a/mathesar_ui/src/component-library/fieldset-group/FieldsetGroup.svelte
+++ b/mathesar_ui/src/component-library/fieldset-group/FieldsetGroup.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
-  import type { Option } from '@mathesar-component-library-dir/types';
   import LabeledInput from '@mathesar-component-library-dir/labeled-input/LabeledInput.svelte';
+  import type { LabelGetter } from '@mathesar-component-library-dir/common/utils/formatUtils';
+  import { getLabel as defaultGetLabel } from '@mathesar-component-library-dir/common/utils/formatUtils';
+  import StringOrComponent from '@mathesar-component-library-dir/string-or-component/StringOrComponent.svelte';
+
+  type Option = $$Generic;
 
   export let isInline = false;
   export let options: Option[] = [];
   export let label: string | undefined = undefined;
+
+  export let labelKey = 'label';
+  let customGetLabel: LabelGetter<Option> | undefined = undefined;
+  export { customGetLabel as getLabel };
+
+  export let getDisabled: (value: Option | undefined) => boolean = () => false;
+
+  $: getLabel = customGetLabel ?? ((o: Option) => defaultGetLabel(o, labelKey));
 </script>
 
 <fieldset class="fieldset-group" class:inline={isInline} on:change>
@@ -15,20 +27,13 @@
     </legend>
   {/if}
   <ul class="options">
-    {#each options as option (option.value)}
+    {#each options as option (option)}
       <li class="option">
         <LabeledInput layout="inline-input-first">
           <svelte:fragment slot="label">
-            {#if option.label}
-              {option.label}
-            {:else}
-              <svelte:component
-                this={option.labelComponent}
-                {...option.labelComponentProps}
-              />
-            {/if}
+            <StringOrComponent arg={getLabel(option)} />
           </svelte:fragment>
-          <slot {option} />
+          <slot {option} disabled={getDisabled(option)} />
         </LabeledInput>
       </li>
     {/each}

--- a/mathesar_ui/src/component-library/radio-group/RadioGroup.svelte
+++ b/mathesar_ui/src/component-library/radio-group/RadioGroup.svelte
@@ -1,15 +1,51 @@
 <script lang="ts">
-  import type { Option } from '@mathesar-component-library-dir/types';
   import FieldsetGroup from '@mathesar-component-library-dir/fieldset-group/FieldsetGroup.svelte';
   import Radio from '@mathesar-component-library-dir/radio/Radio.svelte';
+  import type { LabelGetter } from '@mathesar-component-library-dir/common/utils/formatUtils';
 
-  export let value: string;
+  type Option = $$Generic;
+
+  export let value: Option | undefined;
   export let isInline = false;
   export let options: Option[] = [];
   export let label: string | undefined = undefined;
+  export let radioLabelKey: string | undefined = undefined;
+  export let getRadioLabel: LabelGetter<Option> | undefined = undefined;
+
+  /**
+   * By default, options will be compared by equality. If you're using objects as
+   * options, you can supply a custom function here to compare them.
+   *
+   * For example:
+   *
+   * ```ts
+   * valuesAreEqual={(a, b) => a.id === b.id}
+   * ```
+   */
+  export let valuesAreEqual: (
+    optionToCompare: Option | undefined,
+    selectedOption: Option | undefined,
+  ) => boolean = (a, b) => a === b;
 </script>
 
-<FieldsetGroup {isInline} {options} {label} let:option on:change>
-  <Radio bind:group={value} value={option.value} disabled={option.disabled} />
+<FieldsetGroup
+  {isInline}
+  {options}
+  {label}
+  let:option
+  let:disabled
+  on:change
+  labelKey={radioLabelKey}
+  getLabel={getRadioLabel}
+>
+  <Radio
+    {disabled}
+    checked={valuesAreEqual(value, option)}
+    on:change={({ detail: checked }) => {
+      if (checked) {
+        value = option;
+      }
+    }}
+  />
   <slot slot="label" />
 </FieldsetGroup>

--- a/mathesar_ui/src/component-library/radio-group/__meta__/RadioGroup.stories.svelte
+++ b/mathesar_ui/src/component-library/radio-group/__meta__/RadioGroup.stories.svelte
@@ -77,6 +77,10 @@
     bind:value={richValue}
     isInline
     label="Rich text"
+    getRadioLabel={(o) => ({
+      component: o.labelComponent,
+      props: o.labelComponentProps,
+    })}
   />
 </Story>
 

--- a/mathesar_ui/src/component-library/radio/Radio.svelte
+++ b/mathesar_ui/src/component-library/radio/Radio.svelte
@@ -1,12 +1,28 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import BaseInput from '@mathesar-component-library-dir/common/base-components/BaseInput.svelte';
 
-  export let group: string | number | string[] | undefined = undefined;
+  const dispatch = createEventDispatcher<{ change: boolean }>();
+
+  export let checked = false;
   export let value: string | number | string[] | undefined = undefined;
   export let disabled = false;
   export let id: string | undefined = undefined;
+
+  function handleChange() {
+    checked = !checked;
+    dispatch('change', checked);
+  }
 </script>
 
 <BaseInput {...$$restProps} bind:id {disabled} />
 
-<input class="radio" type="radio" bind:group {value} {id} {disabled} />
+<input
+  class="radio"
+  type="radio"
+  {checked}
+  {id}
+  {disabled}
+  {value}
+  on:change={handleChange}
+/>

--- a/mathesar_ui/src/component-library/radio/__meta__/Radio.stories.svelte
+++ b/mathesar_ui/src/component-library/radio/__meta__/Radio.stories.svelte
@@ -15,13 +15,13 @@
 
   <p>
     <LabeledInput label="With a form label" layout="inline-input-first">
-      <Radio group={null} />
+      <Radio />
     </LabeledInput>
   </p>
 
   <p>
     <LabeledInput label="Disabled" layout="inline-input-first">
-      <Radio group={null} disabled />
+      <Radio disabled />
     </LabeledInput>
   </p>
 </Story>

--- a/mathesar_ui/src/component-library/types.ts
+++ b/mathesar_ui/src/component-library/types.ts
@@ -1,5 +1,3 @@
-import type { SvelteComponent } from 'svelte';
-
 export * from './common/utils';
 
 export type Appearance =
@@ -9,14 +7,6 @@ export type Appearance =
   | 'plain'
   | 'ghost';
 export type Size = 'small' | 'medium' | 'large';
-
-export interface Option {
-  value: string | number;
-  label?: string;
-  labelComponent?: typeof SvelteComponent;
-  labelComponentProps?: unknown;
-  disabled?: boolean;
-}
 
 export type { Tab } from './tabs/TabContainerTypes';
 export type { TreeItem } from './tree/TreeTypes';

--- a/mathesar_ui/src/sections/import-data/preview/Preview.svelte
+++ b/mathesar_ui/src/sections/import-data/preview/Preview.svelte
@@ -50,10 +50,6 @@
       previewColumns: [...previewColumns],
     });
   }
-
-  function handleChangeFirstRowAsHeader(e: CustomEvent) {
-    void updateDataFileHeader(fileImportStore, e.detail.checked as boolean);
-  }
 </script>
 
 <h2>Confirm your data</h2>
@@ -79,7 +75,7 @@
     <Checkbox
       bind:checked={$fileImportStore.firstRowHeader}
       disabled={$fileImportStore.previewStatus === States.Loading}
-      on:change={handleChangeFirstRowAsHeader}
+      on:change={({ detail }) => updateDataFileHeader(fileImportStore, detail)}
     />
   </LabeledInput>
 </div>

--- a/mathesar_ui/src/sections/import-data/upload/Upload.svelte
+++ b/mathesar_ui/src/sections/import-data/upload/Upload.svelte
@@ -1,32 +1,18 @@
 <script lang="ts">
   import { RadioGroup } from '@mathesar-component-library';
   import type { FileImport } from '@mathesar/stores/fileImports';
-  import type { SvelteComponent } from 'svelte';
   import UploadViaFile from './UploadViaFile.svelte';
   import UploadViaUrl from './UploadViaUrl.svelte';
   import UploadViaClipboard from './UploadViaClipboard.svelte';
 
   export let fileImportStore: FileImport;
 
-  type UploadMethod = 'File' | 'URL' | 'Copy and Paste Text';
-  interface UploadMethodOption {
-    value: UploadMethod;
-    component: typeof SvelteComponent;
-  }
-  const uploadMethods: UploadMethodOption[] = [
-    { value: 'File', component: UploadViaFile },
-    { value: 'URL', component: UploadViaUrl },
-    { value: 'Copy and Paste Text', component: UploadViaClipboard },
+  const uploadMethods = [
+    { label: 'File', component: UploadViaFile },
+    { label: 'URL', component: UploadViaUrl },
+    { label: 'Copy and Paste Text', component: UploadViaClipboard },
   ];
-  const radioOptions = uploadMethods.map(({ value }) => ({
-    value,
-    label: value,
-  }));
-
-  let uploadMethodId: UploadMethod = 'File';
-
-  $: uploadMethod =
-    uploadMethods.find((m) => m.value === uploadMethodId) ?? uploadMethods[0];
+  let uploadMethod = uploadMethods[0];
 </script>
 
 <h2>Import your data</h2>
@@ -38,8 +24,8 @@
 </div>
 
 <RadioGroup
-  bind:value={uploadMethodId}
-  options={radioOptions}
+  bind:value={uploadMethod}
+  options={uploadMethods}
   isInline
   label="Upload Method"
 >

--- a/mathesar_ui/src/sections/table-view/row/RowControl.svelte
+++ b/mathesar_ui/src/sections/table-view/row/RowControl.svelte
@@ -26,11 +26,10 @@
   $: errors = status?.errorsFromWholeRowAndCells ?? [];
   $: isRowSelected = primaryKeyValue !== undefined && $selectedRows.has(rowKey);
 
-  function selectionChanged(event: CustomEvent<{ checked: boolean }>) {
+  function selectionChanged({ detail: checked }: CustomEvent<boolean>) {
     if (primaryKeyValue === undefined) {
       return;
     }
-    const { checked } = event.detail;
     if (checked) {
       meta.selectedRows.add(rowKey);
     } else {


### PR DESCRIPTION
Make the props structure of `RadioGroup` and `CheckboxGroup` mirror the new approach we're now using for the `Select` component.

If you look at `Upload.svelte`, you can see the improvement because the code is simpler.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

