### PR TITLE
Fix race condition bug in Link Table dialog

### DIFF
--- a/mathesar_ui/src/sections/table-view/link-table/LinkTableModal.svelte
+++ b/mathesar_ui/src/sections/table-view/link-table/LinkTableModal.svelte
@@ -56,17 +56,14 @@
   /** Name of column in the mapping table which references "that" table */
   let mappingToThatColumnName = '';
 
-  $: thisTable = (() => {
-    const t = $tables.data.get($tabularData.id);
-    if (!t) {
-      // This should never happen because the user shouldn't be able to open
-      // the modal if the table doesn't exist. But we throw an error here to
-      // make sure that `thisTable` is always defined.
-      throw new Error('Unable to configure a table ling without a base table');
-    }
-    return t;
-  })();
-  $: isSelfReferential = thisTable.id === thatTable?.id;
+  /**
+   * It's annoying that `thisTable` can be `undefined`, but this situation
+   * actually does happen when adding a new table via copy-paste CSV data
+   * because we open a tab for the table (and mount this component in the
+   * process) before the entry for the table is set into the `$tables` store.
+   */
+  $: thisTable = $tables.data.get($tabularData.id);
+  $: isSelfReferential = thisTable?.id === thatTable?.id;
   $: canProceed =
     thatTable &&
     thisHasManyOfThat !== undefined &&
@@ -99,10 +96,7 @@
     thisHasManyOfThat = undefined;
     thatHasManyOfThis = undefined;
     mappingTableName = getAvailableName(
-      // eslint is not smart enough to handle this, probably because of the IIFE
-      // used to assign thisTable.
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `${thisTable.name}_${_thatTable?.name ?? ''}`,
+      `${(thisTable?.name ?? '') as string}_${_thatTable?.name ?? ''}`,
       unavailableTableNames,
     );
   }
@@ -123,12 +117,12 @@
     }
     switch (_relationshipType) {
       case 'many-to-many':
-        mappingToThisColumnName = makeFkColumnName(thisTable.name);
+        mappingToThisColumnName = makeFkColumnName(thisTable?.name ?? '');
         mappingToThatColumnName = makeFkColumnName(thatTable.name);
         break;
       case 'one-to-many':
         thatNewColumnName = makeFkColumnName(
-          thisTable.name,
+          thisTable?.name ?? '',
           _namesOfColumnsInThatTable,
         );
         break;
@@ -163,7 +157,7 @@
 
 <ControlledModal {controller} on:open={init} size="large">
   <div slot="title">
-    Link <Identifier>{thisTable.name}</Identifier> to Another Table
+    Link <Identifier>{thisTable?.name}</Identifier> to Another Table
     <Help>
       <p>Associate records from this table with records from another table.</p>
       <p>
@@ -194,7 +188,7 @@
                   isInline
                 >
                   Can one
-                  <TableName name={thisTable.name} which="this" />
+                  <TableName name={thisTable?.name} which="this" />
                   record have multiple
                   <TableName name={thatTable.name} which="that" />
                   records?
@@ -211,7 +205,7 @@
                     Can one
                     <TableName name={thatTable.name} which="that" />
                     record have multiple
-                    <TableName name={thisTable.name} which="this" />
+                    <TableName name={thisTable?.name} which="this" />
                     records?
                   </RadioGroup>
                 </FormField>
@@ -255,7 +249,7 @@
                     Each
                     <TableName name={mappingTableName} which="mapping" />
                     record will reference one
-                    <TableName name={thisTable.name} which="this" />
+                    <TableName name={thisTable?.name} which="this" />
                     record using a column named:
                   </div>
                   <TextInput bind:value={mappingToThisColumnName} />
@@ -267,7 +261,7 @@
                     Each
                     <TableName name={mappingTableName} which="mapping" />
                     record will reference one
-                    <TableName name={thatTable?.name ?? ''} which="that" />
+                    <TableName name={thatTable?.name} which="that" />
                     record using a column named:
                   </div>
                   <TextInput bind:value={mappingToThatColumnName} />
@@ -278,7 +272,7 @@
                 <LabeledInput>
                   <div slot="label">
                     The
-                    <TableName name={thatTable?.name ?? ''} which="that" />
+                    <TableName name={thatTable?.name} which="that" />
                     table will get a new column named:
                   </div>
                   <TextInput bind:value={thatNewColumnName} />
@@ -286,9 +280,9 @@
               </FormField>
               <FormField>
                 Then each
-                <TableName name={thatTable?.name ?? ''} which="that" />
+                <TableName name={thatTable?.name} which="that" />
                 record will use that column to reference one
-                <TableName name={thisTable.name} which="this" />
+                <TableName name={thisTable?.name} which="this" />
                 record.
               </FormField>
             {:else if relationshipType === 'many-to-one'}
@@ -296,7 +290,7 @@
                 <LabeledInput>
                   <div slot="label">
                     The
-                    <TableName name={thisTable.name} which="this" />
+                    <TableName name={thisTable?.name} which="this" />
                     table will get a new column named:
                   </div>
                   <TextInput bind:value={thisNewColumnName} />
@@ -304,9 +298,9 @@
               </FormField>
               <FormField>
                 Then each
-                <TableName name={thisTable.name} which="this" />
+                <TableName name={thisTable?.name} which="this" />
                 record will use that column to reference one
-                <TableName name={thatTable?.name ?? ''} which="that" />
+                <TableName name={thatTable?.name} which="that" />
                 record.
               </FormField>
             {:else if relationshipType === 'one-to-one'}
@@ -314,7 +308,7 @@
                 <LabeledInput>
                   <div slot="label">
                     The
-                    <TableName name={thisTable.name} which="this" />
+                    <TableName name={thisTable?.name} which="this" />
                     table will get a new column named:
                   </div>
                   <TextInput bind:value={thisNewColumnName} />
@@ -322,17 +316,17 @@
               </FormField>
               <FormField>
                 Then each
-                <TableName name={thisTable.name} which="this" />
+                <TableName name={thisTable?.name} which="this" />
                 record will use that column to reference one
-                <TableName name={thatTable?.name ?? ''} which="that" />
+                <TableName name={thatTable?.name} which="that" />
                 record.
               </FormField>
               <FormField>
                 The
-                <TableName name={thisTable.name} which="this" />
+                <TableName name={thisTable?.name} which="this" />
                 table will also get a unique constraint ensuring that no two records
                 can reference the same
-                <TableName name={thatTable?.name ?? ''} which="that" />
+                <TableName name={thatTable?.name} which="that" />
                 record.
               </FormField>
             {/if}

--- a/mathesar_ui/src/sections/table-view/link-table/TableName.svelte
+++ b/mathesar_ui/src/sections/table-view/link-table/TableName.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Identifier from '@mathesar/components/Identifier.svelte';
 
-  export let name: string;
+  export let name = '';
   export let which: 'this' | 'that' | 'mapping';
 </script>
 


### PR DESCRIPTION
This PR fixes a small bug with the following repro steps...

1. "New Table" > "Import Data" > "Copy and Paste Text" > Paste the following, and click "Continue" and then "Finish Import".

    ```
    a,b
    2,3
    ```

1. When the tab for the new table loads, observe a JS error in the console. This is because the tab is opened before an entry in the `$tables` store exists, and when the tab is opened, the Link Table modal component mounts. (I put some code in that component that incorrectly assumed we'd always have an entry in the `$tables` store.)


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

