### PR TITLE
Improve getLabel functions

### DIFF
--- a/mathesar_ui/src/component-library/fieldset-group/FieldsetGroup.svelte
+++ b/mathesar_ui/src/component-library/fieldset-group/FieldsetGroup.svelte
@@ -11,12 +11,10 @@
   export let label: string | undefined = undefined;
 
   export let labelKey = 'label';
-  let customGetLabel: LabelGetter<Option> | undefined = undefined;
-  export { customGetLabel as getLabel };
+  export let getLabel: LabelGetter<Option> = (o: Option) =>
+    defaultGetLabel(o, labelKey);
 
   export let getDisabled: (value: Option | undefined) => boolean = () => false;
-
-  $: getLabel = customGetLabel ?? ((o: Option) => defaultGetLabel(o, labelKey));
 </script>
 
 <fieldset class="fieldset-group" class:inline={isInline} on:change>

--- a/mathesar_ui/src/component-library/list-box/ListBox.svelte
+++ b/mathesar_ui/src/component-library/list-box/ListBox.svelte
@@ -31,7 +31,8 @@
   export let searchable: DefinedProps['searchable'] = false;
   export let disabled: DefinedProps['disabled'] = false;
   export let labelKey: DefinedProps['labelKey'] = 'label';
-  export let getLabel: DefinedProps['getLabel'] = defaultGetLabel;
+  export let getLabel: DefinedProps['getLabel'] = (option: Option) =>
+    defaultGetLabel(option, labelKey);
   export let checkEquality: DefinedProps['checkEquality'] = (
     opt: Option,
     opt2: Option,
@@ -231,7 +232,6 @@
 
   const staticProps: Writable<ListBoxStaticContextProps<Option>> = writable({
     selectionType,
-    labelKey,
     getLabel,
     searchable,
     disabled,
@@ -240,7 +240,6 @@
   });
   $: staticProps.set({
     selectionType,
-    labelKey,
     getLabel,
     searchable,
     disabled,

--- a/mathesar_ui/src/component-library/list-box/ListBoxOptions.svelte
+++ b/mathesar_ui/src/component-library/list-box/ListBoxOptions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, getContext, tick } from 'svelte';
+  import StringOrComponent from '../string-or-component/StringOrComponent.svelte';
   import type { ListBoxContext } from './ListBoxTypes';
 
   type Option = $$Generic;
@@ -62,7 +63,7 @@
       class:in-focus={index === $focusedOptionIndex}
       on:click={() => api.pick(option)}
     >
-      <span>{$staticProps.getLabel(option, $staticProps.labelKey)}</span>
+      <StringOrComponent arg={$staticProps.getLabel(option)} />
     </li>
   {/each}
 </ul>

--- a/mathesar_ui/src/component-library/list-box/ListBoxTypes.ts
+++ b/mathesar_ui/src/component-library/list-box/ListBoxTypes.ts
@@ -1,10 +1,10 @@
 import type { Readable } from 'svelte/store';
 import type CancellablePromise from '@mathesar-component-library-dir/common/utils/CancellablePromise';
+import type { LabelGetter } from '@mathesar-component-library-dir/common/utils/formatUtils';
 
 export interface ListBoxStaticContextProps<Option> {
   selectionType: 'single' | 'multiple';
-  labelKey: string;
-  getLabel: (value: Option, labelKey?: string) => string;
+  getLabel: LabelGetter<Option>;
   searchable: boolean;
   disabled: boolean;
   checkEquality: (option: Option, optionToCompare: Option) => boolean;
@@ -13,6 +13,7 @@ export interface ListBoxStaticContextProps<Option> {
 
 export interface ListBoxProps<Option>
   extends Partial<ListBoxStaticContextProps<Option>> {
+  labelKey?: string;
   options: Option[] | (() => CancellablePromise<Option[]>);
   value?: Option[];
 }

--- a/mathesar_ui/src/component-library/select/Select.svelte
+++ b/mathesar_ui/src/component-library/select/Select.svelte
@@ -6,9 +6,11 @@
     ListBoxOptions,
   } from '@mathesar-component-library-dir/list-box';
   import { Dropdown } from '@mathesar-component-library-dir/dropdown';
+  import type { LabelGetter } from '@mathesar-component-library-dir/common/utils/formatUtils';
   import { getLabel as defaultGetLabel } from '@mathesar-component-library-dir/common/utils/formatUtils';
   import type { Appearance } from '@mathesar-component-library-dir/types';
   import { getGloballyUniqueId } from '@mathesar-component-library-dir/common/utils/domUtils';
+  import StringOrComponent from '../string-or-component/StringOrComponent.svelte';
 
   type Option = $$Generic;
 
@@ -22,6 +24,10 @@
    * Specifies the key on which the options label is stored.
    */
   export let labelKey = 'label';
+
+  export let getLabel: LabelGetter<Option | undefined> = (
+    o: Option | undefined,
+  ) => defaultGetLabel(o, labelKey);
 
   /**
    * List of options to select from. Must be an array of SelectOption.
@@ -52,11 +58,6 @@
    * The ARIA label for this select component.
    */
   export let ariaLabel: string | undefined = undefined;
-
-  export let getLabel: (
-    value: Option | undefined,
-    labelKey?: string,
-  ) => string = defaultGetLabel;
 
   /**
    * By default, options will be compared by equality. If you're using objects as
@@ -119,7 +120,7 @@
     on:keydown={(e) => api.handleKeyDown(e)}
   >
     <svelte:fragment slot="trigger">
-      {getLabel(value, labelKey)}
+      <StringOrComponent arg={getLabel(value)} />
     </svelte:fragment>
 
     <svelte:fragment slot="content">


### PR DESCRIPTION
This PR cleans up `getLabel` props for a few components, with the following goals.

- Don't use a `labelKey` argument within the `getLabel` prop.

    Rationale: The consuming component has two ways of customizing the label. Either (a) via the `labelKey` prop, or (b) via the `getLabel` prop. When using (b), then (a) should be irrelevant. The `getLabel` function signature is simpler when it does not concern itself with `labelKey`.

- Allow `getLabel` to return an instance of `ComponentAndProps`.

- Make all `getLabel` props consistently use the type `LabelGetter<Option>` across all relevant components.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

