### PR TITLE
Add API and UI support for toggling grouping separators within numbers

### DIFF
--- a/mathesar/api/display_options.py
+++ b/mathesar/api/display_options.py
@@ -52,6 +52,11 @@ DISPLAY_OPTIONS_BY_UI_TYPE = LazyDictionary(
                     "enum": ['dropdown', 'checkbox']
                 },
                 {
+                    "name": "use_grouping",
+                    "type": "string",
+                    "enum": ['true', 'false', 'auto']
+                },
+                {
                     "name": "locale",
                     "type": "string"
                 }

--- a/mathesar/api/serializers/shared_serializers.py
+++ b/mathesar/api/serializers/shared_serializers.py
@@ -116,6 +116,18 @@ class BooleanDisplayOptionSerializer(MathesarErrorMessageMixin, OverrideRootPart
 class AbstractNumberDisplayOptionSerializer(serializers.Serializer):
     number_format = serializers.ChoiceField(required=False, allow_null=True, choices=['english', 'german', 'french', 'hindi', 'swiss'])
 
+    use_grouping = serializers.ChoiceField(required=False, choices=['true', 'false', 'auto'], default='auto')
+    """
+    The choices here correspond to the options available for the `useGrouping`
+    property within the [Intl API][1]. True and False are encoded as strings
+    instead of booleans to maintain consistency with the Intl API and to keep
+    the type consistent. We did considering using an optional boolean but
+    decided a string would be better, especially if we want to support other
+    options eventually, like "min2".
+
+    [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
+    """
+
 
 class NumberDisplayOptionSerializer(
     MathesarErrorMessageMixin,

--- a/mathesar/tests/api/test_column_api_display_options.py
+++ b/mathesar/tests/api/test_column_api_display_options.py
@@ -314,8 +314,6 @@ def test_column_alter_same_type_display_options(
     column_index = 2
     column = columns[column_index]
     pre_alter_display_options = column.display_options
-    print("----------------------------------------------------")
-    print(pre_alter_display_options)
     with engine.begin() as conn:
         alter_column_type(table.oid, column.name, engine, conn, PostgresType.NUMERIC)
     column_id = column.id

--- a/mathesar/tests/api/test_column_api_display_options.py
+++ b/mathesar/tests/api/test_column_api_display_options.py
@@ -28,7 +28,7 @@ def column_test_table_with_service_layer_options(patent_schema):
     column_data_list = [
         {},
         {'display_options': {'input': "dropdown", "custom_labels": {"TRUE": "yes", "FALSE": "no"}}},
-        {'display_options': {'show_as_percentage': True, 'number_format': "english"}},
+        {'display_options': {'show_as_percentage': True, 'number_format': "english", "use_grouping": 'auto'}},
         {'display_options': None},
         {},
         {
@@ -90,18 +90,23 @@ _create_display_options_test_list = [
     ),
     (
         PostgresType.MONEY,
-        {'number_format': "english", 'currency_symbol': '$', 'currency_symbol_location': 'after-minus'},
-        {'currency_symbol': '$', 'currency_symbol_location': 'after-minus', 'number_format': "english"}
+        {'number_format': "english", 'currency_symbol': '$', 'currency_symbol_location': 'after-minus', 'use_grouping': 'true'},
+        {'currency_symbol': '$', 'currency_symbol_location': 'after-minus', 'number_format': "english", 'use_grouping': 'true'}
     ),
     (
         PostgresType.NUMERIC,
-        {"show_as_percentage": True, 'number_format': None},
-        {"show_as_percentage": True, 'number_format': None}
+        {},
+        {"show_as_percentage": False, 'number_format': None, 'use_grouping': 'auto'}
     ),
     (
         PostgresType.NUMERIC,
-        {"show_as_percentage": True, 'number_format': "english"},
-        {"show_as_percentage": True, 'number_format': "english"}
+        {"show_as_percentage": True, 'number_format': None, 'use_grouping': 'false'},
+        {"show_as_percentage": True, 'number_format': None, 'use_grouping': 'false'}
+    ),
+    (
+        PostgresType.NUMERIC,
+        {"show_as_percentage": True, 'number_format': "english", 'use_grouping': 'auto'},
+        {"show_as_percentage": True, 'number_format': "english", 'use_grouping': 'auto'}
     ),
     (
         PostgresType.TIMESTAMP_WITH_TIME_ZONE,
@@ -307,6 +312,8 @@ def test_column_alter_same_type_display_options(
     column_index = 2
     column = columns[column_index]
     pre_alter_display_options = column.display_options
+    print("----------------------------------------------------")
+    print(pre_alter_display_options)
     with engine.begin() as conn:
         alter_column_type(table.oid, column.name, engine, conn, PostgresType.NUMERIC)
     column_id = column.id

--- a/mathesar_ui/src/api/tables/columns.ts
+++ b/mathesar_ui/src/api/tables/columns.ts
@@ -19,14 +19,12 @@ interface FormattedNumberDisplayOptions {
   number_format: NumberFormat | null;
 
   /**
-   * PLANNED FOR FUTURE IMPLEMENTATION POST-ALPHA.
-   *
    * - "true": display grouping separators even if the locale prefers otherwise.
    * - "false": do not display grouping separators.
    * - "auto": display grouping separators based on the locale preference, which
    *   may also be dependent on the currency"
    */
-  // use_grouping: 'true' | 'false' | 'auto';
+  use_grouping: 'true' | 'false' | 'auto';
 }
 
 export interface NumberDisplayOptions

--- a/mathesar_ui/src/component-library/number-input/number-formatter/options.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/options.ts
@@ -4,6 +4,16 @@ export interface Options {
   locale?: string;
   allowFloat: boolean;
   allowNegative: boolean;
+  /**
+   * Corresponds to the options of the [Intl.NumberFormat][1] API.
+   *
+   * The MDN docs say that "true" and "false" are accepted as strings, but in my
+   * testing with Firefox and Chromium, I noticed that those values need to be
+   * passed as booleans to work correctly.
+   *
+   * [1]:
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
+   */
   useGrouping: boolean | 'auto';
   minimumFractionDigits: number;
   forceTrailingDecimal: boolean;

--- a/mathesar_ui/src/components/cell/data-types/components/number/NumberCell.svelte
+++ b/mathesar_ui/src/components/cell/data-types/components/number/NumberCell.svelte
@@ -12,7 +12,7 @@
   export let isActive: $$Props['isActive'];
   export let value: $$Props['value'];
   export let disabled: $$Props['disabled'];
-
+  export let useGrouping: $$Props['useGrouping'];
   export let locale: $$Props['locale'];
   export let allowFloat: $$Props['allowFloat'];
 
@@ -20,6 +20,7 @@
     locale,
     allowFloat,
     allowNegative: true,
+    useGrouping,
   };
   $: formatter = new StringifiedNumberFormatter(formatterOptions);
 

--- a/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
@@ -1,6 +1,7 @@
 import type {
   FormattedInputProps,
   SelectProps,
+  StringifiedNumberInputProps,
 } from '@mathesar-component-library/types';
 
 export interface CellTypeProps<Value> {
@@ -30,6 +31,7 @@ export type TextAreaCellProps = TextBoxCellProps;
 export interface NumberCellExternalProps {
   locale?: string;
   allowFloat: boolean;
+  useGrouping: StringifiedNumberInputProps['useGrouping'];
 }
 
 export interface NumberCellProps

--- a/mathesar_ui/src/components/cell/data-types/number.ts
+++ b/mathesar_ui/src/components/cell/data-types/number.ts
@@ -1,4 +1,8 @@
-import type { NumberColumn, NumberFormat } from '@mathesar/api/tables/columns';
+import type {
+  NumberColumn,
+  NumberDisplayOptions,
+  NumberFormat,
+} from '@mathesar/api/tables/columns';
 import type { ComponentAndProps } from '@mathesar-component-library/types';
 import NumberCell from './components/number/NumberCell.svelte';
 import NumberCellInput from './components/number/NumberCellInput.svelte';
@@ -37,6 +41,20 @@ function getAllowFloat(
   return true;
 }
 
+function getUseGrouping(
+  apiUseGrouping: NumberDisplayOptions['use_grouping'],
+): NumberCellExternalProps['useGrouping'] {
+  switch (apiUseGrouping) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    case 'auto':
+    default:
+      return 'auto';
+  }
+}
+
 function getProps(
   column: NumberColumn,
   config?: Config,
@@ -44,6 +62,7 @@ function getProps(
   const format = column.display_options?.number_format ?? null;
   const props = {
     locale: (format && localeMap.get(format)) ?? undefined,
+    useGrouping: getUseGrouping(column.display_options?.use_grouping ?? 'auto'),
     allowFloat: getAllowFloat(column, config?.floatAllowanceStrategy),
   };
   return props;

--- a/mathesar_ui/src/stores/abstract-types/type-configs/number.ts
+++ b/mathesar_ui/src/stores/abstract-types/type-configs/number.ts
@@ -1,5 +1,8 @@
 import { faHashtag } from '@fortawesome/free-solid-svg-icons';
-import type { NumberDisplayOptions } from '@mathesar/api/tables/columns';
+import type {
+  NumberDisplayOptions,
+  NumberFormat,
+} from '@mathesar/api/tables/columns';
 import type { FormValues } from '@mathesar-component-library/types';
 import type { DbType } from '@mathesar/AppTypes';
 import type { Column } from '@mathesar/stores/table-data/types';
@@ -200,7 +203,12 @@ function constructDbFormValuesFromTypeOptions(
 
 const displayForm: AbstractTypeConfigForm = {
   variables: {
-    format: {
+    useGrouping: {
+      type: 'string',
+      enum: ['true', 'false', 'auto'],
+      default: 'auto',
+    },
+    numberFormat: {
       type: 'string',
       enum: ['none', 'english', 'german', 'french', 'hindi', 'swiss'],
       default: 'none',
@@ -211,7 +219,17 @@ const displayForm: AbstractTypeConfigForm = {
     elements: [
       {
         type: 'input',
-        variable: 'format',
+        variable: 'useGrouping',
+        label: 'Digit Grouping',
+        options: {
+          true: { label: 'On' },
+          false: { label: 'Off' },
+          auto: { label: 'Auto' },
+        },
+      },
+      {
+        type: 'input',
+        variable: 'numberFormat',
         label: 'Format',
         options: {
           none: { label: 'Use browser locale' },
@@ -227,23 +245,30 @@ const displayForm: AbstractTypeConfigForm = {
 };
 
 function determineDisplayOptions(
-  dispFormValues: FormValues,
+  formValues: FormValues,
 ): Column['display_options'] {
-  const displayOptions: Column['display_options'] = {};
-  if (dispFormValues.format !== 'none') {
-    displayOptions.number_format = dispFormValues.format;
-  }
-  return displayOptions;
+  const opts: Partial<NumberDisplayOptions> = {
+    number_format:
+      formValues.numberFormat === 'none'
+        ? undefined
+        : (formValues.numberFormat as NumberFormat),
+    use_grouping:
+      (formValues.useGrouping as
+        | NumberDisplayOptions['use_grouping']
+        | undefined) ?? 'auto',
+  };
+  return opts;
 }
 
 function constructDisplayFormValuesFromDisplayOptions(
   columnDisplayOpts: Column['display_options'],
 ): FormValues {
   const displayOptions = columnDisplayOpts as NumberDisplayOptions | null;
-  const dispFormValues: FormValues = {
-    format: displayOptions?.number_format ?? 'none',
+  const formValues: FormValues = {
+    numberFormat: displayOptions?.number_format ?? 'none',
+    useGrouping: displayOptions?.use_grouping ?? 'auto',
   };
-  return dispFormValues;
+  return formValues;
 }
 
 const numberType: AbstractTypeConfiguration = {


### PR DESCRIPTION
Fixes #1329

## Demo

![Peek 2022-05-25 16-50](https://user-images.githubusercontent.com/42411/170364947-fce0b684-7f5e-4378-97d2-5eac11f42e80.gif)

## Before

- All numbers display grouping separators. This is annoying sometimes, e.g. if you have an integer column to represent "year".

## After

- We have a display option for it.

## Notes

- I don't completely understand the behavior of `useGrouping: "auto"` from [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat). Under what scenarios do `true` and `"auto"` differ? I'm not sure. But I stuck with using a separate option for it because that was the approach which seemed to involve the least amount of thought and research into edge cases.
- I didn't implement the custom "Number Format" options as spec'ed in #1329 because it's tricky to do within the serializable form generator. I think we might need a custom component for that. I'll open a ticket for that work separately after we merge this PR.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

