### PR TITLE
Duration frontend implementation

### DIFF
--- a/mathesar_ui/package-lock.json
+++ b/mathesar_ui/package-lock.json
@@ -15513,6 +15513,11 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "dayjs": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.1.tgz",
+      "integrity": "sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA=="
+    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",

--- a/mathesar_ui/package.json
+++ b/mathesar_ui/package.json
@@ -72,8 +72,9 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@popperjs/core": "^2.9.2",
-    "iter-tools": "^7.3.1",
+    "dayjs": "^1.11.1",
     "fast-diff": "^1.2.0",
+    "iter-tools": "^7.3.1",
     "js-cookie": "^2.2.1",
     "perfect-scrollbar": "^1.5.1"
   }

--- a/mathesar_ui/src/api/tables/columns.ts
+++ b/mathesar_ui/src/api/tables/columns.ts
@@ -1,5 +1,5 @@
 import type { DbType } from '@mathesar/AppTypes';
-import type { DurationUnit } from '@mathesar/utils/Duration';
+import type { DurationUnit } from '@mathesar/utils/duration/types';
 
 /**
  * | value     | example locale | example format |
@@ -110,6 +110,7 @@ export interface Column extends BaseColumn {
   display_options: Record<string, unknown> | null;
 }
 
+// TODO: Remove specification DB types here
 export interface NumberColumn extends Column {
   type:
     | 'BIGINT'

--- a/mathesar_ui/src/api/tables/columns.ts
+++ b/mathesar_ui/src/api/tables/columns.ts
@@ -1,4 +1,5 @@
 import type { DbType } from '@mathesar/AppTypes';
+import type { DurationUnit } from '@mathesar/utils/Duration';
 
 /**
  * | value     | example locale | example format |
@@ -76,8 +77,6 @@ export interface BooleanDisplayOptions extends Record<string, unknown> {
     FALSE: string;
   } | null;
 }
-
-export type DurationUnit = 'd' | 'h' | 'm' | 's' | 'ms';
 
 export interface DurationDisplayOptions extends Record<string, unknown> {
   min: DurationUnit | null;

--- a/mathesar_ui/src/api/tables/columns.ts
+++ b/mathesar_ui/src/api/tables/columns.ts
@@ -77,6 +77,14 @@ export interface BooleanDisplayOptions extends Record<string, unknown> {
   } | null;
 }
 
+export type DurationUnit = 'd' | 'h' | 'm' | 's' | 'ms';
+
+export interface DurationDisplayOptions extends Record<string, unknown> {
+  min: DurationUnit | null;
+  max: DurationUnit | null;
+  show_units: boolean | null;
+}
+
 export interface BaseColumn {
   id: number;
   name: string;

--- a/mathesar_ui/src/component-library/form-builder/FormBuilder.svelte
+++ b/mathesar_ui/src/component-library/form-builder/FormBuilder.svelte
@@ -20,6 +20,7 @@
       stores={form.stores}
       variables={form.variables}
       element={form.layout}
+      customComponents={form.customComponents}
       validationResult={$validationStore}
     />
   </form>

--- a/mathesar_ui/src/component-library/form-builder/FormCustomComponent.svelte
+++ b/mathesar_ui/src/component-library/form-builder/FormCustomComponent.svelte
@@ -6,16 +6,16 @@
   } from './types';
 
   export let componentId: FormStaticElement['componentId'];
-  export let props: FormStaticElement['props'];
+  export let props: FormStaticElement['props'] = undefined;
   export let stores: FormBuildConfiguration['stores'];
   export let store: FormValueStore;
   export let customComponents: FormBuildConfiguration['customComponents'];
 </script>
 
 {#if customComponents?.[componentId]}
-  <svlete:component
+  <svelte:component
     this={customComponents[componentId]}
-    {...props}
+    {...props ?? {}}
     {store}
     {stores}
   />

--- a/mathesar_ui/src/component-library/form-builder/FormCustomComponent.svelte
+++ b/mathesar_ui/src/component-library/form-builder/FormCustomComponent.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import type {
+    FormBuildConfiguration,
+    FormStaticElement,
+    FormValueStore,
+  } from './types';
+
+  export let componentId: FormStaticElement['componentId'];
+  export let props: FormStaticElement['props'];
+  export let stores: FormBuildConfiguration['stores'];
+  export let store: FormValueStore;
+  export let customComponents: FormBuildConfiguration['customComponents'];
+</script>
+
+{#if customComponents?.[componentId]}
+  <svlete:component
+    this={customComponents[componentId]}
+    {...props}
+    {store}
+    {stores}
+  />
+{/if}

--- a/mathesar_ui/src/component-library/form-builder/FormElement.svelte
+++ b/mathesar_ui/src/component-library/form-builder/FormElement.svelte
@@ -3,6 +3,7 @@
   import FormLayout from './FormLayout.svelte';
   import Switch from './Switch.svelte';
   import If from './If.svelte';
+  import FormCustomComponent from './FormCustomComponent.svelte';
   import type {
     FormElement,
     FormBuildConfiguration,
@@ -12,18 +13,26 @@
   export let element: FormElement;
   export let stores: FormBuildConfiguration['stores'];
   export let variables: FormBuildConfiguration['variables'];
+  export let customComponents: FormBuildConfiguration['customComponents'];
   export let validationResult: FormValidationResult;
 
   $: store = 'variable' in element ? stores.get(element.variable) : undefined;
+  $: variableType =
+    'variable' in element ? variables[element.variable].type : undefined;
 </script>
 
 {#if element.type === 'input' && store}
-  <FormInput
-    {...element}
-    {...variables[element.variable]}
-    {store}
-    validationErrors={validationResult.failedChecks[element.variable] || []}
-  />
+  {#if variableType && variableType !== 'custom'}
+    <FormInput
+      {...element}
+      {...variables[element.variable]}
+      type={variableType}
+      {store}
+      validationErrors={validationResult.failedChecks[element.variable] || []}
+    />
+  {/if}
+{:else if element.type === 'static' && store}
+  <FormCustomComponent {...element} {customComponents} {store} {stores} />
 {:else if element.type === 'switch' && store}
   <Switch {store} cases={element.cases} let:element={childElement}>
     <svelte:self {...$$props} element={childElement} />

--- a/mathesar_ui/src/component-library/form-builder/FormInput.svelte
+++ b/mathesar_ui/src/component-library/form-builder/FormInput.svelte
@@ -5,13 +5,13 @@
   import type { DynamicInputDataType } from '@mathesar-component-library-dir/dynamic-input/types';
   import type {
     FormInputElement,
-    FormInputStore,
+    FormValueStore,
     FormValidationCheck,
   } from './types';
 
   export let type: DynamicInputDataType;
   export let label: FormInputElement['label'] = undefined;
-  export let store: FormInputStore;
+  export let store: FormValueStore;
   export let validationErrors: FormValidationCheck[];
 </script>
 

--- a/mathesar_ui/src/component-library/form-builder/If.svelte
+++ b/mathesar_ui/src/component-library/form-builder/If.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { computeIfElements } from './utils';
-  import type { FormInputStore, ConditionalIfElement } from './types';
+  import type { FormValueStore, ConditionalIfElement } from './types';
 
-  export let store: FormInputStore;
+  export let store: FormValueStore;
   export let condition: ConditionalIfElement['condition'] = 'eq';
   export let value: ConditionalIfElement['value'];
   export let elements: ConditionalIfElement['elements'];

--- a/mathesar_ui/src/component-library/form-builder/Switch.svelte
+++ b/mathesar_ui/src/component-library/form-builder/Switch.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { computeSwitchElements } from './utils';
-  import type { FormInputStore, ConditionalSwitchElement } from './types';
+  import type { FormValueStore, ConditionalSwitchElement } from './types';
 
-  export let store: FormInputStore;
+  export let store: FormValueStore;
   export let cases: ConditionalSwitchElement['cases'];
 
   $: elementsToDisplay = computeSwitchElements($store, { cases });

--- a/mathesar_ui/src/component-library/form-builder/formFactory.ts
+++ b/mathesar_ui/src/component-library/form-builder/formFactory.ts
@@ -61,6 +61,7 @@ function getNamesOfConditionalVariables(element: FormElement): Set<string> {
 export function makeForm(
   formConfig: FormConfiguration,
   formValues?: FormValues,
+  customComponents?: FormBuildConfiguration['customComponents'],
 ): FormBuildConfiguration {
   const conditionalVariableNames = getNamesOfConditionalVariables(
     formConfig.layout,
@@ -161,5 +162,6 @@ export function makeForm(
     values,
     validationStore,
     getValidationResult,
+    customComponents,
   };
 }

--- a/mathesar_ui/src/component-library/form-builder/formFactory.ts
+++ b/mathesar_ui/src/component-library/form-builder/formFactory.ts
@@ -15,7 +15,7 @@ function getNamesOfVariablesInUse(
 ): Set<string> {
   const variablesInUse: Set<string> = new Set();
   let childElements: FormElement[] = [];
-  if (element.type === 'input') {
+  if (element.type === 'input' || element.type === 'static') {
     variablesInUse.add(element.variable);
   } else if (element.type === 'switch') {
     const valueOfVariable = values[element.variable];

--- a/mathesar_ui/src/component-library/form-builder/types.ts
+++ b/mathesar_ui/src/component-library/form-builder/types.ts
@@ -1,8 +1,6 @@
 import type { Readable, Writable } from 'svelte/store';
 import type { DynamicInputDataType } from '@mathesar-component-library-dir/dynamic-input/types';
 
-export type FormInputDataType = boolean | string | number | null;
-
 export interface FormInputBaseElement {
   type: 'input';
   interfaceType?: string;
@@ -57,15 +55,31 @@ export interface FormLayout {
 
 export type FormValidationCheck = 'isEmpty' | 'isInvalid';
 
-export interface FormConfigurationVariable {
+interface FormConfigurationBaseVariable {
   type: DynamicInputDataType;
-  default?: FormInputDataType;
-  enum?: unknown[];
+  default?: unknown;
   validation?: {
     checks: FormValidationCheck[];
     // TODO: Support specification of invalidation logic
   };
 }
+
+export interface FormConfigurationCustomVariable
+  extends FormConfigurationBaseVariable {
+  type: 'custom';
+  componentId: string;
+  componentProps: Record<string, unknown>;
+}
+
+export interface FormConfigurationEnumVariable
+  extends FormConfigurationBaseVariable {
+  enum?: unknown[];
+}
+
+export type FormConfigurationVariable =
+  | FormConfigurationBaseVariable
+  | FormConfigurationEnumVariable
+  | FormConfigurationCustomVariable;
 
 export type FormConfigurationVariables = Record<
   string,
@@ -77,9 +91,9 @@ export interface FormConfiguration {
   layout: FormLayout;
 }
 
-export type FormInputStore = Writable<FormInputDataType>;
+export type FormInputStore = Writable<unknown>;
 
-export type FormValues = Record<string, FormInputDataType>;
+export type FormValues = Record<string, unknown>;
 
 export interface FormValidationResult {
   isValid: boolean;

--- a/mathesar_ui/src/component-library/form-builder/types.ts
+++ b/mathesar_ui/src/component-library/form-builder/types.ts
@@ -1,3 +1,4 @@
+import type { SvelteComponent } from 'svelte';
 import type { Readable, Writable } from 'svelte/store';
 import type { DynamicInputDataType } from '@mathesar-component-library-dir/dynamic-input/types';
 
@@ -25,6 +26,13 @@ export interface FormInputSelectElement extends FormInputBaseElement {
   >;
 }
 
+export interface FormStaticElement {
+  type: 'static';
+  variable: string;
+  componentId: string;
+  props: Record<string, unknown>;
+}
+
 export type FormInputElement = FormInputBaseElement | FormInputSelectElement;
 
 export type ConditionalSwitchElement = {
@@ -45,7 +53,11 @@ export type ConditionalElement =
   | ConditionalSwitchElement
   | ConditionalIfElement;
 
-export type FormElement = FormInputElement | ConditionalElement | FormLayout;
+export type FormElement =
+  | FormInputElement
+  | ConditionalElement
+  | FormLayout
+  | FormStaticElement;
 
 export interface FormLayout {
   type?: 'layout';
@@ -55,31 +67,14 @@ export interface FormLayout {
 
 export type FormValidationCheck = 'isEmpty' | 'isInvalid';
 
-interface FormConfigurationBaseVariable {
-  type: DynamicInputDataType;
+export interface FormConfigurationVariable {
+  type: DynamicInputDataType | 'custom';
   default?: unknown;
+  enum?: unknown[];
   validation?: {
     checks: FormValidationCheck[];
-    // TODO: Support specification of invalidation logic
   };
 }
-
-export interface FormConfigurationCustomVariable
-  extends FormConfigurationBaseVariable {
-  type: 'custom';
-  componentId: string;
-  componentProps: Record<string, unknown>;
-}
-
-export interface FormConfigurationEnumVariable
-  extends FormConfigurationBaseVariable {
-  enum?: unknown[];
-}
-
-export type FormConfigurationVariable =
-  | FormConfigurationBaseVariable
-  | FormConfigurationEnumVariable
-  | FormConfigurationCustomVariable;
 
 export type FormConfigurationVariables = Record<
   string,
@@ -91,7 +86,7 @@ export interface FormConfiguration {
   layout: FormLayout;
 }
 
-export type FormInputStore = Writable<unknown>;
+export type FormValueStore = Writable<unknown>;
 
 export type FormValues = Record<string, unknown>;
 
@@ -101,8 +96,9 @@ export interface FormValidationResult {
 }
 
 export interface FormBuildConfiguration extends FormConfiguration {
-  stores: Map<string, FormInputStore>;
+  stores: Map<string, FormValueStore>;
   values: Readable<FormValues>;
   validationStore: Readable<FormValidationResult>;
   getValidationResult: () => FormValidationResult;
+  customComponents?: Record<string, typeof SvelteComponent>;
 }

--- a/mathesar_ui/src/component-library/form-builder/types.ts
+++ b/mathesar_ui/src/component-library/form-builder/types.ts
@@ -30,7 +30,7 @@ export interface FormStaticElement {
   type: 'static';
   variable: string;
   componentId: string;
-  props: Record<string, unknown>;
+  props?: Record<string, unknown>;
 }
 
 export type FormInputElement = FormInputBaseElement | FormInputSelectElement;

--- a/mathesar_ui/src/component-library/form-builder/utils.ts
+++ b/mathesar_ui/src/component-library/form-builder/utils.ts
@@ -1,12 +1,11 @@
 import type {
-  FormInputDataType,
   ConditionalIfElement,
   ConditionalSwitchElement,
   FormElement,
 } from './types';
 
 function checkCondition(
-  term: FormInputDataType,
+  term: unknown,
   condition: ConditionalIfElement['condition'],
   value: ConditionalIfElement['value'],
 ): boolean {
@@ -20,7 +19,7 @@ function checkCondition(
 }
 
 export function computeSwitchElements(
-  storeValue: FormInputDataType,
+  storeValue: unknown,
   switchArgs: { cases: ConditionalSwitchElement['cases'] },
 ): FormElement[] {
   const { cases } = switchArgs;
@@ -28,7 +27,7 @@ export function computeSwitchElements(
 }
 
 export function computeIfElements(
-  storeValue: FormInputDataType,
+  storeValue: unknown,
   ifArgs: {
     condition: ConditionalIfElement['condition'];
     value: ConditionalIfElement['value'];

--- a/mathesar_ui/src/component-library/index.ts
+++ b/mathesar_ui/src/component-library/index.ts
@@ -38,6 +38,7 @@ export { AttachableDropdown, Dropdown } from './dropdown';
 export { default as DropdownMenu } from './dropdown-menu/DropdownMenu.svelte';
 export { default as DynamicInput } from './dynamic-input/DynamicInput.svelte';
 export { default as FileUpload } from './file-upload/FileUpload.svelte';
+export { default as FormattedInput } from './formatted-input/FormattedInput.svelte';
 export { default as Notification } from './notification/Notification.svelte';
 export { ListBox, ListBoxOptions } from './list-box';
 export { default as Pagination } from './pagination/Pagination.svelte';

--- a/mathesar_ui/src/component-library/types.ts
+++ b/mathesar_ui/src/component-library/types.ts
@@ -7,6 +7,7 @@ export type { TreeItem } from './tree/TreeTypes';
 export type { ComponentAndProps } from './common/types/ComponentAndPropsTypes';
 export * from './icon/IconTypes';
 export * from './file-upload/FileUploadTypes';
+export * from './formatted-input/FormattedInputTypes';
 export * from './dynamic-input/types';
 export * from './form-builder/types';
 export * from './cancel-or-proceed-button-pair/CancelOrProceedButtonPairTypes';

--- a/mathesar_ui/src/components/cell/data-types/components/formatted-input/FormattedInputCell.svelte
+++ b/mathesar_ui/src/components/cell/data-types/components/formatted-input/FormattedInputCell.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { FormattedInput } from '@mathesar-component-library';
+  import SteppedInputCell from '../SteppedInputCell.svelte';
+  import type { DurationCellProps } from '../typeDefinitions';
+
+  type $$Props = DurationCellProps;
+
+  export let isActive: $$Props['isActive'];
+  export let value: $$Props['value'];
+  export let disabled: $$Props['disabled'];
+
+  export let formatter: $$Props['formatter'];
+</script>
+
+<SteppedInputCell
+  {value}
+  {isActive}
+  {disabled}
+  horizontalAlignment="right"
+  let:handleInputBlur
+  let:handleInputKeydown
+  on:movementKeyDown
+  on:activate
+  on:update
+>
+  <FormattedInput
+    focusOnMount={true}
+    {...$$restProps}
+    bind:value
+    {formatter}
+    on:blur={handleInputBlur}
+    on:keydown={handleInputKeydown}
+  />
+</SteppedInputCell>

--- a/mathesar_ui/src/components/cell/data-types/components/formatted-input/FormattedInputCell.svelte
+++ b/mathesar_ui/src/components/cell/data-types/components/formatted-input/FormattedInputCell.svelte
@@ -1,15 +1,27 @@
 <script lang="ts">
-  import { FormattedInput } from '@mathesar-component-library';
+  import {
+    FormattedInput,
+    isDefinedNonNullable,
+  } from '@mathesar-component-library';
   import SteppedInputCell from '../SteppedInputCell.svelte';
-  import type { DurationCellProps } from '../typeDefinitions';
+  import type { FormattedInputCellProps } from '../typeDefinitions';
 
-  type $$Props = DurationCellProps;
+  type $$Props = FormattedInputCellProps;
 
   export let isActive: $$Props['isActive'];
   export let value: $$Props['value'];
   export let disabled: $$Props['disabled'];
 
   export let formatter: $$Props['formatter'];
+
+  function formatValue(
+    v: string | null | undefined,
+  ): string | null | undefined {
+    if (!isDefinedNonNullable(v)) {
+      return v;
+    }
+    return formatter.format(v);
+  }
 </script>
 
 <SteppedInputCell
@@ -19,6 +31,7 @@
   horizontalAlignment="right"
   let:handleInputBlur
   let:handleInputKeydown
+  {formatValue}
   on:movementKeyDown
   on:activate
   on:update
@@ -30,5 +43,6 @@
     {formatter}
     on:blur={handleInputBlur}
     on:keydown={handleInputKeydown}
+    --input-element-text-align="right"
   />
 </SteppedInputCell>

--- a/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
@@ -1,5 +1,7 @@
-import type { SelectProps } from '@mathesar-component-library/types';
-import type { DurationFormatter } from '@mathesar/utils/duration/types';
+import type {
+  FormattedInputProps,
+  SelectProps,
+} from '@mathesar-component-library/types';
 
 export interface CellTypeProps<Value> {
   value: Value | null | undefined;
@@ -54,12 +56,13 @@ export interface SingleSelectCellProps<Option>
 
 // Duration
 
-export interface DurationCellExternalProps {
-  formatter: DurationFormatter;
-}
+export type FormattedInputCellExternalProps = Omit<
+  FormattedInputProps<string>,
+  'disabled' | 'value'
+>;
 
-export interface DurationCellProps
+export interface FormattedInputCellProps
   extends CellTypeProps<string>,
-    DurationCellExternalProps {}
+    FormattedInputCellExternalProps {}
 
 export type HorizontalAlignment = 'left' | 'right' | 'center';

--- a/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
@@ -1,4 +1,5 @@
 import type { SelectProps } from '@mathesar-component-library/types';
+import type { DurationFormatter } from '@mathesar/utils/duration/types';
 
 export interface CellTypeProps<Value> {
   value: Value | null | undefined;
@@ -50,5 +51,15 @@ export type SingleSelectCellExternalProps<Option> = Pick<
 export interface SingleSelectCellProps<Option>
   extends CellTypeProps<Option>,
     SingleSelectCellExternalProps<Option> {}
+
+// Duration
+
+export interface DurationCellExternalProps {
+  formatter: DurationFormatter;
+}
+
+export interface DurationCellProps
+  extends CellTypeProps<string>,
+    DurationCellExternalProps {}
 
 export type HorizontalAlignment = 'left' | 'right' | 'center';

--- a/mathesar_ui/src/components/cell/data-types/duration.ts
+++ b/mathesar_ui/src/components/cell/data-types/duration.ts
@@ -1,0 +1,45 @@
+import { FormattedInput } from '@mathesar-component-library';
+import type {
+  ComponentAndProps,
+  FormattedInputProps,
+} from '@mathesar-component-library/types';
+import type { DurationDisplayOptions } from '@mathesar/api/tables/columns';
+import {
+  DurationFormatter,
+  DurationSpecification,
+} from '@mathesar/utils/duration';
+import FormattedInputCell from './components/formatted-input/FormattedInputCell.svelte';
+import type { DurationCellExternalProps } from './components/typeDefinitions';
+import type { CellComponentFactory, CellColumnLike } from './typeDefinitions';
+
+export interface DurationLikeColumn extends CellColumnLike {
+  display_options: Partial<DurationDisplayOptions> | null;
+}
+
+function getProps(column: DurationLikeColumn): DurationCellExternalProps {
+  const defaults = DurationSpecification.getDefaults();
+  const max = column.display_options?.max ?? defaults.max;
+  const min = column.display_options?.min ?? defaults.min;
+  const durationSpecification = new DurationSpecification({ max, min });
+  const formatter = new DurationFormatter(durationSpecification);
+  return {
+    formatter,
+  };
+}
+
+const durationType: CellComponentFactory = {
+  get: (
+    column: DurationLikeColumn,
+  ): ComponentAndProps<DurationCellExternalProps> => ({
+    component: FormattedInputCell,
+    props: getProps(column),
+  }),
+  getInput: (
+    column: DurationLikeColumn,
+  ): ComponentAndProps<FormattedInputProps<string>> => ({
+    component: FormattedInput,
+    props: getProps(column),
+  }),
+};
+
+export default durationType;

--- a/mathesar_ui/src/components/cell/data-types/duration.ts
+++ b/mathesar_ui/src/components/cell/data-types/duration.ts
@@ -9,14 +9,14 @@ import {
   DurationSpecification,
 } from '@mathesar/utils/duration';
 import FormattedInputCell from './components/formatted-input/FormattedInputCell.svelte';
-import type { DurationCellExternalProps } from './components/typeDefinitions';
+import type { FormattedInputCellExternalProps } from './components/typeDefinitions';
 import type { CellComponentFactory, CellColumnLike } from './typeDefinitions';
 
 export interface DurationLikeColumn extends CellColumnLike {
   display_options: Partial<DurationDisplayOptions> | null;
 }
 
-function getProps(column: DurationLikeColumn): DurationCellExternalProps {
+function getProps(column: DurationLikeColumn): FormattedInputCellExternalProps {
   const defaults = DurationSpecification.getDefaults();
   const max = column.display_options?.max ?? defaults.max;
   const min = column.display_options?.min ?? defaults.min;
@@ -24,13 +24,14 @@ function getProps(column: DurationLikeColumn): DurationCellExternalProps {
   const formatter = new DurationFormatter(durationSpecification);
   return {
     formatter,
+    placeholder: durationSpecification.getFormattingString(),
   };
 }
 
 const durationType: CellComponentFactory = {
   get: (
     column: DurationLikeColumn,
-  ): ComponentAndProps<DurationCellExternalProps> => ({
+  ): ComponentAndProps<FormattedInputCellExternalProps> => ({
     component: FormattedInputCell,
     props: getProps(column),
   }),

--- a/mathesar_ui/src/components/cell/data-types/index.ts
+++ b/mathesar_ui/src/components/cell/data-types/index.ts
@@ -1,12 +1,14 @@
 import string from './string';
 import boolean from './boolean';
 import number from './number';
+import duration from './duration';
 import type { CellDataType, CellComponentFactory } from './typeDefinitions';
 
 const dataTypeComponentFactories: Record<CellDataType, CellComponentFactory> = {
   string,
   boolean,
   number,
+  duration,
 };
 
 export default dataTypeComponentFactories;

--- a/mathesar_ui/src/components/cell/data-types/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell/data-types/typeDefinitions.ts
@@ -5,7 +5,7 @@ import type { ComponentAndProps } from '@mathesar-component-library/types';
 // different from db types.
 // One frontend type can map to multiple db types
 // Yet to add: 'uri' | 'money' | 'date' | 'time' | 'datetime'
-export type CellDataType = 'string' | 'boolean' | 'number';
+export type CellDataType = 'string' | 'boolean' | 'number' | 'duration';
 
 export type CellColumnLike = Pick<
   Column,

--- a/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
+++ b/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { Writable } from 'svelte/store';
+  import type { DurationUnit } from '@mathesar/api/tables/columns';
+  import { LabeledInput, Select } from '@mathesar-component-library';
+  import type { FormValues } from '@mathesar-component-library/types';
+
+  interface DurationFormValues extends FormValues {
+    min: DurationUnit;
+    max: DurationUnit;
+  }
+
+  export let store: Writable<DurationFormValues>;
+
+  const options: DurationUnit[] = ['d', 'h', 'm', 's', 'ms'];
+  const labels: Record<DurationUnit, string> = {
+    d: 'days',
+    h: 'hours',
+    m: 'minutes',
+    s: 'seconds',
+    ms: 'milliseconds',
+  };
+  const getLabel = (opt?: DurationUnit) => (opt && labels[opt]) ?? '';
+</script>
+
+<div class="form-element form-input">
+  <LabeledInput label="Max Time Unit" layout="stacked">
+    <Select {options} bind:value={$store.max} {getLabel} />
+  </LabeledInput>
+</div>
+
+<div class="form-element form-input">
+  <LabeledInput label="Min Time Unit" layout="stacked">
+    <Select {options} bind:value={$store.min} {getLabel} />
+  </LabeledInput>
+</div>
+
+<div class="form-element">Format:</div>

--- a/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
+++ b/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
   import type { Writable } from 'svelte/store';
-  import type { DurationUnit } from '@mathesar/api/tables/columns';
+  import type { DurationUnit } from '@mathesar/utils/Duration';
   import { LabeledInput, Select } from '@mathesar-component-library';
   import type { FormValues } from '@mathesar-component-library/types';
+  import Duration from '@mathesar/utils/Duration';
+  import type { DurationConfig } from '@mathesar/utils/Duration';
 
-  interface DurationFormValues extends FormValues {
-    min: DurationUnit;
-    max: DurationUnit;
-  }
+  interface DurationFormValues extends FormValues, DurationConfig {}
 
   export let store: Writable<DurationFormValues>;
 
-  const options: DurationUnit[] = ['d', 'h', 'm', 's', 'ms'];
+  const options: DurationUnit[] = Duration.getAllUnits();
   const labels: Record<DurationUnit, string> = {
     d: 'days',
     h: 'hours',
@@ -21,20 +20,7 @@
   };
   const getLabel = (opt?: DurationUnit) => (opt && labels[opt]) ?? '';
 
-  function calculateFormat(_storeValue: DurationFormValues): string {
-    const range = options.slice(
-      options.indexOf(_storeValue.max),
-      options.indexOf(_storeValue.min) + 1,
-    );
-    if (range[range.length - 1] === 'ms') {
-      return `${range.slice(0, range.length - 1).join(':')}.${
-        range[range.length - 1]
-      }`;
-    }
-    return range.join(':');
-  }
-
-  $: format = calculateFormat($store);
+  $: format = new Duration($store).getFormattingString();
 
   function onMaxChange(_max?: DurationUnit) {
     if (!_max) return;

--- a/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
+++ b/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
   import type { Writable } from 'svelte/store';
-  import type { DurationUnit } from '@mathesar/utils/Duration';
   import { LabeledInput, Select } from '@mathesar-component-library';
+  import type {
+    DurationUnit,
+    DurationConfig,
+  } from '@mathesar/utils/duration/types';
   import type { FormValues } from '@mathesar-component-library/types';
-  import Duration from '@mathesar/utils/Duration';
-  import type { DurationConfig } from '@mathesar/utils/Duration';
+  import { DurationSpecification } from '@mathesar/utils/duration';
 
   interface DurationFormValues extends FormValues, DurationConfig {}
 
   export let store: Writable<DurationFormValues>;
 
-  const options: DurationUnit[] = Duration.getAllUnits();
+  const options: DurationUnit[] = DurationSpecification.getAllUnits();
   const labels: Record<DurationUnit, string> = {
     d: 'days',
     h: 'hours',
@@ -20,7 +22,7 @@
   };
   const getLabel = (opt?: DurationUnit) => (opt && labels[opt]) ?? '';
 
-  $: format = new Duration($store).getFormattingString();
+  $: format = new DurationSpecification($store).getFormattingString();
 
   function onMaxChange(_max?: DurationUnit) {
     if (!_max) return;

--- a/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
+++ b/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/config-components/DurationConfiguration.svelte
@@ -20,18 +20,83 @@
     ms: 'milliseconds',
   };
   const getLabel = (opt?: DurationUnit) => (opt && labels[opt]) ?? '';
+
+  function calculateFormat(_storeValue: DurationFormValues): string {
+    const range = options.slice(
+      options.indexOf(_storeValue.max),
+      options.indexOf(_storeValue.min) + 1,
+    );
+    if (range[range.length - 1] === 'ms') {
+      return `${range.slice(0, range.length - 1).join(':')}.${
+        range[range.length - 1]
+      }`;
+    }
+    return range.join(':');
+  }
+
+  $: format = calculateFormat($store);
+
+  function onMaxChange(_max?: DurationUnit) {
+    if (!_max) return;
+    let { min } = $store;
+    if (options.indexOf(_max) > options.indexOf($store.min)) {
+      min = _max;
+    }
+    $store = {
+      ...$store,
+      max: _max,
+      min,
+    };
+  }
+
+  function onMinChange(_min?: DurationUnit) {
+    if (!_min) return;
+    let { max } = $store;
+    if (options.indexOf(_min) < options.indexOf($store.max)) {
+      max = _min;
+    }
+    $store = {
+      ...$store,
+      max,
+      min: _min,
+    };
+  }
 </script>
 
 <div class="form-element form-input">
   <LabeledInput label="Max Time Unit" layout="stacked">
-    <Select {options} bind:value={$store.max} {getLabel} />
+    <Select
+      {options}
+      value={$store.max}
+      {getLabel}
+      on:change={(e) => onMaxChange(e.detail)}
+    />
   </LabeledInput>
 </div>
 
 <div class="form-element form-input">
   <LabeledInput label="Min Time Unit" layout="stacked">
-    <Select {options} bind:value={$store.min} {getLabel} />
+    <Select
+      {options}
+      value={$store.min}
+      {getLabel}
+      on:change={(e) => onMinChange(e.detail)}
+    />
   </LabeledInput>
 </div>
 
-<div class="form-element">Format:</div>
+<div class="form-element format">
+  Format: <span>{format}</span>
+</div>
+
+<style lang="scss">
+  .format {
+    margin-top: 1rem;
+    span {
+      padding: 0.3rem 0.5rem;
+      border-radius: 0.2rem;
+      font-weight: 500;
+      background: #efefef;
+    }
+  }
+</style>

--- a/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/utils.ts
+++ b/mathesar_ui/src/sections/table-view/header/header-cell/abstract-type-configuration/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from '@mathesar/stores/abstract-types/types';
 import type { Column } from '@mathesar/stores/table-data/types';
 import { readable } from 'svelte/store';
+import DurationConfiguration from './config-components/DurationConfiguration.svelte';
 
 export function getFormValueStore(
   form: FormBuildConfiguration | undefined,
@@ -66,7 +67,9 @@ export function constructDisplayForm(
             column.display_options,
           )
         : {};
-    displayForm = makeForm(displayOptionsConfig.form, displayFormValues);
+    displayForm = makeForm(displayOptionsConfig.form, displayFormValues, {
+      'duration-config-menu': DurationConfiguration,
+    });
   }
   const displayFormValues = getFormValueStore(displayForm);
   return {

--- a/mathesar_ui/src/sections/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/sections/table-view/row/RowCell.svelte
@@ -64,11 +64,13 @@
   async function setValue(newValue: unknown) {
     if (newValue !== value) {
       value = newValue;
+      let updatedRow;
       if (row.isNew) {
-        await recordsData.createOrUpdateRecord(row, column);
+        updatedRow = await recordsData.createOrUpdateRecord(row, column);
       } else {
-        await recordsData.updateCell(row, column);
+        updatedRow = await recordsData.updateCell(row, column);
       }
+      value = updatedRow.record?.[column.id] ?? value;
     }
   }
 

--- a/mathesar_ui/src/stores/abstract-types/abstractTypeCategories.ts
+++ b/mathesar_ui/src/stores/abstract-types/abstractTypeCategories.ts
@@ -3,6 +3,7 @@ import { abstractTypeCategory } from './constants';
 import Text from './type-configs/text';
 import Number from './type-configs/number';
 import Boolean from './type-configs/boolean';
+import Duration from './type-configs/duration';
 import Fallback from './type-configs/fallback';
 import type {
   AbstractType,
@@ -22,6 +23,7 @@ const abstractTypeCategories: Partial<
   [abstractTypeCategory.Text]: Text,
   [abstractTypeCategory.Number]: Number,
   [abstractTypeCategory.Boolean]: Boolean,
+  [abstractTypeCategory.Duration]: Duration,
   [abstractTypeCategory.Other]: Fallback,
 };
 

--- a/mathesar_ui/src/stores/abstract-types/type-configs/duration.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/duration.ts
@@ -1,13 +1,13 @@
 import type { FormValues } from '@mathesar-component-library/types';
 import type { Column } from '@mathesar/stores/table-data/types';
 import type { DurationDisplayOptions } from '@mathesar/api/tables/columns';
-import DurationUtils from '@mathesar/utils/Duration';
+import { DurationSpecification } from '@mathesar/utils/duration';
 import type {
   AbstractTypeConfigForm,
   AbstractTypeConfiguration,
 } from '../types';
 
-const durationDefaults = DurationUtils.getDefaults();
+const durationDefaults = DurationSpecification.getDefaults();
 
 const displayForm: AbstractTypeConfigForm = {
   variables: {
@@ -64,7 +64,7 @@ function constructDisplayFormValuesFromDisplayOptions(
 const durationType: AbstractTypeConfiguration = {
   icon: ':',
   cell: {
-    type: 'string',
+    type: 'duration',
   },
   getDisplayConfig: () => ({
     form: displayForm,

--- a/mathesar_ui/src/stores/abstract-types/type-configs/duration.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/duration.ts
@@ -1,0 +1,76 @@
+import type { FormValues } from '@mathesar-component-library/types';
+import type { Column } from '@mathesar/stores/table-data/types';
+import type { DurationDisplayOptions } from '@mathesar/api/tables/columns';
+import type {
+  AbstractTypeConfigForm,
+  AbstractTypeConfiguration,
+} from '../types';
+
+const defaultMax = 'm';
+const defaultMin = 's';
+
+const displayForm: AbstractTypeConfigForm = {
+  variables: {
+    /**
+     * For the sake of time, use a custom component
+     * for duration config.
+     *
+     * TODO: Make this serializable instead of the
+     * custom component.
+     */
+    durationConfig: {
+      type: 'custom',
+      default: {
+        max: defaultMax,
+        min: defaultMin,
+      },
+    },
+  },
+  layout: {
+    orientation: 'vertical',
+    elements: [
+      {
+        type: 'static',
+        variable: 'durationConfig',
+        componentId: 'duration-config-menu',
+      },
+    ],
+  },
+};
+
+function determineDisplayOptions(
+  dispFormValues: FormValues,
+): Column['display_options'] {
+  const displayOptions: Column['display_options'] = {
+    ...(dispFormValues.durationConfig as Record<string, unknown>),
+    show_units: false,
+  };
+  return displayOptions;
+}
+
+function constructDisplayFormValuesFromDisplayOptions(
+  columnDisplayOpts: Column['display_options'],
+): FormValues {
+  const displayOptions = columnDisplayOpts as DurationDisplayOptions | null;
+  const dispFormValues: FormValues = {
+    durationConfig: {
+      max: displayOptions?.max ?? defaultMax,
+      min: displayOptions?.min ?? defaultMin,
+    },
+  };
+  return dispFormValues;
+}
+
+const durationType: AbstractTypeConfiguration = {
+  icon: ':',
+  cell: {
+    type: 'string',
+  },
+  getDisplayConfig: () => ({
+    form: displayForm,
+    determineDisplayOptions,
+    constructDisplayFormValuesFromDisplayOptions,
+  }),
+};
+
+export default durationType;

--- a/mathesar_ui/src/stores/abstract-types/type-configs/duration.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/duration.ts
@@ -1,13 +1,13 @@
 import type { FormValues } from '@mathesar-component-library/types';
 import type { Column } from '@mathesar/stores/table-data/types';
 import type { DurationDisplayOptions } from '@mathesar/api/tables/columns';
+import DurationUtils from '@mathesar/utils/Duration';
 import type {
   AbstractTypeConfigForm,
   AbstractTypeConfiguration,
 } from '../types';
 
-const defaultMax = 'm';
-const defaultMin = 's';
+const durationDefaults = DurationUtils.getDefaults();
 
 const displayForm: AbstractTypeConfigForm = {
   variables: {
@@ -21,8 +21,8 @@ const displayForm: AbstractTypeConfigForm = {
     durationConfig: {
       type: 'custom',
       default: {
-        max: defaultMax,
-        min: defaultMin,
+        max: durationDefaults.max,
+        min: durationDefaults.min,
       },
     },
   },
@@ -54,8 +54,8 @@ function constructDisplayFormValuesFromDisplayOptions(
   const displayOptions = columnDisplayOpts as DurationDisplayOptions | null;
   const dispFormValues: FormValues = {
     durationConfig: {
-      max: displayOptions?.max ?? defaultMax,
-      min: displayOptions?.min ?? defaultMin,
+      max: displayOptions?.max ?? durationDefaults.max,
+      min: displayOptions?.min ?? durationDefaults.min,
     },
   };
   return dispFormValues;

--- a/mathesar_ui/src/stores/abstract-types/types.ts
+++ b/mathesar_ui/src/stores/abstract-types/types.ts
@@ -19,9 +19,10 @@ export interface AbstractTypeResponse {
   db_types: DbType[];
 }
 
-type AbstractTypeConfigFormVariable = FormConfigurationVariable & {
+export interface AbstractTypeConfigFormVariable
+  extends FormConfigurationVariable {
   conditionalDefault?: Record<DbType, unknown>;
-};
+}
 
 export interface AbstractTypeConfigForm extends FormConfiguration {
   variables: Record<string, AbstractTypeConfigFormVariable>;

--- a/mathesar_ui/src/stores/abstract-types/types.ts
+++ b/mathesar_ui/src/stores/abstract-types/types.ts
@@ -1,7 +1,6 @@
 import type {
   FormConfiguration,
   FormConfigurationVariable,
-  FormInputDataType,
   FormValues,
 } from '@mathesar-component-library/types';
 import type { CellDataType } from '@mathesar/components/cell/data-types/typeDefinitions';
@@ -20,9 +19,10 @@ export interface AbstractTypeResponse {
   db_types: DbType[];
 }
 
-interface AbstractTypeConfigFormVariable extends FormConfigurationVariable {
-  conditionalDefault?: Record<DbType, FormInputDataType>;
-}
+type AbstractTypeConfigFormVariable = FormConfigurationVariable & {
+  conditionalDefault?: Record<DbType, unknown>;
+};
+
 export interface AbstractTypeConfigForm extends FormConfiguration {
   variables: Record<string, AbstractTypeConfigFormVariable>;
 }

--- a/mathesar_ui/src/stores/table-data/filtering.ts
+++ b/mathesar_ui/src/stores/table-data/filtering.ts
@@ -6,9 +6,9 @@ import type {
 } from '@mathesar/api/tables/records';
 
 export interface FilterEntry {
-  columnId: number;
-  conditionId: string;
-  value: unknown;
+  readonly columnId: number;
+  readonly conditionId: string;
+  readonly value: unknown;
 }
 
 function makeApiFilterCondition(filterEntry: FilterEntry): FilterCondition {

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -401,17 +401,19 @@ export class RecordsData {
     }
   }
 
-  async updateCell(row: Row, column: Column): Promise<void> {
+  // TODO: It would be better to throw errors instead of silently failing
+  // and returning a value.
+  async updateCell(row: Row, column: Column): Promise<Row> {
     const { record } = row;
     if (!record) {
       console.error('Unable to update row that does not have a record');
-      return;
+      return row;
     }
     const { primaryKeyColumnId } = this.columnsDataStore.get();
     if (!primaryKeyColumnId) {
       // eslint-disable-next-line no-console
       console.error('Unable to update record for a row without a primary key');
-      return;
+      return row;
     }
     const primaryKeyValue = record[primaryKeyColumnId];
     if (primaryKeyValue === undefined) {
@@ -419,13 +421,13 @@ export class RecordsData {
       console.error(
         'Unable to update record for a row with a missing primary key value',
       );
-      return;
+      return row;
     }
     const rowKey = getRowKey(row, primaryKeyColumnId);
     const cellKey = getCellKey(rowKey, column.id);
     this.meta.cellModificationStatus.set(cellKey, { state: 'processing' });
     this.updatePromises?.get(cellKey)?.cancel();
-    const promise = patchAPI<unknown>(
+    const promise = patchAPI<ApiRecord>(
       `${this.url}${String(primaryKeyValue)}/`,
       { [column.id]: record[column.id] },
     );
@@ -435,8 +437,12 @@ export class RecordsData {
     this.updatePromises.set(cellKey, promise);
 
     try {
-      await promise;
+      const result = await promise;
       this.meta.cellModificationStatus.set(cellKey, { state: 'success' });
+      return {
+        ...row,
+        record: result,
+      };
     } catch (err) {
       this.meta.cellModificationStatus.set(cellKey, {
         state: 'failure',
@@ -447,6 +453,7 @@ export class RecordsData {
         this.updatePromises.delete(cellKey);
       }
     }
+    return row;
   }
 
   getNewEmptyRecord(): Row {
@@ -468,7 +475,7 @@ export class RecordsData {
     return newRecord;
   }
 
-  async createRecord(row: Row): Promise<void> {
+  async createRecord(row: Row): Promise<Row> {
     const { primaryKeyColumnId } = this.columnsDataStore.get();
     const rowKeyOfBlankRow = getRowKey(row, primaryKeyColumnId);
     this.meta.rowCreationStatus.set(rowKeyOfBlankRow, { state: 'processing' });
@@ -498,6 +505,7 @@ export class RecordsData {
         }),
       );
       this.totalCount.update((count) => (count ?? 0) + 1);
+      return newRow;
     } catch (err) {
       this.meta.rowCreationStatus.set(rowKeyOfBlankRow, {
         state: 'failure',
@@ -508,9 +516,10 @@ export class RecordsData {
         this.createPromises.delete(rowKeyOfBlankRow);
       }
     }
+    return row;
   }
 
-  async createOrUpdateRecord(row: Row, column: Column): Promise<void> {
+  async createOrUpdateRecord(row: Row, column: Column): Promise<Row> {
     const { primaryKeyColumnId } = this.columnsDataStore.get();
 
     // Row may not have been updated yet in view when additional request is made.
@@ -529,16 +538,18 @@ export class RecordsData {
       });
     }
 
+    let result = row;
     if (
       primaryKeyColumnId &&
       !existingNewRecordRow?.record?.[primaryKeyColumnId] &&
       row.isNew &&
       !row.record?.[primaryKeyColumnId]
     ) {
-      await this.createRecord(row);
+      result = await this.createRecord(row);
     } else {
-      await this.updateCell(row, column);
+      result = await this.updateCell(row, column);
     }
+    return result;
   }
 
   async addEmptyRecord(): Promise<void> {

--- a/mathesar_ui/src/utils/Duration.ts
+++ b/mathesar_ui/src/utils/Duration.ts
@@ -1,0 +1,44 @@
+export type DurationUnit = 'd' | 'h' | 'm' | 's' | 'ms';
+
+export interface DurationConfig {
+  max: DurationUnit;
+  min: DurationUnit;
+}
+
+const allUnits: DurationUnit[] = ['d', 'h', 'm', 's', 'ms'];
+const defaults: DurationConfig = {
+  max: 'm',
+  min: 's',
+};
+
+export default class Duration {
+  private min: DurationUnit;
+
+  private max: DurationUnit;
+
+  constructor(config?: Partial<DurationConfig>) {
+    this.min = config?.min ?? defaults.min;
+    this.max = config?.max ?? defaults.max;
+  }
+
+  getFormattingString(): string {
+    const range = allUnits.slice(
+      allUnits.indexOf(this.max),
+      allUnits.indexOf(this.min) + 1,
+    );
+    if (range[range.length - 1] === 'ms') {
+      return `${range.slice(0, range.length - 1).join(':')}.${
+        range[range.length - 1]
+      }`;
+    }
+    return range.join(':');
+  }
+
+  static getAllUnits(): DurationUnit[] {
+    return allUnits;
+  }
+
+  static getDefaults(): DurationConfig {
+    return defaults;
+  }
+}

--- a/mathesar_ui/src/utils/duration/DurationFormatter.ts
+++ b/mathesar_ui/src/utils/duration/DurationFormatter.ts
@@ -1,8 +1,165 @@
+import dayjs from 'dayjs';
+import durationPlugin from 'dayjs/plugin/duration';
+import type { Duration, DurationUnitType } from 'dayjs/plugin/duration';
 import type {
   InputFormatter,
   ParseResult,
 } from '@mathesar-component-library/types';
 import type DurationSpecification from './DurationSpecification';
+import type { DurationUnit } from './DurationSpecification';
+
+dayjs.extend(durationPlugin);
+
+const FLOAT_REGEX = /^((\.?\d+)|(\d+(\.\d+)?))$/;
+
+function parseRawDurationStringToISOString(
+  specification: DurationSpecification,
+  userInput: string,
+): string {
+  let unitsInRange = specification.getUnitsInRange();
+  if (unitsInRange[unitsInRange.length - 1] === 'ms') {
+    unitsInRange = unitsInRange.slice(0, unitsInRange.length - 1);
+  }
+
+  let cleanedInput = userInput.trim();
+  if (cleanedInput === '') {
+    return dayjs.duration(0, 's').toISOString();
+  }
+
+  const firstEntry = cleanedInput[0];
+  if (firstEntry === ':') {
+    cleanedInput = `0${cleanedInput}`;
+  }
+
+  const lastEntry = cleanedInput[cleanedInput.length - 1];
+  if (lastEntry === ':' || lastEntry === '.') {
+    cleanedInput = `${cleanedInput}0`;
+  }
+
+  const unitValues = cleanedInput.split(':');
+  if (unitValues.length > unitsInRange.length) {
+    throw new Error('Duration exceeds specified unit range');
+  }
+
+  const terms = cleanedInput
+    .split(':')
+    .map((entry) => {
+      let valueString = entry;
+      if (
+        valueString.length > 1 &&
+        valueString[valueString.length - 1] === '.'
+      ) {
+        valueString = `${valueString}0`;
+      }
+      const value = parseFloat(valueString);
+      // We are additionally testing with a regex because
+      // parseFloat("12.12string") will return 12.12, which is valid
+      // Since we have to direcly pass the input string as intermediateDisplay,
+      // we will have to throw a parsing error here for such cases.
+      if (Number.isNaN(value) || !FLOAT_REGEX.test(valueString)) {
+        throw new Error('Unable to parse duration');
+      }
+      return value;
+    })
+    .slice(-unitsInRange.length);
+
+  const slicedUnits = unitsInRange.slice(-terms.length);
+
+  const unitWithValue: Partial<Record<DurationUnit, number>> = {};
+  slicedUnits.forEach((unit, index) => {
+    unitWithValue[unit] = terms[index] ?? 0;
+  });
+
+  return dayjs
+    .duration({
+      years: 0,
+      months: 0,
+      days: unitWithValue.d ?? 0,
+      hours: unitWithValue.h ?? 0,
+      minutes: unitWithValue.m ?? 0,
+      seconds: unitWithValue.s ?? 0,
+    })
+    .toISOString();
+}
+
+const unitConfig: Record<
+  DurationUnit,
+  {
+    convert: (duration: Duration) => number;
+    unitName: DurationUnitType;
+    decimalCorrection?: number;
+  }
+> = {
+  ms: {
+    convert: (duration: Duration) => duration.asMilliseconds(),
+    unitName: 'milliseconds',
+    decimalCorrection: 0,
+  },
+  s: {
+    convert: (duration: Duration) => duration.asSeconds(),
+    unitName: 'seconds',
+  },
+  m: {
+    convert: (duration: Duration) => duration.asMinutes(),
+    unitName: 'minutes',
+  },
+  h: {
+    convert: (duration: Duration) => duration.asHours(),
+    unitName: 'hours',
+  },
+  d: {
+    convert: (duration: Duration) => duration.asDays(),
+    unitName: 'days',
+  },
+};
+
+// DISCUSS: What's best for Mathesar?
+// Duration accuracy or user friendliness?
+// Should 1H80M80S be displayed as is, or transform to 2H21M20S?
+function shiftAndFormatISODurationString(
+  canonicalValue: string,
+  specification: DurationSpecification,
+): string {
+  const unitsWithValues: Partial<Record<DurationUnitType, number>> = {};
+  const duration = dayjs.duration(canonicalValue);
+
+  const units = specification.getUnitsInRange().reverse();
+
+  if (units.length === 0) {
+    // This should never happen;
+    throw new Error('Invalid duration specification');
+  }
+
+  let currentUnitConfig = unitConfig[units[0]];
+  let currentUnitValue = currentUnitConfig.convert(duration);
+
+  for (const unit of units) {
+    const higherUnit = specification.getHigherUnit(unit);
+    let higherUnitValue = 0;
+    if (higherUnit) {
+      const higherUnitConfig = unitConfig[higherUnit];
+      higherUnitValue = Math.floor(
+        higherUnitConfig.convert(
+          dayjs.duration(currentUnitValue, currentUnitConfig.unitName),
+        ),
+      );
+      currentUnitValue -= currentUnitConfig.convert(
+        dayjs.duration(higherUnitValue, higherUnitConfig.unitName),
+      );
+    }
+    unitsWithValues[currentUnitConfig.unitName] = parseFloat(
+      currentUnitValue.toFixed(currentUnitConfig.decimalCorrection ?? 3),
+    );
+    if (higherUnit) {
+      currentUnitValue = higherUnitValue;
+      currentUnitConfig = unitConfig[higherUnit];
+    }
+  }
+
+  return dayjs
+    .duration(unitsWithValues)
+    .format(specification.getFormattingString());
+}
 
 export default class DurationFormatter implements InputFormatter<string> {
   specification: DurationSpecification;
@@ -11,16 +168,18 @@ export default class DurationFormatter implements InputFormatter<string> {
     this.specification = specification;
   }
 
-  parse(input: string): ParseResult<string> {
-    const format = this.specification.getFormattingString();
+  parse(userInput: string): ParseResult<string> {
+    const value = parseRawDurationStringToISOString(
+      this.specification,
+      userInput,
+    );
     return {
-      value: null,
-      intermediateDisplay: '',
+      value,
+      intermediateDisplay: userInput,
     };
   }
 
-  format(value: string): string {
-    const format = this.specification.getFormattingString();
-    return '';
+  format(canonicalValue: string): string {
+    return shiftAndFormatISODurationString(canonicalValue, this.specification);
   }
 }

--- a/mathesar_ui/src/utils/duration/DurationFormatter.ts
+++ b/mathesar_ui/src/utils/duration/DurationFormatter.ts
@@ -1,0 +1,26 @@
+import type {
+  InputFormatter,
+  ParseResult,
+} from '@mathesar-component-library/types';
+import type DurationSpecification from './DurationSpecification';
+
+export default class DurationFormatter implements InputFormatter<string> {
+  specification: DurationSpecification;
+
+  constructor(specification: DurationSpecification) {
+    this.specification = specification;
+  }
+
+  parse(input: string): ParseResult<string> {
+    const format = this.specification.getFormattingString();
+    return {
+      value: null,
+      intermediateDisplay: '',
+    };
+  }
+
+  format(value: string): string {
+    const format = this.specification.getFormattingString();
+    return '';
+  }
+}

--- a/mathesar_ui/src/utils/duration/DurationFormatter.ts
+++ b/mathesar_ui/src/utils/duration/DurationFormatter.ts
@@ -15,7 +15,7 @@ const FLOAT_REGEX = /^((\.?\d+)|(\d+(\.\d+)?))$/;
 function parseRawDurationStringToISOString(
   specification: DurationSpecification,
   userInput: string,
-): string {
+): string | null {
   let unitsInRange = specification.getUnitsInRange();
   if (unitsInRange[unitsInRange.length - 1] === 'ms') {
     unitsInRange = unitsInRange.slice(0, unitsInRange.length - 1);
@@ -23,7 +23,7 @@ function parseRawDurationStringToISOString(
 
   let cleanedInput = userInput.trim();
   if (cleanedInput === '') {
-    return dayjs.duration(0, 's').toISOString();
+    return null;
   }
 
   const firstEntry = cleanedInput[0];

--- a/mathesar_ui/src/utils/duration/DurationSpecification.ts
+++ b/mathesar_ui/src/utils/duration/DurationSpecification.ts
@@ -11,7 +11,7 @@ const defaults: DurationConfig = {
   min: 's',
 };
 
-export default class Duration {
+export default class DurationSpecification {
   private min: DurationUnit;
 
   private max: DurationUnit;

--- a/mathesar_ui/src/utils/duration/DurationSpecification.ts
+++ b/mathesar_ui/src/utils/duration/DurationSpecification.ts
@@ -11,27 +11,54 @@ const defaults: DurationConfig = {
   min: 's',
 };
 
-export default class DurationSpecification {
-  private min: DurationUnit;
+const formattingTokens: Record<DurationUnit, string> = {
+  d: 'D',
+  h: 'HH',
+  m: 'mm',
+  s: 'ss',
+  ms: 'SSS',
+};
 
-  private max: DurationUnit;
+export default class DurationSpecification {
+  readonly min: DurationUnit;
+
+  readonly max: DurationUnit;
 
   constructor(config?: Partial<DurationConfig>) {
     this.min = config?.min ?? defaults.min;
     this.max = config?.max ?? defaults.max;
   }
 
-  getFormattingString(): string {
-    const range = allUnits.slice(
+  getUnitsInRange(): DurationUnit[] {
+    return allUnits.slice(
       allUnits.indexOf(this.max),
       allUnits.indexOf(this.min) + 1,
     );
-    if (range[range.length - 1] === 'ms') {
-      return `${range.slice(0, range.length - 1).join(':')}.${
-        range[range.length - 1]
-      }`;
+  }
+
+  getHigherUnit(unit: DurationUnit): DurationUnit | null {
+    const higherUnit = allUnits[allUnits.indexOf(unit) - 1];
+    if (!higherUnit) {
+      return null;
     }
-    return range.join(':');
+    if (allUnits.indexOf(higherUnit) < allUnits.indexOf(this.max)) {
+      return null;
+    }
+    return higherUnit;
+  }
+
+  getFormattingString(): string {
+    const tokens = this.getUnitsInRange().map((unit) => formattingTokens[unit]);
+    if (tokens.length === 1) {
+      return tokens[0];
+    }
+    if (tokens[tokens.length - 1] === formattingTokens.ms) {
+      return [
+        tokens.slice(0, tokens.length - 1).join(':'),
+        tokens[tokens.length - 1],
+      ].join('.');
+    }
+    return tokens.join(':');
   }
 
   static getAllUnits(): DurationUnit[] {

--- a/mathesar_ui/src/utils/duration/__tests__/DurationFormatter.test.ts
+++ b/mathesar_ui/src/utils/duration/__tests__/DurationFormatter.test.ts
@@ -47,6 +47,13 @@ describe('parse', () => {
       expect(() => formatter.parse(input)).toThrow();
     },
   );
+
+  test('empty string', () => {
+    const formatter = new DurationFormatter(
+      new DurationSpecification({ min: 'm', max: 's' }),
+    );
+    expect(formatter.parse('').value).toBeNull();
+  });
 });
 
 describe('format', () => {

--- a/mathesar_ui/src/utils/duration/__tests__/DurationFormatter.test.ts
+++ b/mathesar_ui/src/utils/duration/__tests__/DurationFormatter.test.ts
@@ -1,0 +1,70 @@
+import DurationFormatter from '../DurationFormatter';
+import DurationSpecification from '../DurationSpecification';
+import type { DurationConfig } from '../DurationSpecification';
+
+describe('parse', () => {
+  // prettier-ignore
+  const successScenarios: [string, DurationConfig, string, string][] = [
+    // input             , config                 , formatted value  , value
+    [ '3'                , { max: 'm', min: 's'  }, '00:03'          , 'PT3S'              ],
+    [ '.'                , { max: 'm', min: 's'  }, '00:00'          , 'P0D'               ],
+    [ '3:12'             , { max: 'm', min: 's'  }, '03:12'          , 'PT3M12S'           ],
+    [ '3:12:33'          , { max: 'd', min: 's'  }, '0:03:12:33'     , 'PT3H12M33S'        ],
+    [ '3:12:33'          , { max: 'd', min: 'ms' }, '0:03:12:33.000' , 'PT3H12M33S'        ],
+    [ '3:12:33.23'       , { max: 'd', min: 'ms' }, '0:03:12:33.230' , 'PT3H12M33.23S'     ],
+    [ '2:3:12:33.23'     , { max: 'd', min: 'ms' }, '2:03:12:33.230' , 'P2DT3H12M33.23S'   ],
+    [ '25:61:61.100'     , { max: 'd', min: 'ms' }, '1:02:02:01.100' , 'PT25H61M61.1S'     ],
+    [ ':23.'             , { max: 'm', min: 's'  }, '00:23'          , 'PT23S'             ],
+    [ ':.'               , { max: 'm', min: 's'  }, '00:00'          , 'P0D'               ],
+  ];
+
+  // prettier-ignore
+  const failureScenarios: [string, DurationConfig][] = [
+    [ '3:12:33'  , { max: 'm', min: 's' } ],
+    [ '::'       , { max: 'm', min: 's' } ],
+  ];
+
+  test.each(successScenarios)(
+    'with userInput=%s config=%s',
+    (input, { min, max }, formattedValue, expectedValue) => {
+      const formatter = new DurationFormatter(
+        new DurationSpecification({ min, max }),
+      );
+      const parsed = formatter.parse(input);
+      expect(parsed.value).toEqual(expectedValue);
+      expect(parsed.intermediateDisplay).toEqual(input);
+
+      expect(formatter.format(expectedValue)).toEqual(formattedValue);
+    },
+  );
+
+  test.each(failureScenarios)(
+    'with userInput=%s config=%s',
+    (input, { min, max }) => {
+      const formatter = new DurationFormatter(
+        new DurationSpecification({ min, max }),
+      );
+      expect(() => formatter.parse(input)).toThrow();
+    },
+  );
+});
+
+describe('format', () => {
+  // prettier-ignore
+  const entries: [string, DurationConfig, string][] = [
+    [ 'P1D'      , { max: 'm' , min: 's'  }, '1440:00'  ],
+    [ 'P1D'      , { max: 'ms', min: 'ms' }, '86400000' ],
+    [ 'PT3601S'  , { max: 'm' , min: 's'  }, '60:01'    ],
+    [ 'PT3601S'  , { max: 'h' , min: 's'  }, '01:00:01' ],
+  ];
+
+  test.each(entries)(
+    'with userInput=%s config=%s',
+    (canonicalInput, { min, max }, expectedValue) => {
+      const formatter = new DurationFormatter(
+        new DurationSpecification({ min, max }),
+      );
+      expect(formatter.format(canonicalInput)).toEqual(expectedValue);
+    },
+  );
+});

--- a/mathesar_ui/src/utils/duration/index.ts
+++ b/mathesar_ui/src/utils/duration/index.ts
@@ -1,0 +1,2 @@
+export { default as DurationSpecification } from './DurationSpecification';
+export { default as DurationFormatter } from './DurationFormatter';

--- a/mathesar_ui/src/utils/duration/types.ts
+++ b/mathesar_ui/src/utils/duration/types.ts
@@ -1,0 +1,6 @@
+export type {
+  DurationUnit,
+  DurationConfig,
+  default as DurationSpecification,
+} from './DurationSpecification';
+export type { default as DurationFormatter } from './DurationFormatter';


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #261 , Fixes #1337 , Fixes #1108 

![Screenshot 2022-05-05 at 6 24 56 AM](https://user-images.githubusercontent.com/11850603/166850085-9f380511-6d64-4678-bc6b-dfefe42b8440.png)

https://user-images.githubusercontent.com/11850603/166850095-53e73bc1-16d6-46e4-b14f-cf9585947cdd.mov

## Note:
* Fractional values for each unit is allowed.
   * User may save duration in `mm:ss` and then change format to `hh`. In this case, the hour value will be fractional.
   * Fractional values are rounded off to 3 decimal places.
* `show_units` display option is removed for the sake of faster completion.
   * Several UX considerations need to be taken into account to allow user to edit a duration field with unit strings.
   * It is very different from number where the user need not enter the grouping separators.
* `dayjs` is installed inorder to be used with duration and for date & time types. The main consideration was the library size and `dayjs` is a lot smaller than the other options. Since we not require heavy date time operations on the frontend, this seems like the best choice.   

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
