### PR TITLE
Update datetime display options

### DIFF
--- a/mathesar/api/serializers/shared_serializers.py
+++ b/mathesar/api/serializers/shared_serializers.py
@@ -131,6 +131,15 @@ class TimeFormatDisplayOptionSerializer(
     format = serializers.CharField(max_length=255)
 
 
+class DateTimeFormatDisplayOptionSerializer(
+    MathesarErrorMessageMixin,
+    OverrideRootPartialMixin,
+    serializers.Serializer
+):
+    time_format = serializers.CharField(max_length=255)
+    date_format = serializers.CharField(max_length=255)
+
+
 class DurationDisplayOptionSerializer(MathesarErrorMessageMixin, OverrideRootPartialMixin, serializers.Serializer):
     min = serializers.CharField(max_length=255)
     max = serializers.CharField(max_length=255)
@@ -146,7 +155,7 @@ class DisplayOptionsMappingSerializer(
     serializers_mapping = {
         MathesarTypeIdentifier.BOOLEAN.value: BooleanDisplayOptionSerializer,
         MathesarTypeIdentifier.NUMBER.value: NumberDisplayOptionSerializer,
-        MathesarTypeIdentifier.DATETIME.value: TimeFormatDisplayOptionSerializer,
+        MathesarTypeIdentifier.DATETIME.value: DateTimeFormatDisplayOptionSerializer,
         MathesarTypeIdentifier.DATE.value: TimeFormatDisplayOptionSerializer,
         MathesarTypeIdentifier.TIME.value: TimeFormatDisplayOptionSerializer,
         MathesarTypeIdentifier.DURATION.value: DurationDisplayOptionSerializer,

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from unittest.mock import patch
 from django.core.cache import cache
-from sqlalchemy import Column, Integer, String, MetaData, Text, select, Boolean, TIMESTAMP
+from sqlalchemy import Column, Integer, String, MetaData, Text, select, Boolean, TIMESTAMP, TIME, DATE
 from sqlalchemy import Table as SATable
 
 from db.columns.operations.alter import alter_column_type
@@ -60,14 +60,20 @@ def column_test_table_with_service_layer_options(patent_schema):
         Column("mycolumn4", Text),
         Column("mycolumn5", Text),
         Column("mycolumn6", TIMESTAMP),
+        Column("mycolumn7", TIME),
+        Column("mycolumn8", DATE),
     ]
-    column_data_list = [{},
-                        {'display_options': {'input': "dropdown", "custom_labels": {"TRUE": "yes", "FALSE": "no"}}},
-                        {'display_options': {'show_as_percentage': True, 'number_format': "english"}},
-                        {'display_options': None},
-                        {},
-                        {},
-                        {'display_options': {'format': 'YYYY-MM-DD hh:mm'}}]
+    column_data_list = [
+        {},
+        {'display_options': {'input': "dropdown", "custom_labels": {"TRUE": "yes", "FALSE": "no"}}},
+        {'display_options': {'show_as_percentage': True, 'number_format': "english"}},
+        {'display_options': None},
+        {},
+        {},
+        {'display_options': {'time_format': 'hh:mm', 'date_format': 'YYYY-MM-DD'}},
+        {'display_options': {'format': 'hh:mm'}},
+        {'display_options': {'format': 'YYYY-MM-DD'}},
+    ]
     db_table = SATable(
         "anewtable",
         MetaData(bind=engine),
@@ -251,14 +257,15 @@ def test_column_create_invalid_default(column_test_table, client):
     assert f'default "{data["default"]}" is invalid for type' in response.json()[0]['message']
 
 
+# NOTE: display option value types are checked backend, but that's it: e.g. a time format may be any string.
 create_display_options_test_list = [
     ("BOOLEAN", {"input": "dropdown"}),
     ("BOOLEAN", {"input": "checkbox", "custom_labels": {"TRUE": "yes", "FALSE": "no"}}),
     ("DATE", {'format': 'YYYY-MM-DD'}),
     ("INTERVAL", {'min': 's', 'max': 'h', 'show_units': True}),
     ("NUMERIC", {"show_as_percentage": True, 'number_format': "english"}),
-    ("TIMESTAMP WITH TIME ZONE", {'format': 'YYYY-MM-DD hh:mm'}),
-    ("TIMESTAMP WITHOUT TIME ZONE", {'format': 'YYYY-MM-DD hh:mm'}),
+    ("TIMESTAMP WITH TIME ZONE", {'date_format': 'x', 'time_format': 'x'}),
+    ("TIMESTAMP WITHOUT TIME ZONE", {'date_format': 'x', 'time_format': 'x'}),
     ("TIME WITHOUT TIME ZONE", {'format': 'hh:mm'}),
     ("TIME WITH TIME ZONE", {'format': 'hh:mm Z'}),
 ]


### PR DESCRIPTION
Sets Datetime UI type display options to be `time_format` and `date_format`, as specified [here](https://www.figma.com/proto/Uaf1ntcldzK2U41Jhw6vS2/Mathesar-MVP?page-id=7250%3A80778&node-id=7251%3A82246&viewport=300%2C48%2C0.41&scaling=min-zoom) (see last): 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
