### PR TITLE
Remove UI for percentage as a display option

### DIFF
--- a/mathesar_ui/src/api/tables/columns.ts
+++ b/mathesar_ui/src/api/tables/columns.ts
@@ -31,9 +31,7 @@ interface FormattedNumberDisplayOptions {
 
 export interface NumberDisplayOptions
   extends Record<string, unknown>,
-    FormattedNumberDisplayOptions {
-  show_as_percentage: boolean;
-}
+    FormattedNumberDisplayOptions {}
 
 /**
  * See the [Postgres docs][1] for an explanation of `scale` and `precision`.

--- a/mathesar_ui/src/components/cell/data-types/components/number/NumberCell.svelte
+++ b/mathesar_ui/src/components/cell/data-types/components/number/NumberCell.svelte
@@ -15,7 +15,6 @@
 
   export let locale: $$Props['locale'];
   export let allowFloat: $$Props['allowFloat'];
-  export let isPercentage: $$Props['isPercentage'];
 
   $: formatterOptions = {
     locale,
@@ -50,7 +49,6 @@
     {disabled}
     bind:value
     {...formatterOptions}
-    {isPercentage}
     on:blur={handleInputBlur}
     on:keydown={handleInputKeydown}
   />

--- a/mathesar_ui/src/components/cell/data-types/components/number/NumberCellInput.svelte
+++ b/mathesar_ui/src/components/cell/data-types/components/number/NumberCellInput.svelte
@@ -5,7 +5,6 @@
 
   interface $$Props extends Omit<StringifiedNumberInputProps, 'value'> {
     value: NumberCellProps['value'];
-    isPercentage: NumberCellProps['isPercentage'];
   }
 
   type ParentValue = $$Props['value'];
@@ -13,9 +12,6 @@
 
   let parentValue: ParentValue = undefined;
   export { parentValue as value };
-
-  // TODO connect this to StringifiedNumberInput
-  export let isPercentage: $$Props['isPercentage'];
 
   let childValue: ChildValue = null;
 

--- a/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
@@ -30,7 +30,6 @@ export type TextAreaCellProps = TextBoxCellProps;
 export interface NumberCellExternalProps {
   locale?: string;
   allowFloat: boolean;
-  isPercentage: boolean;
 }
 
 export interface NumberCellProps

--- a/mathesar_ui/src/components/cell/data-types/number.ts
+++ b/mathesar_ui/src/components/cell/data-types/number.ts
@@ -44,7 +44,6 @@ function getProps(
   const format = column.display_options?.number_format ?? null;
   const props = {
     locale: (format && localeMap.get(format)) ?? undefined,
-    isPercentage: column.display_options?.show_as_percentage ?? false,
     allowFloat: getAllowFloat(column, config?.floatAllowanceStrategy),
   };
   return props;
@@ -60,11 +59,6 @@ const numberType: CellComponentFactory = {
     };
   },
 
-  /**
-   * This should ideally return `StringifiedNumberInput` with props But since we
-   * require additional operations like `isPercentage`, it's better to use a
-   * dedicated `NumberCellInput` component.
-   */
   getInput(
     column: NumberColumn,
     config?: Config,

--- a/mathesar_ui/src/stores/abstract-types/type-configs/number.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/number.ts
@@ -200,10 +200,6 @@ function constructDbFormValuesFromTypeOptions(
 
 const displayForm: AbstractTypeConfigForm = {
   variables: {
-    showAsPercentage: {
-      type: 'boolean',
-      default: false,
-    },
     format: {
       type: 'string',
       enum: ['none', 'english', 'german', 'french', 'hindi', 'swiss'],
@@ -213,11 +209,6 @@ const displayForm: AbstractTypeConfigForm = {
   layout: {
     orientation: 'vertical',
     elements: [
-      {
-        type: 'input',
-        variable: 'showAsPercentage',
-        label: 'Show as Percentage',
-      },
       {
         type: 'input',
         variable: 'format',
@@ -238,9 +229,7 @@ const displayForm: AbstractTypeConfigForm = {
 function determineDisplayOptions(
   dispFormValues: FormValues,
 ): Column['display_options'] {
-  const displayOptions: Column['display_options'] = {
-    show_as_percentage: dispFormValues.showAsPercentage,
-  };
+  const displayOptions: Column['display_options'] = {};
   if (dispFormValues.format !== 'none') {
     displayOptions.number_format = dispFormValues.format;
   }
@@ -252,7 +241,6 @@ function constructDisplayFormValuesFromDisplayOptions(
 ): FormValues {
   const displayOptions = columnDisplayOpts as NumberDisplayOptions | null;
   const dispFormValues: FormValues = {
-    showAsPercentage: displayOptions?.show_as_percentage ?? false,
     format: displayOptions?.number_format ?? 'none',
   };
   return dispFormValues;


### PR DESCRIPTION
## Notes

- In #1331 we decided not to use display options for percentages.
- In #1395 we'll soon be removing support from the API for the `show_as_percentage` display option, so that we can implement percentage as a new UI type entirely.
- This PR removes the `show_as_percentage` display option from the UI so as not to leave the UI with features implemented that don't exist in the API after #1395 is completed.
- The proper front end changes for percentages will be implemented in #1396


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

