### PR TITLE
Fix bugs present after renaming a table

### DIFF
--- a/mathesar_ui/src/sections/Base.svelte
+++ b/mathesar_ui/src/sections/Base.svelte
@@ -59,7 +59,7 @@
   }
 
   function tabRemoved(e: { detail: { removedTab: MathesarTab } }) {
-    tabList.remove(e.detail.removedTab);
+    tabList.removeTabAndItsData(e.detail.removedTab);
   }
 
   // @ts-ignore: https://github.com/centerofci/mathesar/issues/1055

--- a/mathesar_ui/src/sections/import-data/importUtils.ts
+++ b/mathesar_ui/src/sections/import-data/importUtils.ts
@@ -437,7 +437,7 @@ export function cancelImport(fileImportStore: FileImport): void {
     );
     const existingTab = tabList.getImportTabByImportID(fileImportData.id);
     if (existingTab) {
-      tabList.remove(existingTab);
+      tabList.removeTabAndItsData(existingTab);
     }
     void deletePreviewTable(fileImportStore);
   }

--- a/mathesar_ui/src/stores/tabs/tabList.ts
+++ b/mathesar_ui/src/stores/tabs/tabList.ts
@@ -248,7 +248,7 @@ export class TabList {
     return tabSubstance.find((entry) => entry.id === importTabId);
   }
 
-  remove(tab: MathesarTab): void {
+  private removeTabWithoutTouchingItsData(tab: MathesarTab): void {
     const tabSubstance = get(this.tabs);
     const activeTabSubstance = get(this.activeTab);
 
@@ -278,6 +278,10 @@ export class TabList {
     if (removedTabIndexInTabsArray > -1) {
       this.tabs.set(tabSubstance.filter((entry) => entry.id !== tab.id));
     }
+  }
+
+  removeTabAndItsData(tab: MathesarTab): void {
+    this.removeTabWithoutTouchingItsData(tab);
 
     if (tab.type === TabType.Import) {
       if (tab.fileImportId) {
@@ -298,7 +302,7 @@ export class TabList {
     const existingTab = tabSubstance[existingTabIndex];
 
     if (existingTab) {
-      this.remove(existingTab);
+      this.removeTabWithoutTouchingItsData(existingTab);
     }
     this.add(tab, {
       position: existingTabIndex,


### PR DESCRIPTION
Fixes #982 (both the repro steps in the ticket description, and the additional repro steps in this [comment](https://github.com/centerofci/mathesar/issues/982#issuecomment-1016836793))

Fixes #1181

## Before

- We had some bugs associated with renaming a table.
- After renaming a table we would call `TabList.prototype.replace` to fix the table name within the tab. That would call `TabList.prototype.remove` which would call `removeTabularContent`, leaving us with a tab that had no TabularData. 😲

## After

- The `TabList.prototype.remove` method no longer exists.
- In its place are two methods with more explicit names: `removeTabAndItsData` (public) and `removeTabWithoutTouchingItsData` (private).
- We can use the two different methods for more granular control over the behavior when removing tabs.
- The `TabList.prototype.replace` removes the tab without touching the tab's data.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

