### PR TITLE
Setup Python class to represent name db

### DIFF
--- a/db/tests/columns/operations/test_create.py
+++ b/db/tests/columns/operations/test_create.py
@@ -73,6 +73,7 @@ type_set = {
     'TIMESTAMP WITHOUT TIME ZONE',
     'VARCHAR',
     '"char"',
+    'name'
 }
 
 

--- a/db/tests/types/test_mathesar_name.py
+++ b/db/tests/types/test_mathesar_name.py
@@ -1,0 +1,42 @@
+from sqlalchemy import text, MetaData, Table, Column
+from db.tests.types import fixtures
+from db.types import mathesar_name
+
+# We need to set these variables when the file loads, or pytest can't
+# properly detect the fixtures.  Importing them directly results in a
+# flake8 unused import error, and a bunch of flake8 F811 errors.
+engine_with_types = fixtures.engine_with_types
+engine_email_type = fixtures.engine_email_type
+temporary_testing_schema = fixtures.temporary_testing_schema
+
+
+def test_mathesar_name_type_column_creation(engine_email_type):
+    engine, app_schema = engine_email_type
+    with engine.begin() as conn:
+        conn.execute(text(f"SET search_path={app_schema}"))
+        metadata = MetaData(bind=conn)
+        test_table = Table(
+            "test_table",
+            metadata,
+            Column("char_col", mathesar_name.MATHESAR_NAME),
+        )
+        test_table.create()
+
+
+def test_mathesar_name_type_column_reflection(engine_email_type):
+    engine, app_schema = engine_email_type
+    with engine.begin() as conn:
+        metadata = MetaData(bind=conn, schema=app_schema)
+        test_table = Table(
+            "test_table",
+            metadata,
+            Column("char_col", mathesar_name.MATHESAR_NAME),
+        )
+        test_table.create()
+
+    with engine.begin() as conn:
+        metadata = MetaData(bind=conn, schema=app_schema)
+        reflect_table = Table("test_table", metadata, autoload_with=conn)
+    expect_cls = mathesar_name.MATHESAR_NAME
+    actual_cls = reflect_table.columns["char_col"].type.__class__
+    assert actual_cls == expect_cls

--- a/db/types/__init__.py
+++ b/db/types/__init__.py
@@ -1,5 +1,5 @@
 from sqlalchemy import DECIMAL as sa_decimal
-from db.types import datetime, email, money, multicurrency, uri, mathesar_char
+from db.types import datetime, email, money, multicurrency, uri, mathesar_char, mathesar_name
 from db.types.base import PostgresType
 
 
@@ -9,6 +9,7 @@ CUSTOM_TYPE_DICT = {
     PostgresType.DECIMAL.value: sa_decimal,
     PostgresType.INTERVAL.value: datetime.Interval,
     PostgresType.MATHESAR_CHAR.value: mathesar_char.MATHESAR_CHAR,
+    PostgresType.MATHESAR_NAME.value: mathesar_name.MATHESAR_NAME,
     email.DB_TYPE: email.Email,
     multicurrency.DB_TYPE: multicurrency.MulticurrencyMoney,
     money.DB_TYPE: money.MathesarMoney,

--- a/db/types/base.py
+++ b/db/types/base.py
@@ -46,6 +46,7 @@ class PostgresType(Enum):
     JSONB = 'jsonb'
     MACADDR = 'macaddr'
     MATHESAR_CHAR = '"char"'
+    MATHESAR_NAME = 'name'
     MONEY = 'money'
     NAME = 'name'
     NUMERIC = 'numeric'

--- a/db/types/mathesar_name.py
+++ b/db/types/mathesar_name.py
@@ -1,3 +1,4 @@
+from sqlalchemy.dialects.postgresql import CHAR as SA_CHAR
 from sqlalchemy.types import TypeDecorator
 from sqlalchemy.ext.compiler import compiles
 

--- a/db/types/mathesar_name.py
+++ b/db/types/mathesar_name.py
@@ -1,0 +1,21 @@
+from sqlalchemy.types import TypeDecorator
+from sqlalchemy.ext.compiler import compiles
+
+from db.types.base import PostgresType
+
+
+class MATHESAR_NAME(TypeDecorator):
+    impl = SA_CHAR
+
+    @classmethod
+    def __str__(cls):
+        return cls.__name__
+
+
+@compiles(MATHESAR_NAME, 'postgresql')
+def _compile_mathesar_name(element, compiler, **kw):
+    unchanged_compiled_string = compiler.visit_VARCHAR(element, **kw)
+    unchanged_id = "VARCHAR"
+    changed_id = PostgresType.MATHESAR_NAME.value
+    changed_compiled_string = unchanged_compiled_string.replace(unchanged_id, changed_id)
+    return changed_compiled_string

--- a/db/types/operations/cast.py
+++ b/db/types/operations/cast.py
@@ -40,6 +40,7 @@ FULL_VARCHAR = base.PostgresType.CHARACTER_VARYING.value
 FULL_CHAR = base.PostgresType.CHARACTER.value
 NAME = base.PostgresType.NAME.value
 MATHESAR_CHAR = base.PostgresType.MATHESAR_CHAR.value
+MATHESAR_NAME = base.PostgresType.MATHESAR_NAME.value
 
 DECIMAL_TYPES = frozenset([DECIMAL, DOUBLE_PRECISION, FLOAT, NUMERIC, REAL])
 INTEGER_TYPES = frozenset([BIGINT, INTEGER, SMALLINT])
@@ -82,6 +83,7 @@ def get_supported_alter_column_types(engine, friendly_names=True):
         TIMESTAMP_WITHOUT_TIME_ZONE: dialect_types.get(TIMESTAMP_WITHOUT_TIME_ZONE),
         VARCHAR: dialect_types.get(FULL_VARCHAR),
         MATHESAR_CHAR: dialect_types.get(MATHESAR_CHAR),
+        MATHESAR_NAME: dialect_types.get(MATHESAR_NAME),
         # Custom Mathesar types
         EMAIL: dialect_types.get(email.DB_TYPE),
         MATHESAR_MONEY: dialect_types.get(money.DB_TYPE),


### PR DESCRIPTION
Fixes #1214 

**Technical details**
Initial setup of the python class to represent 'name' db Type
**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
