### PR TITLE
Add a default value for precision field if only scale is present

### DIFF
--- a/mathesar/api/db/viewsets/columns.py
+++ b/mathesar/api/db/viewsets/columns.py
@@ -49,6 +49,7 @@ class ColumnViewSet(viewsets.ModelViewSet):
             )
         else:
             try:
+                # TODO Refactor add_column to user serializer validated date instead of request data
                 column = table.add_column(request.data)
             except ProgrammingError as e:
                 if type(e.orig) == DuplicateColumn:

--- a/mathesar/api/db/viewsets/columns.py
+++ b/mathesar/api/db/viewsets/columns.py
@@ -34,7 +34,8 @@ class ColumnViewSet(viewsets.ModelViewSet):
         # We only support adding a single column through the API.
         serializer = ColumnSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
-
+        if request.data.get('type_options', None) is not None and request.data['type_options'].get('scale', None) is not None and request.data['type_options'].get('precision', None) is None:
+            request.data['type_options']['precision'] = 1000
         if 'source_column' in serializer.validated_data:
             column = table.duplicate_column(
                 serializer.validated_data['source_column'],

--- a/mathesar/api/db/viewsets/columns.py
+++ b/mathesar/api/db/viewsets/columns.py
@@ -34,8 +34,12 @@ class ColumnViewSet(viewsets.ModelViewSet):
         # We only support adding a single column through the API.
         serializer = ColumnSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
-        if request.data.get('type_options', None) is not None and request.data['type_options'].get('scale', None) is not None and request.data['type_options'].get('precision', None) is None:
-            request.data['type_options']['precision'] = 1000
+        type_options = request.data.get('type_options', None)
+        if type_options is not None:
+            scale = type_options.get('scale', None)
+            precision = type_options.get('precision', None)
+            if scale is not None and precision is None:
+                request.data['type_options']['precision'] = 1000
         if 'source_column' in serializer.validated_data:
             column = table.duplicate_column(
                 serializer.validated_data['source_column'],

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -31,6 +31,11 @@ class TypeOptionSerializer(MathesarErrorMessageMixin, serializers.Serializer):
     scale = serializers.IntegerField(required=False)
     fields = serializers.CharField(required=False)
 
+    def validate(self, attrs):
+        if attrs.get('scale', None) is not None and attrs.get('precision', None) is None:
+            attrs['precision'] = 1000
+        return super().validate(attrs)
+
     def run_validation(self, data=empty):
         # Ensure that there are no unknown type options passed in.
         if data is not empty and data is not None:

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -338,17 +338,18 @@ def test_column_create_wrong_display_options(
 
 
 @pytest.mark.parametrize(
-    "type_,type_options",
+    "type_,type_options,expected_type_options",
     [
-        ("NUMERIC", {"precision": 5, "scale": 3}),
-        ("VARCHAR", {"length": 5}),
-        ("CHAR", {"length": 5}),
-        ("INTERVAL", {"precision": 5}),
-        ("INTERVAL", {"precision": 5, "fields": "second"}),
-        ("INTERVAL", {"fields": "day"}),
+        ("NUMERIC", {"precision": 5, "scale": 3}, {"precision": 5, "scale": 3}),
+        ("NUMERIC", {"scale": 3}, {"precision": 1000, "scale": 3}),
+        ("VARCHAR", {"length": 5}, {"length": 5}),
+        ("CHAR", {"length": 5}, {"length": 5}),
+        ("INTERVAL", {"precision": 5}, {"precision": 5}),
+        ("INTERVAL", {"precision": 5, "fields": "second"}, {"precision": 5, "fields": "second"}),
+        ("INTERVAL", {"fields": "day"}, {"fields": "day"}),
     ]
 )
-def test_column_create_retrieve_options(column_test_table, client, type_, type_options):
+def test_column_create_retrieve_options(column_test_table, client, type_, type_options, expected_type_options):
     name = "anewcolumn"
     cache.clear()
     num_columns = len(column_test_table.sa_columns)
@@ -367,7 +368,7 @@ def test_column_create_retrieve_options(column_test_table, client, type_, type_o
     actual_new_col = new_columns_response.json()["results"][-1]
     assert actual_new_col["name"] == name
     assert actual_new_col["type"] == type_
-    assert actual_new_col["type_options"] == type_options
+    assert actual_new_col["type_options"] == expected_type_options
 
 
 invalid_type_options = [

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -705,7 +705,8 @@ def test_column_update_name_type_nullable_default(column_test_table, client):
 def test_column_update_type_options(column_test_table, client):
     cache.clear()
     type_ = "NUMERIC"
-    type_options = {"precision": 3, "scale": 1}
+    type_options = {"scale": 1}
+    expected_type_options = {'precision': 1000, 'scale': 1}
     data = {"type": type_, "type_options": type_options}
     column = _get_columns_by_name(column_test_table, ['mycolumn3'])[0]
     response = client.patch(
@@ -713,7 +714,7 @@ def test_column_update_type_options(column_test_table, client):
         data,
     )
     assert response.json()["type"] == type_
-    assert response.json()["type_options"] == type_options
+    assert response.json()["type_options"] == expected_type_options
 
 
 def test_column_update_type_options_no_type(column_test_table, client):

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -280,7 +280,7 @@ create_display_options_test_list = [
     ("MONEY",
      {'number_format': "english", 'currency_symbol': '$', 'currency_symbol_location': 'after-minus'},
      {'currency_symbol': '$', 'currency_symbol_location': 'after-minus', 'number_format': "english"}),
-    ("NUMERIC", {"show_as_percentage": True}, {"show_as_percentage": True}),
+    ("NUMERIC", {"show_as_percentage": True, 'number_format': None}, {"show_as_percentage": True, 'number_format': None}),
     ("NUMERIC",
      {"show_as_percentage": True, 'number_format': "english"},
      {"show_as_percentage": True, 'number_format': "english"}),


### PR DESCRIPTION


<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1300 

Assigns a default value of `1000` for the `precision` type_option if only `scale` type_option is sent as a request.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
