### PR TITLE
Shift partial_update logic and Fix error behaviour for patch updating columns without an "id" field

### DIFF
--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -31,27 +31,12 @@ class TableViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, viewset
         return Table.objects.all().order_by('-created_at')
 
     def partial_update(self, request, pk=None):
+        table = self.get_object()
         serializer = TableSerializer(
-            data=request.data, context={'request': request}, partial=True
+            table, data=request.data, context={'request': request}, partial=True
         )
         serializer.is_valid(raise_exception=True)
-        table = self.get_object()
-
-        # Save the fields that are stored in the model.
-        present_model_fields = []
-        for model_field in table.MODEL_FIELDS:
-            if model_field in serializer.validated_data:
-                setattr(table, model_field, serializer.validated_data[model_field])
-                present_model_fields.append(model_field)
-        table.save(update_fields=present_model_fields)
-        for key in present_model_fields:
-            del serializer.validated_data[key]
-
-        # Save the fields that are stored in the underlying DB.
-        try:
-            table.update_sa_table(serializer.validated_data)
-        except ValueError as e:
-            raise base_api_exceptions.ValueAPIException(e, status_code=status.HTTP_400_BAD_REQUEST)
+        serializer.save()
 
         # Reload the table to avoid cached properties
         table = self.get_object()

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 from psycopg2.errors import DuplicateTable
 from rest_framework import serializers, status
+from rest_framework.exceptions import ValidationError
 from sqlalchemy.exc import ProgrammingError
 
 from db.types.base import get_db_type_enum_from_id
@@ -11,6 +12,7 @@ from mathesar.api.exceptions.validation_exceptions.exceptions import (
 )
 from mathesar.api.exceptions.database_exceptions.exceptions import DuplicateTableAPIException
 from mathesar.api.exceptions.database_exceptions.base_exceptions import ProgrammingAPIException
+from mathesar.api.exceptions.generic_exceptions import base_exceptions as base_api_exceptions
 from mathesar.api.exceptions.mixins import MathesarErrorMessageMixin
 from mathesar.api.serializers.columns import SimpleColumnSerializer
 from mathesar.models import Table, DataFile
@@ -102,6 +104,34 @@ class TableSerializer(MathesarErrorMessageMixin, serializers.ModelSerializer):
             else:
                 raise ProgrammingAPIException(e)
         return table
+    
+    def update(self, instance, validated_data):
+        if self.partial:
+            # Save the fields that are stored in the model.
+            present_model_fields = []
+            for model_field in instance.MODEL_FIELDS:
+                if model_field in validated_data:
+                    setattr(instance, model_field, validated_data[model_field])
+                    present_model_fields.append(model_field)
+            instance.save(update_fields=present_model_fields)
+            for key in present_model_fields:
+                del validated_data[key]
+            # Save the fields that are stored in the underlying DB.
+            try:
+                instance.update_sa_table(validated_data)
+            except ValueError as e:
+                raise base_api_exceptions.ValueAPIException(e, status_code=status.HTTP_400_BAD_REQUEST)
+        return instance
+
+    def validate(self, data):
+        if self.partial:
+            columns = data.get('columns', None)
+            for col in columns:
+                id = col.get('id', None)
+                if id is None:
+                    message = "'id' field is required while batch updating columns."
+                    raise base_api_exceptions.NotFoundAPIException(ValidationError, message=message, status_code=status.HTTP_400_BAD_REQUEST)
+        return data
 
 
 class TablePreviewSerializer(MathesarErrorMessageMixin, serializers.Serializer):


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1389

<!-- Concisely describe what the pull request does. -->
This PR fixes the wrong error that was being thrown while batch updating columns without the "id" field in the request payload. Also, this PR shifts the current `partial_update` logic that was present in the `TableViewSet` to the `TableSerializer` 

**Updated behavior**

#### Request
```json
{
    "columns": [
        {
            "name": "id",
            "type": "INTEGER"
        },
        {
            "name": "Center",
            "type": "TEXT"
        }
    ]
}
```
#### Response
```json
{
     "code": 4005,
     "message": "'id' field is required while batch updating columns.",
     "field": null,
     "detail": null
 }
```
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
