### PR TITLE
API and UI for configuring number of digits to display on numbers

### DIFF
--- a/mathesar/api/display_options.py
+++ b/mathesar/api/display_options.py
@@ -57,6 +57,14 @@ DISPLAY_OPTIONS_BY_UI_TYPE = LazyDictionary(
                     "enum": ['true', 'false', 'auto']
                 },
                 {
+                    "name": "minimum_fraction_digits",
+                    "type": "number",
+                },
+                {
+                    "name": "maximum_fraction_digits",
+                    "type": "number",
+                },
+                {
                     "name": "locale",
                     "type": "string"
                 }

--- a/mathesar/api/exceptions/error_codes.py
+++ b/mathesar/api/exceptions/error_codes.py
@@ -40,3 +40,4 @@ class ErrorCodes(Enum):
     URLInvalidContentType = 4406
     UnknownDBType = 4408
     InvalidLinkChoice = 4409
+    IncompatibleFractionDigitValues = 4410

--- a/mathesar/api/exceptions/validation_exceptions/exceptions.py
+++ b/mathesar/api/exceptions/validation_exceptions/exceptions.py
@@ -73,3 +73,15 @@ class MoneyDisplayOptionValueConflictAPIException(MathesarValidationException):
             details=None,
     ):
         super().__init__(None, self.error_code, message, field, details)
+
+
+class IncompatibleFractionDigitValuesAPIException(MathesarValidationException):
+    error_code = ErrorCodes.IncompatibleFractionDigitValues.value
+
+    def __init__(
+            self,
+            message="maximum_fraction_digits cannot be less than minimum_fraction_digits.",
+            field=None,
+            details=None,
+    ):
+        super().__init__(None, self.error_code, message, field, details)

--- a/mathesar/api/serializers/shared_serializers.py
+++ b/mathesar/api/serializers/shared_serializers.py
@@ -150,6 +150,13 @@ class AbstractNumberDisplayOptionSerializer(serializers.Serializer):
     minimum_fraction_digits = serializers.IntegerField(**FRACTION_DIGITS_CONFIG)
     maximum_fraction_digits = serializers.IntegerField(**FRACTION_DIGITS_CONFIG)
 
+    def validate(self, data):
+        if data['minimum_fraction_digits'] > data['maximum_fraction_digits']:
+            raise serializers.ValidationError(
+                "maximum_fraction_digits cannot be less than minimum_fraction_digits."
+            )
+        return data
+
 
 class NumberDisplayOptionSerializer(
     MathesarErrorMessageMixin,

--- a/mathesar/api/serializers/shared_serializers.py
+++ b/mathesar/api/serializers/shared_serializers.py
@@ -150,11 +150,19 @@ class AbstractNumberDisplayOptionSerializer(serializers.Serializer):
     minimum_fraction_digits = serializers.IntegerField(**FRACTION_DIGITS_CONFIG)
     maximum_fraction_digits = serializers.IntegerField(**FRACTION_DIGITS_CONFIG)
 
-    def validate(self, data):
-        if data['minimum_fraction_digits'] > data['maximum_fraction_digits']:
+    def _validate_fraction_digits(self, data):
+        minimum = data.get("minimum_fraction_digits")
+        maximum = data.get("maximum_fraction_digits")
+        if minimum is None or maximum is None:
+            # No errors if one of the fields is not set
+            return
+        if minimum > maximum:
             raise serializers.ValidationError(
                 "maximum_fraction_digits cannot be less than minimum_fraction_digits."
             )
+
+    def validate(self, data):
+        self._validate_fraction_digits(data)
         return data
 
 

--- a/mathesar/api/serializers/shared_serializers.py
+++ b/mathesar/api/serializers/shared_serializers.py
@@ -119,6 +119,19 @@ class BooleanDisplayOptionSerializer(MathesarErrorMessageMixin, OverrideRootPart
     custom_labels = CustomBooleanLabelSerializer(required=False)
 
 
+FRACTION_DIGITS_CONFIG = {
+    "required": False,
+    "allow_null": True,
+    "min_value": 0,
+    "max_value": 20
+}
+"""
+Max value of 20 is taken from [Intl.NumberFormat docs][1].
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
+"""
+
+
 class AbstractNumberDisplayOptionSerializer(serializers.Serializer):
     number_format = serializers.ChoiceField(required=False, allow_null=True, choices=['english', 'german', 'french', 'hindi', 'swiss'])
 
@@ -133,6 +146,9 @@ class AbstractNumberDisplayOptionSerializer(serializers.Serializer):
 
     [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat
     """
+
+    minimum_fraction_digits = serializers.IntegerField(**FRACTION_DIGITS_CONFIG)
+    maximum_fraction_digits = serializers.IntegerField(**FRACTION_DIGITS_CONFIG)
 
 
 class NumberDisplayOptionSerializer(

--- a/mathesar/api/serializers/shared_serializers.py
+++ b/mathesar/api/serializers/shared_serializers.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from rest_framework import serializers
 
 from mathesar.api.exceptions.mixins import MathesarErrorMessageMixin
+from mathesar.api.exceptions.validation_exceptions.exceptions import IncompatibleFractionDigitValuesAPIException
 from mathesar.database.types import UIType, get_ui_type_from_db_type
 
 
@@ -178,9 +179,7 @@ class AbstractNumberDisplayOptionSerializer(BaseDisplayOptionsSerializer):
             # No errors if one of the fields is not set
             return
         if minimum > maximum:
-            raise serializers.ValidationError(
-                "maximum_fraction_digits cannot be less than minimum_fraction_digits."
-            )
+            raise IncompatibleFractionDigitValuesAPIException()
 
     def validate(self, data):
         self._validate_fraction_digits(data)

--- a/mathesar/tests/api/test_column_api_display_options.py
+++ b/mathesar/tests/api/test_column_api_display_options.py
@@ -28,7 +28,15 @@ def column_test_table_with_service_layer_options(patent_schema):
     column_data_list = [
         {},
         {'display_options': {'input': "dropdown", "custom_labels": {"TRUE": "yes", "FALSE": "no"}}},
-        {'display_options': {'show_as_percentage': True, 'number_format': "english", "use_grouping": 'auto'}},
+        {
+            'display_options': {
+                'show_as_percentage': True,
+                'number_format': "english",
+                "use_grouping": 'auto',
+                "minimum_fraction_digits": None,
+                "maximum_fraction_digits": None,
+            }
+        },
         {'display_options': None},
         {},
         {
@@ -90,23 +98,67 @@ _create_display_options_test_list = [
     ),
     (
         PostgresType.MONEY,
-        {'number_format': "english", 'currency_symbol': '$', 'currency_symbol_location': 'after-minus', 'use_grouping': 'true'},
-        {'currency_symbol': '$', 'currency_symbol_location': 'after-minus', 'number_format': "english", 'use_grouping': 'true'}
+        {
+            'number_format': "english",
+            'currency_symbol': '$',
+            'currency_symbol_location': 'after-minus',
+            'use_grouping': 'true',
+            "minimum_fraction_digits": 2,
+            "maximum_fraction_digits": 2,
+        },
+        {
+            'currency_symbol': '$',
+            'currency_symbol_location': 'after-minus',
+            'number_format': "english",
+            'use_grouping': 'true',
+            "minimum_fraction_digits": 2,
+            "maximum_fraction_digits": 2,
+        },
     ),
     (
         PostgresType.NUMERIC,
         {},
-        {"show_as_percentage": False, 'number_format': None, 'use_grouping': 'auto'}
+        {
+            "show_as_percentage": False,
+            'number_format': None,
+            'use_grouping': 'auto',
+            "minimum_fraction_digits": None,
+            "maximum_fraction_digits": None,
+        },
     ),
     (
         PostgresType.NUMERIC,
-        {"show_as_percentage": True, 'number_format': None, 'use_grouping': 'false'},
-        {"show_as_percentage": True, 'number_format': None, 'use_grouping': 'false'}
+        {
+            "show_as_percentage": True,
+            'number_format': None,
+            'use_grouping': 'false',
+            "minimum_fraction_digits": 2,
+            "maximum_fraction_digits": 20,
+        },
+        {
+            "show_as_percentage": True,
+            'number_format': None,
+            'use_grouping': 'false',
+            "minimum_fraction_digits": 2,
+            "maximum_fraction_digits": 20,
+        },
     ),
     (
         PostgresType.NUMERIC,
-        {"show_as_percentage": True, 'number_format': "english", 'use_grouping': 'auto'},
-        {"show_as_percentage": True, 'number_format': "english", 'use_grouping': 'auto'}
+        {
+            "show_as_percentage": True,
+            'number_format': "english",
+            'use_grouping': 'auto',
+            "minimum_fraction_digits": None,
+            "maximum_fraction_digits": None,
+        },
+        {
+            "show_as_percentage": True,
+            'number_format': "english",
+            'use_grouping': 'auto',
+            "minimum_fraction_digits": None,
+            "maximum_fraction_digits": None,
+        },
     ),
     (
         PostgresType.TIMESTAMP_WITH_TIME_ZONE,
@@ -197,6 +249,19 @@ _create_display_options_invalid_test_list = [
         PostgresType.NUMERIC,
         {'number_format': "wrong"}
     ),
+
+    # Out of range values
+    (PostgresType.NUMERIC, {'minimum_fraction_digits': -1}),
+    (PostgresType.NUMERIC, {'maximum_fraction_digits': -1}),
+    (PostgresType.NUMERIC, {'minimum_fraction_digits': 21}),
+    (PostgresType.NUMERIC, {'maximum_fraction_digits': 21}),
+
+    # Incorrect types
+    (PostgresType.NUMERIC, {'minimum_fraction_digits': 1.5}),
+    (PostgresType.NUMERIC, {'maximum_fraction_digits': 1.5}),
+    (PostgresType.NUMERIC, {'minimum_fraction_digits': "can't be a string"}),
+    (PostgresType.NUMERIC, {'maximum_fraction_digits': "can't be a string"}),
+
     (
         PostgresType.TIMESTAMP_WITH_TIME_ZONE,
         {'format': []}

--- a/mathesar/tests/api/test_column_api_display_options.py
+++ b/mathesar/tests/api/test_column_api_display_options.py
@@ -262,6 +262,15 @@ _create_display_options_invalid_test_list = [
     (PostgresType.NUMERIC, {'minimum_fraction_digits': "can't be a string"}),
     (PostgresType.NUMERIC, {'maximum_fraction_digits': "can't be a string"}),
 
+    # Values in conflict. Max must be greater or equal to min.
+    (
+        PostgresType.NUMERIC,
+        {
+            'minimum_fraction_digits': 4,
+            'maximum_fraction_digits': 3,
+        },
+    ),
+
     (
         PostgresType.TIMESTAMP_WITH_TIME_ZONE,
         {'format': []}

--- a/mathesar_ui/src/api/tables/columns.ts
+++ b/mathesar_ui/src/api/tables/columns.ts
@@ -26,8 +26,8 @@ interface FormattedNumberDisplayOptions {
    */
   use_grouping: 'true' | 'false' | 'auto';
 
-  minimum_fraction_digits: number;
-  maximum_fraction_digits: number;
+  minimum_fraction_digits: number | null;
+  maximum_fraction_digits: number | null;
 }
 
 export interface NumberDisplayOptions

--- a/mathesar_ui/src/api/tables/columns.ts
+++ b/mathesar_ui/src/api/tables/columns.ts
@@ -25,6 +25,9 @@ interface FormattedNumberDisplayOptions {
    *   may also be dependent on the currency"
    */
   use_grouping: 'true' | 'false' | 'auto';
+
+  minimum_fraction_digits: number;
+  maximum_fraction_digits: number;
 }
 
 export interface NumberDisplayOptions

--- a/mathesar_ui/src/component-library/common/types/utilityTypes.ts
+++ b/mathesar_ui/src/component-library/common/types/utilityTypes.ts
@@ -1,0 +1,12 @@
+/**
+ * This is sort of how `Partial` behaves when `exactOptionalPropertyTypes` is
+ * `false`. Even though we have [exactOptionalPropertyTypes][1] set to `false`,
+ * I'd like to start using this utility type in place of `Partial` where
+ * appropriate because it will help us transition to setting
+ * `exactOptionalPropertyTypes` to `true` at some point in the future.
+ *
+ * [1]: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes
+ */
+export type PartiallyMissingOrUndefined<T> = {
+  [P in keyof T]?: T[P] | undefined;
+};

--- a/mathesar_ui/src/component-library/common/utils/__tests__/miscUtils.test.ts
+++ b/mathesar_ui/src/component-library/common/utils/__tests__/miscUtils.test.ts
@@ -1,0 +1,22 @@
+import { withDefaults, withoutUndefinedValues } from '../miscUtils';
+
+test('withoutUndefinedValues', () => {
+  expect(withoutUndefinedValues({})).toEqual({});
+  expect(withoutUndefinedValues({ a: 7 })).toEqual({ a: 7 });
+  expect(withoutUndefinedValues({ a: 7, b: undefined })).toEqual({ a: 7 });
+  expect(withoutUndefinedValues({ a: undefined, b: undefined })).toEqual({});
+});
+
+test('withDefaults', () => {
+  expect(withDefaults({ a: 7, b: 8 })).toEqual({ a: 7, b: 8 });
+  expect(withDefaults({ a: 7, b: 8 }, { a: 100 })).toEqual({ a: 100, b: 8 });
+  expect(withDefaults({ a: 7, b: 8 }, { b: 200 })).toEqual({ a: 7, b: 200 });
+  expect(withDefaults({ a: 7, b: 8 }, { b: undefined })).toEqual({
+    a: 7,
+    b: 8,
+  });
+  expect(withDefaults({ a: 7, b: 8 }, { a: undefined, b: 200 })).toEqual({
+    a: 7,
+    b: 200,
+  });
+});

--- a/mathesar_ui/src/component-library/common/utils/index.ts
+++ b/mathesar_ui/src/component-library/common/utils/index.ts
@@ -16,3 +16,4 @@ export * from './storeUtils';
 export * from './contextValidationUtil';
 export * from './inputUtils';
 export * from './typeUtils';
+export * from './miscUtils';

--- a/mathesar_ui/src/component-library/common/utils/miscUtils.ts
+++ b/mathesar_ui/src/component-library/common/utils/miscUtils.ts
@@ -1,0 +1,19 @@
+import type { PartiallyMissingOrUndefined } from '../types/utilityTypes';
+
+export function withoutUndefinedValues<T>(
+  object: PartiallyMissingOrUndefined<T> = {},
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(object).filter(([, value]) => value !== undefined),
+  ) as Partial<T>;
+}
+
+export function withDefaults<T>(
+  defaults: T,
+  supplied: PartiallyMissingOrUndefined<T> = {},
+): T {
+  return {
+    ...defaults,
+    ...withoutUndefinedValues(supplied),
+  };
+}

--- a/mathesar_ui/src/component-library/number-input/NumberInputTypes.ts
+++ b/mathesar_ui/src/component-library/number-input/NumberInputTypes.ts
@@ -1,6 +1,8 @@
 import type { FormattedInputProps } from '@mathesar-component-library-dir/formatted-input/FormattedInputTypes';
 import type { NumberFormatterOptions } from './number-formatter/types';
 
+export * from './number-formatter/types';
+
 export interface NumberInputProps extends Partial<NumberFormatterOptions> {
   value?: number;
   element?: HTMLInputElement;

--- a/mathesar_ui/src/component-library/number-input/number-formatter/AbstractNumberFormatter.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/AbstractNumberFormatter.ts
@@ -2,6 +2,8 @@ import type {
   InputFormatter,
   ParseResult,
 } from '@mathesar-component-library-dir/formatted-input/FormattedInputTypes';
+import type { PartiallyMissingOrUndefined } from '@mathesar-component-library-dir/types';
+import { withDefaults } from '@mathesar-component-library-dir/common/utils';
 import type { DerivedOptions, Options } from './options';
 import { defaultOptions, getDerivedOptions } from './options';
 
@@ -10,11 +12,8 @@ export default abstract class AbstractNumberFormatter<T>
 {
   opts: DerivedOptions;
 
-  constructor(partialOptions: Partial<Options> = {}) {
-    this.opts = getDerivedOptions({
-      ...defaultOptions,
-      ...partialOptions,
-    });
+  constructor(partialOptions: PartiallyMissingOrUndefined<Options> = {}) {
+    this.opts = getDerivedOptions(withDefaults(defaultOptions, partialOptions));
   }
 
   abstract format(value: T): string;

--- a/mathesar_ui/src/component-library/number-input/number-formatter/__tests__/NumberFormatter.test.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/__tests__/NumberFormatter.test.ts
@@ -13,73 +13,94 @@ function getFormatter(partialOpts: Partial<Options> = {}): NumberFormatter {
 }
 
 describe('parse and re-parse', () => {
+  const u = undefined;
   // prettier-ignore
-  const localeEnUs: [string, boolean, boolean, string, string, number | null][] = [
-  // locale   allowFloat
-  //                  allowNegative
-  //                          input          intermediateDisplay
-  //                                                          value
-    ['en-US', true  , true  , ''           , ''             , null       ],
-    ['en-US', true  , true  , ','          , ''             , null       ],
-    ['en-US', true  , true  , 'a'          , ''             , null       ],
-    ['en-US', true  , true  , 'abc'        , ''             , null       ],
-    ['en-US', true  , true  , 'NaN'        , ''             , null       ],
-    ['en-US', true  , true  , 'Infinity'   , ''             , null       ],
-    ['en-US', true  , true  , ' '          , ''             , null       ],
-    ['en-US', true  , true  , '-'          , '-'            , null       ], // see 4
-    ['en-US', true  , false , '-'          , ''             , null       ],
-    ['en-US', true  , true  , '-a'         , '-'            , null       ],
-    ['en-US', true  , true  , 'a-'         , '-'            , null       ],
-    ['en-US', true  , true  , '-0'         , '-0'           , -0         ],
-    ['en-US', true  , true  , '-.'         , '-0.'          , -0         ],
-    ['en-US', true  , true  , '-0.'        , '-0.'          , -0         ],
-    ['en-US', true  , true  , '-0.0'       , '-0.0'         , -0         ],
-    ['en-US', true  , true  , '-0.0a'      , '-0.0'         , -0         ],
-    ['en-US', true  , true  , '-0.0a0'     , '-0.00'        , -0         ],
-    ['en-US', true  , true  , '-0.0a1'     , '-0.01'        , -0.01      ],
-    ['en-US', true  , true  , '0'          , '0'            , 0          ],
-    ['en-US', true  , true  , '0.'         , '0.'           , 0          ],
-    ['en-US', false , true  , '0.'         , '0'            , 0          ],
-    ['en-US', true  , true  , '.-'         , '0.'           , 0          ],
-    ['en-US', true  , true  , '0.0'        , '0.0'          , 0          ],
-    ['en-US', true  , true  , '.00000'     , '0.00000'      , 0          ], // See 2
-    ['en-US', true  , true  , '.'          , '0.'           , 0          ],
-    ['en-US', true  , true  , '.0'         , '0.0'          , 0          ],
-    ['en-US', true  , true  , '-.1'        , '-0.1'         , -0.1       ],
-    ['en-US', true  , true  , '.1'         , '0.1'          , 0.1        ],
-    ['en-US', true  , true  , '.1.'        , '0.1'          , 0.1        ],
-    ['en-US', true  , true  , '.1.2'       , '0.12'         , 0.12       ],
-    ['en-US', true  , true  , '1.2'        , '1.2'          , 1.2        ],
-    ['en-US', true  , true  , '1.2.'       , '1.2'          , 1.2        ],
-    ['en-US', true  , true  , '1..2'       , '1.2'          , 1.2        ],
-    ['en-US', true  , true  , '1.2.3'      , '1.23'         , 1.23       ],
-    ['en-US', true  , true  , '-1'         , '-1'           , -1         ],
-    ['en-US', true  , true  , '-a1'        , '-1'           , -1         ],
-    ['en-US', true  , true  , '-1-'        , '-1'           , -1         ],
-    ['en-US', true  , true  , '--1'        , '-1'           , -1         ],
-    ['en-US', true  , true  , '\u20121'    , '-1'           , -1         ], // See 3
-    ['en-US', true  , true  , '1'          , '1'            , 1          ],
-    ['en-US', true  , true  , '1,'         , '1'            , 1          ],
-    ['en-US', true  , true  , '+1'         , '1'            , 1          ],
-    ['en-US', true  , true  , ' 1 '        , '1'            , 1          ],
-    ['en-US', true  , true  , 'a1a'        , '1'            , 1          ],
-    ['en-US', true  , true  , '1-'         , '1'            , 1          ],
-    ['en-US', true  , true  , '12345'      , '12,345'       , 12345      ],
-    ['en-US', true  , true  , '12,345'     , '12,345'       , 12345      ],
-    ['en-US', true  , true  , '1,2345'     , '12,345'       , 12345      ],
-    ['en-US', true  , true  , '1234567.89' , '1,234,567.89' , 1234567.89 ],
-    ['en-US', true  , true  , '.123456789' , '0.123456789'  , 0.123456789],
-    ['en-US', true  , true  , '-1-2-'      , '-12'          , -12        ],
-    ['en-US', true  , true  , '1e2'        , '12'           , 12         ], // See 1
-    ['en-US', true  , true  , '1,,2'       , '12'           , 12         ],
-    ['en-US', true  , true  , '1-2'        , '12'           , 12         ],
-    ['en-US', true  , true  , '12-'        , '12'           , 12         ],
-    ['en-US', true  , true  , '1-2-'       , '12'           , 12         ],
-    ['de-DE', true  , true  , '2..3'       , '23'           , 23         ],
-    ['de-DE', true  , true  , '2,,3'       , '2,3'          , 2.3        ],
-    ['de-DE', true  , true  , '1.2.3.4'    , '1.234'        , 1234       ],
-    ['de-DE', true  , true  , '1,2,3,4'    , '1,234'        , 1.234      ],
-    ['li'   , true  , true  , '-1'         , '-1'           , -1         ], // See 5
+  const cases: [
+    string,
+    boolean,
+    boolean,
+    number | undefined,
+    number | undefined,
+    string,
+    string,
+    number | null
+  ][] = [
+  // locale | allowFloat
+  //        |      | allowNegative
+  //        |      |      | minimumFractionDigits
+  //        |      |      |  | maximumFractionDigits
+  //        |      |      |  |  | input        | intermediateDisplay
+  //        |      |      |  |  |              |                | value
+    ['en-US', true , true , u, u, ''           , ''             , null       ],
+    ['en-US', true , true , u, u, ','          , ''             , null       ],
+    ['en-US', true , true , u, u, 'a'          , ''             , null       ],
+    ['en-US', true , true , u, u, 'abc'        , ''             , null       ],
+    ['en-US', true , true , u, u, 'NaN'        , ''             , null       ],
+    ['en-US', true , true , u, u, 'Infinity'   , ''             , null       ],
+    ['en-US', true , true , u, u, ' '          , ''             , null       ],
+    ['en-US', true , true , u, u, '-'          , '-'            , null       ], // see 4
+    ['en-US', true , false, u, u, '-'          , ''             , null       ],
+    ['en-US', true , true , u, u, '-a'         , '-'            , null       ],
+    ['en-US', true , true , u, u, 'a-'         , '-'            , null       ],
+    ['en-US', true , true , u, u, '-0'         , '-0'           , -0         ],
+    ['en-US', true , true , u, u, '-.'         , '-0.'          , -0         ],
+    ['en-US', true , true , u, u, '-0.'        , '-0.'          , -0         ],
+    ['en-US', true , true , u, u, '-0.0'       , '-0.0'         , -0         ],
+    ['en-US', true , true , u, u, '-0.0a'      , '-0.0'         , -0         ],
+    ['en-US', true , true , u, u, '-0.0a0'     , '-0.00'        , -0         ],
+    ['en-US', true , true , u, u, '-0.0a1'     , '-0.01'        , -0.01      ],
+    ['en-US', true , true , u, u, '0'          , '0'            , 0          ],
+    ['en-US', true , true , u, u, '0.'         , '0.'           , 0          ],
+    ['en-US', false, true , u, u, '0.'         , '0'            , 0          ],
+    ['en-US', true , true , u, u, '.-'         , '0.'           , 0          ],
+    ['en-US', true , true , u, u, '0.0'        , '0.0'          , 0          ],
+    ['en-US', true , true , u, u, '.00000'     , '0.00000'      , 0          ], // See 2
+    ['en-US', true , true , u, u, '.'          , '0.'           , 0          ],
+    ['en-US', true , true , u, u, '.0'         , '0.0'          , 0          ],
+    ['en-US', true , true , u, u, '-.1'        , '-0.1'         , -0.1       ],
+    ['en-US', true , true , u, u, '.1'         , '0.1'          , 0.1        ],
+    ['en-US', true , true , u, u, '.1.'        , '0.1'          , 0.1        ],
+    ['en-US', true , true , u, u, '.1.2'       , '0.12'         , 0.12       ],
+    ['en-US', true , true , u, u, '1.2'        , '1.2'          , 1.2        ],
+    ['en-US', true , true , u, u, '1.2.'       , '1.2'          , 1.2        ],
+    ['en-US', true , true , u, u, '1..2'       , '1.2'          , 1.2        ],
+    ['en-US', true , true , u, u, '1.2.3'      , '1.23'         , 1.23       ],
+    ['en-US', true , true , u, u, '-1'         , '-1'           , -1         ],
+    ['en-US', true , true , u, u, '-a1'        , '-1'           , -1         ],
+    ['en-US', true , true , u, u, '-1-'        , '-1'           , -1         ],
+    ['en-US', true , true , u, u, '--1'        , '-1'           , -1         ],
+    ['en-US', true , true , u, u, '\u20121'    , '-1'           , -1         ], // See 3
+    ['en-US', true , true , u, u, '1'          , '1'            , 1          ],
+    ['en-US', true , true , u, u, '1,'         , '1'            , 1          ],
+    ['en-US', true , true , u, u, '+1'         , '1'            , 1          ],
+    ['en-US', true , true , u, u, ' 1 '        , '1'            , 1          ],
+    ['en-US', true , true , u, u, 'a1a'        , '1'            , 1          ],
+    ['en-US', true , true , u, u, '1-'         , '1'            , 1          ],
+    ['en-US', true , true , u, u, '12345'      , '12,345'       , 12345      ],
+    ['en-US', true , true , u, u, '12,345'     , '12,345'       , 12345      ],
+    ['en-US', true , true , u, u, '1,2345'     , '12,345'       , 12345      ],
+    ['en-US', true , true , u, u, '1234567.89' , '1,234,567.89' , 1234567.89 ],
+    ['en-US', true , true , u, u, '.123456789' , '0.123456789'  , 0.123456789],
+    ['en-US', true , true , u, u, '-1-2-'      , '-12'          , -12        ],
+    ['en-US', true , true , u, u, '1e2'        , '12'           , 12         ], // See 1
+    ['en-US', true , true , u, u, '1,,2'       , '12'           , 12         ],
+    ['en-US', true , true , u, u, '1-2'        , '12'           , 12         ],
+    ['en-US', true , true , u, u, '12-'        , '12'           , 12         ],
+    ['en-US', true , true , u, u, '1-2-'       , '12'           , 12         ],
+    ['de-DE', true , true , u, u, '2..3'       , '23'           , 23         ],
+    ['de-DE', true , true , u, u, '2,,3'       , '2,3'          , 2.3        ],
+    ['de-DE', true , true , u, u, '1.2.3.4'    , '1.234'        , 1234       ],
+    ['de-DE', true , true , u, u, '1,2,3,4'    , '1,234'        , 1.234      ],
+    ['li'   , true , true , u, u, '-1'         , '-1'           , -1         ], // See 5
+    ['en-US', true , true , 2, 2, '1'          , '1'            , 1          ],
+    ['en-US', true , true , 2, 2, '1.2'        , '1.2'          , 1.2        ],
+    ['en-US', true , true , 2, 2, '1.229'      , '1.23'         , 1.23       ],
+    ['en-US', true , true , 2, 2, '-1.229'     , '-1.23'        , -1.23      ],
+    ['en-US', true , true , u, 2, '1.229'      , '1.23'         , 1.23       ],
+    ['en-US', true , true , u, 2, '1.00'       , '1.00'         , 1          ],
+    ['en-US', true , true , 2, u, '1'          , '1'            , 1          ],
+    ['en-US', true , true , 2, u, '1.0'        , '1.0'          , 1          ],
+    ['en-US', true , true , 2, u, '1.229'      , '1.229'        , 1.229      ],
 
     // 1. Entering numbers in scientific notation is not yet supported. We could
     //    add this in the future.
@@ -94,17 +115,25 @@ describe('parse and re-parse', () => {
     // 5. Important because locale will format using a Unicode minus sign but
     //    we're overriding it with a hyphen.
   ];
-  test.each(localeEnUs)(
-    'with locale=%s, input="%s"',
+  test.each(cases)(
+    'case %#',
     (
       locale,
       allowFloat,
       allowNegative,
+      minimumFractionDigits,
+      maximumFractionDigits,
       input,
       expectedIntermediateDisplay,
       expectedValue,
     ) => {
-      const formatter = getFormatter({ locale, allowFloat, allowNegative });
+      const formatter = getFormatter({
+        locale,
+        allowFloat,
+        allowNegative,
+        minimumFractionDigits,
+        maximumFractionDigits,
+      });
       const parsed = formatter.parse(input);
       expect(parsed.value).toEqual(expectedValue);
       expect(parsed.intermediateDisplay).toEqual(expectedIntermediateDisplay);

--- a/mathesar_ui/src/component-library/number-input/number-formatter/__tests__/formatter.test.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/__tests__/formatter.test.ts
@@ -3,27 +3,31 @@ import { getDerivedOptions } from '../options';
 
 test.each(
   // prettier-ignore
+  [
   // locale
-  //          allowFloat
-  //                 allowNegative
-  //                        useGrouping
-  //                               forceTrailingDecimal
-  //                                      minimumFractionDigits
-  [ //                                       input        output
-    ['en-US', true,  true,  true,  false, 0, 1,          '1'            ],
-    ['en-US', true,  true,  true,  false, 0, 0,          '0'            ],
-    ['en-US', true,  true,  true,  false, 0, -0,         '-0'           ], // See 1
-    ['en-US', true,  true,  true,  false, 0, -1,         '-1'           ],
-    ['en-US', true,  true,  true,  false, 0, 1.1,        '1.1'          ],
-    ['en-US', true,  true,  true,  false, 0, 0.1,        '0.1'          ],
-    ['en-US', true,  true,  true,  false, 0, -0.1,       '-0.1'         ],
-    ['en-US', true,  true,  true,  false, 0, 1.0,        '1'            ],
-    ['en-US', true,  true,  true,  false, 0, 1234,       '1,234'        ],
-    ['en-US', true,  true,  true,  false, 0, 0.123456789,'0.123456789'  ],
-    ['en-US', true,  true,  true,  false, 0, 1234567.89, '1,234,567.89' ],
-    ['en-US', true,  true,  false, false, 0, 1234567.89, '1234567.89'   ],
-    ['de-DE', true,  true,  true,  false, 0, 1234567.89, '1.234.567,89' ],
-    ['en-US', true,  true,  true,  false, 5, 1.1,        '1.10000'      ],
+  //        | allowFloat
+  //        |      | allowNegative
+  //        |      |      | useGrouping
+  //        |      |      |      | forceTrailingDecimal
+  //        |      |      |      |      | minimumFractionDigits
+  //        |      |      |      |      |   | maximumFractionDigits
+  //        |      |      |      |      |   |   | input      | output
+    ['en-US', true,  true,  true,  false, 0, 20, 1,           '1'            ],
+    ['en-US', true,  true,  true,  false, 0, 20, 0,           '0'            ],
+    ['en-US', true,  true,  true,  false, 0, 20, -0,          '-0'           ], // See 1
+    ['en-US', true,  true,  true,  false, 0, 20, -1,          '-1'           ],
+    ['en-US', true,  true,  true,  false, 0, 20, 1.1,         '1.1'          ],
+    ['en-US', true,  true,  true,  false, 0, 20, 0.1,         '0.1'          ],
+    ['en-US', true,  true,  true,  false, 0, 20, -0.1,        '-0.1'         ],
+    ['en-US', true,  true,  true,  false, 0, 20, 1.0,         '1'            ],
+    ['en-US', true,  true,  true,  false, 0, 20, 1234,        '1,234'        ],
+    ['en-US', true,  true,  true,  false, 0, 20, 0.123456789, '0.123456789'  ],
+    ['en-US', true,  true,  true,  false, 0, 20, 1234567.89,  '1,234,567.89' ],
+    ['en-US', true,  true,  false, false, 0, 20, 1234567.89,  '1234567.89'   ],
+    ['de-DE', true,  true,  true,  false, 0, 20, 1234567.89,  '1.234.567,89' ],
+    ['en-US', true,  true,  true,  false, 5, 20, 1.1,         '1.10000'      ],
+    ['en-US', true,  true,  true,  false, 2, 2 , 1.1,         '1.10'         ],
+    ['en-US', true,  true,  true,  false, 2, 2 , 1.559,       '1.56'         ],
   ],
   // 1. Edge case. Intl.NumberFormat accepts `signDisplay: negative` to format
   //    negative zero without a sign, but it's an experimental feature and we
@@ -39,6 +43,7 @@ test.each(
     useGrouping,
     forceTrailingDecimal,
     minimumFractionDigits,
+    maximumFractionDigits,
     input,
     output,
   ) => {
@@ -49,6 +54,7 @@ test.each(
       useGrouping,
       forceTrailingDecimal,
       minimumFractionDigits,
+      maximumFractionDigits,
     };
     const format = makeFormatter(getDerivedOptions(options));
     expect(format(input)).toBe(output);
@@ -63,6 +69,7 @@ test('format, errors', () => {
     useGrouping: true,
     forceTrailingDecimal: false,
     minimumFractionDigits: 0,
+    maximumFractionDigits: 20,
   };
 
   const formatInteger = makeFormatter(

--- a/mathesar_ui/src/component-library/number-input/number-formatter/formatter.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/formatter.ts
@@ -38,6 +38,7 @@ export function makeFormatter(
     if (validationErrors.length) {
       throw new Error(`Unable to format value. ${validationErrors.join(', ')}`);
     }
+
     const parts = Intl.NumberFormat(opts.locale, {
       // Override the numbering system which is inferred from the locale so that
       // we don't end up with 1.2 formatted as "১.২", "۱٫۲", or "१.२". Users
@@ -46,11 +47,13 @@ export function makeFormatter(
       // Bengali, Persian, or Marathi.
       numberingSystem: 'latn',
       minimumFractionDigits: opts.minimumFractionDigits,
+      // Ensure that max is greater or equal to min, for safety's sake.
+      maximumFractionDigits: Math.max(
+        opts.minimumFractionDigits,
+        opts.maximumFractionDigits,
+      ),
       // @ts-ignore because TypeScript's Intl.NumberFormatOptions is not up-to-date
       useGrouping: opts.useGrouping,
-      // 20 is the max allowed by the spec. The default is 3. We set this to
-      // avoid rounding.
-      maximumFractionDigits: 20,
     }).formatToParts(value);
 
     const polishers = [];
@@ -77,6 +80,7 @@ export function formatToNormalizedForm(value: number | bigint): string {
       allowNegative: true,
       useGrouping: false,
       minimumFractionDigits: 0,
+      maximumFractionDigits: 20,
       forceTrailingDecimal: false,
     }),
   )(value);

--- a/mathesar_ui/src/component-library/number-input/number-formatter/inference.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/inference.ts
@@ -1,20 +1,7 @@
-import type { Options } from './options';
-
-function getFractionDigitCount(simplifiedInput: string): number {
+export function fractionDigitCount(simplifiedInput: string): number {
   return (simplifiedInput.split('.')[1] ?? '').length;
 }
 
-function hasTrailingDecimal(simplifiedInput: string): boolean {
+export function hasTrailingDecimal(simplifiedInput: string): boolean {
   return simplifiedInput.endsWith('.');
-}
-
-export function inferOptsFromSimplifiedInput(
-  simplifiedInput: string,
-): Partial<Options> {
-  return {
-    // Need zeros entered after decimal so that the user can continue typing
-    minimumFractionDigits: getFractionDigitCount(simplifiedInput),
-    // Need to retain trailing decimal so that the user can continue typing
-    forceTrailingDecimal: hasTrailingDecimal(simplifiedInput),
-  };
 }

--- a/mathesar_ui/src/component-library/number-input/number-formatter/options.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/options.ts
@@ -16,6 +16,7 @@ export interface Options {
    */
   useGrouping: boolean | 'auto';
   minimumFractionDigits: number;
+  maximumFractionDigits: number;
   forceTrailingDecimal: boolean;
 }
 
@@ -28,6 +29,7 @@ export const defaultOptions: Options = {
   allowNegative: false,
   useGrouping: 'auto',
   minimumFractionDigits: 0,
+  maximumFractionDigits: 20,
   forceTrailingDecimal: false,
 };
 

--- a/mathesar_ui/src/component-library/number-input/number-formatter/parsers.ts
+++ b/mathesar_ui/src/component-library/number-input/number-formatter/parsers.ts
@@ -5,7 +5,7 @@ import {
   makeFormatter,
   factoryToFormatSimplifiedInputForLocale,
 } from './formatter';
-import { inferOptsFromSimplifiedInput } from './inference';
+import { fractionDigitCount, hasTrailingDecimal } from './inference';
 import type { DerivedOptions } from './options';
 
 function parseNumber(simplifiedInput: string): number | undefined {
@@ -61,8 +61,7 @@ export function makeUniversalNumberParser(
   opts: DerivedOptions,
 ): UniversalNumberParser {
   function parse(input: string): UniversalNumberParseResult {
-    const simplify = factoryToSimplify(opts);
-    const simplifiedInput = simplify(input);
+    const simplifiedInput = factoryToSimplify(opts)(input);
     const numberValue = parseNumber(simplifiedInput);
     if (numberValue === undefined) {
       return {
@@ -70,22 +69,31 @@ export function makeUniversalNumberParser(
         intermediateDisplay: simplifiedInput,
       };
     }
-    const normalize = factoryToNormalize(opts);
-    const normalizedInput = normalize(input);
-    const intermediateDisplay = makeFormatter({
-      ...opts,
-      ...inferOptsFromSimplifiedInput(simplifiedInput),
-    })(numberValue);
-    if (formatToNormalizedForm(numberValue) === normalizedInput) {
+    const normalizedInput = factoryToNormalize(opts)(input);
+
+    const canReformatWithoutLossOfPrecision =
+      formatToNormalizedForm(numberValue) === normalizedInput;
+    if (canReformatWithoutLossOfPrecision) {
+      const roundedNumberValue = Object.is(numberValue, -0)
+        ? -0 // Because `toFixed` converts `-0` to `"0"`.
+        : parseFloat(numberValue.toFixed(opts.maximumFractionDigits));
       return {
         value: {
           type: 'number',
-          numericalValue: numberValue,
-          normalizedStringifiedNumber: normalizedInput,
+          numericalValue: roundedNumberValue,
+          normalizedStringifiedNumber: roundedNumberValue.toString(),
         },
-        intermediateDisplay,
+        intermediateDisplay: makeFormatter({
+          ...opts,
+          forceTrailingDecimal: hasTrailingDecimal(simplifiedInput),
+          minimumFractionDigits: Math.min(
+            fractionDigitCount(simplifiedInput),
+            opts.maximumFractionDigits,
+          ),
+        })(roundedNumberValue),
       };
     }
+
     const bigIntValue = parseBigInt(simplifiedInput);
     if (bigIntValue !== undefined) {
       return {
@@ -94,9 +102,15 @@ export function makeUniversalNumberParser(
           numericalValue: bigIntValue,
           normalizedStringifiedNumber: normalizedInput,
         },
-        intermediateDisplay,
+        intermediateDisplay: makeFormatter({
+          ...opts,
+          forceTrailingDecimal: false,
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        })(bigIntValue),
       };
     }
+
     return {
       value: {
         type: 'bigfloat',

--- a/mathesar_ui/src/component-library/types.ts
+++ b/mathesar_ui/src/component-library/types.ts
@@ -5,6 +5,7 @@ export type { BaseInputProps } from './common/base-components/BaseInputTypes';
 export type { Tab } from './tabs/TabContainerTypes';
 export type { TreeItem } from './tree/TreeTypes';
 export type { ComponentAndProps } from './common/types/ComponentAndPropsTypes';
+export type { PartiallyMissingOrUndefined } from './common/types/utilityTypes';
 export * from './icon/IconTypes';
 export * from './file-upload/FileUploadTypes';
 export * from './formatted-input/FormattedInputTypes';

--- a/mathesar_ui/src/components/cell/data-types/components/number/NumberCell.svelte
+++ b/mathesar_ui/src/components/cell/data-types/components/number/NumberCell.svelte
@@ -13,6 +13,8 @@
   export let value: $$Props['value'];
   export let disabled: $$Props['disabled'];
   export let useGrouping: $$Props['useGrouping'];
+  export let minimumFractionDigits: $$Props['minimumFractionDigits'];
+  export let maximumFractionDigits: $$Props['maximumFractionDigits'];
   export let locale: $$Props['locale'];
   export let allowFloat: $$Props['allowFloat'];
 
@@ -21,8 +23,15 @@
     allowFloat,
     allowNegative: true,
     useGrouping,
+    minimumFractionDigits,
   };
-  $: formatter = new StringifiedNumberFormatter(formatterOptions);
+  /** Used only for display -- not during input */
+  $: displayFormatter = new StringifiedNumberFormatter({
+    ...formatterOptions,
+    // We only want to apply `maximumFractionDigits` during display. We don't
+    // want it to take effect during input.
+    maximumFractionDigits,
+  });
 
   function formatValue(
     v: string | number | null | undefined,
@@ -30,7 +39,7 @@
     if (!isDefinedNonNullable(v)) {
       return v;
     }
-    return formatter.format(String(v));
+    return displayFormatter.format(String(v));
   }
 </script>
 

--- a/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
+++ b/mathesar_ui/src/components/cell/data-types/components/typeDefinitions.ts
@@ -1,7 +1,7 @@
 import type {
   FormattedInputProps,
+  NumberFormatterOptions,
   SelectProps,
-  StringifiedNumberInputProps,
 } from '@mathesar-component-library/types';
 
 export interface CellTypeProps<Value> {
@@ -28,11 +28,7 @@ export type TextAreaCellProps = TextBoxCellProps;
 
 // Number
 
-export interface NumberCellExternalProps {
-  locale?: string;
-  allowFloat: boolean;
-  useGrouping: StringifiedNumberInputProps['useGrouping'];
-}
+export type NumberCellExternalProps = Partial<NumberFormatterOptions>;
 
 export interface NumberCellProps
   extends CellTypeProps<string | number>,

--- a/mathesar_ui/src/components/cell/data-types/number.ts
+++ b/mathesar_ui/src/components/cell/data-types/number.ts
@@ -59,14 +59,17 @@ function getProps(
   column: NumberColumn,
   config?: Config,
 ): NumberCellExternalProps {
-  const format = column.display_options?.number_format ?? null;
-  const props = {
+  const displayOptions = column.display_options;
+  const format = displayOptions?.number_format ?? null;
+  return {
     locale: (format && localeMap.get(format)) ?? undefined,
-    useGrouping: getUseGrouping(column.display_options?.use_grouping ?? 'auto'),
+    useGrouping: getUseGrouping(displayOptions?.use_grouping ?? 'auto'),
     allowFloat: getAllowFloat(column, config?.floatAllowanceStrategy),
+    minimumFractionDigits: displayOptions?.minimum_fraction_digits ?? undefined,
+    maximumFractionDigits: displayOptions?.maximum_fraction_digits ?? undefined,
   };
-  return props;
 }
+
 const numberType: CellComponentFactory = {
   get(
     column: NumberColumn,


### PR DESCRIPTION
Fixes #1332

## Before

- The number of digits displayed for a number is always taken from the number of digits in that number's numerical value. There is no way to format `1` as `1.00`, for example. And no way to format `1.119999999` as `1.12`.

## After

- The back end and API supports two display options for numbers:

    - `minimum_fraction_digits`
    - `maximum_fraction_digits`

    Why two separate options? See use-case "(C)" in the [ticket](https://github.com/centerofci/mathesar/issues/1332).

- The Postgres `scale` value for `NUMERIC` numbers is _not_ used to format the number of decimal places. A benefit to this approach is that we can format other Postgres types like `DOUBLE PRECISION`.

- If the value of a number has more decimal places than the formatting allows, it will be rounded during formatting, and the full value will be visible while editing.

## Demo

https://www.loom.com/share/ddd468c2c40e42d190632e56676e8827

## Notes

- The UI implemented here does not address use-case "(C)" in the [ticket](https://github.com/centerofci/mathesar/issues/1332). I have opened #1401 for that purpose.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

