### PR TITLE
Fix bug with locale number formatting

### DIFF
--- a/mathesar_ui/src/component-library/number-input/number-formatter/StringifiedNumberFormatter.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/StringifiedNumberFormatter.ts
@@ -4,8 +4,14 @@ import { makeFormatter } from './formatter';
 import { makeUniversalNumberParser } from './parsers';
 
 export default class StringifiedNumberFormatter extends AbstractNumberFormatter<string> {
-  format(value: string): string {
-    const parseResult = makeUniversalNumberParser(this.opts)(value);
+  format(canonicalStringifiedNumber: string): string {
+    const parseCanonical = makeUniversalNumberParser({
+      ...this.opts,
+      // Override the decimal separator because we're parsing a canonical
+      // stringified number.
+      decimalSeparator: '.',
+    });
+    const parseResult = parseCanonical(canonicalStringifiedNumber);
     switch (parseResult.value?.type) {
       case 'bigfloat':
         return parseResult.value.normalizedStringifiedNumber;
@@ -17,8 +23,9 @@ export default class StringifiedNumberFormatter extends AbstractNumberFormatter<
     }
   }
 
-  parse(input: string): ParseResult<string> {
-    const result = makeUniversalNumberParser(this.opts)(input);
+  parse(userInput: string): ParseResult<string> {
+    const parseUserInput = makeUniversalNumberParser(this.opts);
+    const result = parseUserInput(userInput);
     return {
       value: result.value?.normalizedStringifiedNumber ?? null,
       intermediateDisplay: result.intermediateDisplay,


### PR DESCRIPTION
This PR fixes a small bug with the following steps to reproduce:

## Reproduce

1. Set up a number column with numerical value `1234.567`.

1. Set "Format" to `1.234.567,89` (german).

1. Expect cell value to be formatted as `1.234,567`.

1. Observe cell value to be formatted as `1.234.567`.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

