### PR TITLE
Re-enable E2E test blocked by #1276

### DIFF
--- a/mathesar/tests/integration/test_columns.py
+++ b/mathesar/tests/integration/test_columns.py
@@ -1,6 +1,6 @@
 from playwright.sync_api import expect
-# from mathesar.tests.integration.utils.table_actions import open_column_options, get_default_value_checkbox
-# from mathesar.tests.integration.utils.validators import expect_tab_to_be_visible
+from mathesar.tests.integration.utils.table_actions import open_column_options, get_default_value_checkbox
+from mathesar.tests.integration.utils.validators import expect_tab_to_be_visible
 
 
 def test_add_column(page, go_to_patents_data_table):
@@ -57,23 +57,21 @@ def test_group_by_column(page, go_to_patents_data_table):
     expect(page.locator("button:has-text('Group')")).to_be_visible()
 
 
-# Column patch requests from frontend currently fails
-# Commented until https://github.com/centerofci/mathesar/issues/1276 is merged
-# def test_set_column_default_value(page, go_to_all_types_table):
-#     expect_tab_to_be_visible(page, "All datatypes table")
-#     open_column_options(page, "text", "Text")
-#     default_value_cb_locator = get_default_value_checkbox(page)
-#     default_value_cb_handle = default_value_cb_locator.element_handle()
-#     assert default_value_cb_handle.is_checked() is False
-#     default_value_cb_handle.click()
-#     assert default_value_cb_handle.is_checked() is True
-#     page.pause()
-#     default_value_input = page.locator("span:has-text('Default Value') textarea")
-#     expect(default_value_input).to_be_empty()
-#     default_value_input.fill("some default value")
-#     page.click("button:has-text('Save')")
-#     expect(page.locator(".type-options-content")).not_to_be_visible()
-#     page.click("button:has-text('New Record')")
-#     created_row = page.locator(".row.created")
-#     expect(created_row).to_be_visible()
-#     expect(created_row.locator(".cell:has-text('some default value')")).to_be_visible()
+def test_set_column_default_value(page, go_to_all_types_table):
+    expect_tab_to_be_visible(page, "All datatypes table")
+    open_column_options(page, "text", "Text")
+    default_value_cb_locator = get_default_value_checkbox(page)
+    default_value_cb_handle = default_value_cb_locator.element_handle()
+    assert default_value_cb_handle.is_checked() is False
+    default_value_cb_handle.click()
+    assert default_value_cb_handle.is_checked() is True
+    page.pause()
+    default_value_input = page.locator("span:has-text('Default Value') textarea")
+    expect(default_value_input).to_be_empty()
+    default_value_input.fill("some default value")
+    page.click("button:has-text('Save')")
+    expect(page.locator(".type-options-content")).not_to_be_visible()
+    page.click("button:has-text('New Record')")
+    created_row = page.locator(".row.created")
+    expect(created_row).to_be_visible()
+    expect(created_row.locator(".cell:has-text('some default value')")).to_be_visible()


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #1276

<!-- Concisely describe what the pull request does. -->
The E2E test `test_set_column_default_value` was disabled due to 500s when patching columns. Since #1276 is now fixed by #1293, this test can be re-enabled.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
