### PR TITLE
Unknown type bugfix

### DIFF
--- a/db/tests/columns/test_base.py
+++ b/db/tests/columns/test_base.py
@@ -197,7 +197,7 @@ def test_MC_plain_type_array_type(engine):
     assert mc.plain_type is None
 
 
-def test_MC_plain_type_array_type(engine):
+def test_MC_plain_type_json_type(engine):
     mc = MathesarColumn('testable_col', JSON())
     mc.add_engine(engine)
     assert mc.plain_type == "JSON"

--- a/db/tests/columns/test_base.py
+++ b/db/tests/columns/test_base.py
@@ -1,7 +1,9 @@
 import re
 
 import pytest
-from sqlalchemy import CHAR, ForeignKey, Integer, Numeric, String, VARCHAR, ARRAY
+from sqlalchemy import (
+    CHAR, ForeignKey, Integer, Numeric, String, VARCHAR, ARRAY, JSON
+)
 from sqlalchemy.sql.sqltypes import NullType
 
 from db.columns.base import MathesarColumn
@@ -193,6 +195,12 @@ def test_MC_plain_type_array_type(engine):
     mc = MathesarColumn('testable_col', ARRAY(Integer))
     mc.add_engine(engine)
     assert mc.plain_type is None
+
+
+def test_MC_plain_type_array_type(engine):
+    mc = MathesarColumn('testable_col', JSON())
+    mc.add_engine(engine)
+    assert mc.plain_type == "JSON"
 
 
 def test_MC_type_options_no_opts(engine):

--- a/db/tests/columns/test_base.py
+++ b/db/tests/columns/test_base.py
@@ -1,7 +1,8 @@
 import re
 
 import pytest
-from sqlalchemy import (CHAR, ForeignKey, Integer, Numeric, String, VARCHAR)
+from sqlalchemy import CHAR, ForeignKey, Integer, Numeric, String, VARCHAR, ARRAY
+from sqlalchemy.sql.sqltypes import NullType
 
 from db.columns.base import MathesarColumn
 from db.columns.defaults import DEFAULT_COLUMNS
@@ -180,6 +181,18 @@ def test_MC_plain_type_numeric_opts(engine):
     mc = MathesarColumn('testable_col', Numeric(5, 2))
     mc.add_engine(engine)
     assert mc.plain_type == "NUMERIC"
+
+
+def test_MC_plain_type_unknown_type(engine):
+    mc = MathesarColumn('testable_col', NullType())
+    mc.add_engine(engine)
+    assert mc.plain_type is None
+
+
+def test_MC_plain_type_array_type(engine):
+    mc = MathesarColumn('testable_col', ARRAY(Integer))
+    mc.add_engine(engine)
+    assert mc.plain_type is None
 
 
 def test_MC_type_options_no_opts(engine):


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1316 

<!-- Concisely describe what the pull request does. -->

This adds a couple lines to smoothly ignore exceptions that may occur when a type isn't recognized by SQLAlchemy.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

Because we rely on the SQLAlchemy class representing a DB type for creating strings to represent the type in the API, problems can occur when no such class exists. This PR modifies this behavior to simply return `null` when we don't understand a type.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
