### PR TITLE
Add API support for extracting columns into a new Table

### DIFF
--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -6,6 +6,8 @@ from rest_framework.mixins import ListModelMixin, RetrieveModelMixin, CreateMode
 from rest_framework.response import Response
 from sqlalchemy.exc import DataError, IntegrityError
 
+from db.tables.operations.select import get_oid_from_table
+from db.tables.operations.split import extract_columns_from_table
 from mathesar.api.exceptions.database_exceptions import (
     exceptions as database_api_exceptions,
     base_exceptions as database_base_api_exceptions,
@@ -13,8 +15,12 @@ from mathesar.api.exceptions.database_exceptions import (
 from db.types.exceptions import UnsupportedTypeException
 from mathesar.api.dj_filters import TableFilter
 from mathesar.api.pagination import DefaultLimitOffsetPagination
-from mathesar.api.serializers.tables import TableSerializer, TablePreviewSerializer
+from mathesar.api.serializers.tables import (
+    SplitTableResponseSerializer, SplitTableRequestSerializer, TableSerializer,
+    TablePreviewSerializer,
+)
 from mathesar.models import Table
+from mathesar.reflection import reflect_db_objects
 from mathesar.utils.tables import (
     get_table_column_types
 )
@@ -53,6 +59,35 @@ class TableViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, viewset
         table = self.get_object()
         col_types = get_table_column_types(table)
         return Response(col_types)
+
+    @action(methods=['post'], detail=True)
+    def split_table(self, request, pk=None):
+        table = self.get_object()
+        serializer = SplitTableRequestSerializer(data=request.data, context={"request": request, 'table': table})
+        if serializer.is_valid(True):
+            extracted_columns = [column.name for column in serializer.validated_data['extract_columns']]
+            extracted_table_name = serializer.validated_data['extract_table_name']
+            remainder_table_name = serializer.validated_data['remainder_table_name']
+            drop_original_table = serializer.validated_data['drop_original_table']
+            engine = table._sa_engine
+            extracted_table, remainder_table, remainder_fk = extract_columns_from_table(
+                table.name,
+                extracted_columns,
+                extracted_table_name,
+                remainder_table_name,
+                table.schema.name,
+                engine,
+                drop_original_table=drop_original_table
+            )
+            extracted_table_oid = get_oid_from_table(extracted_table.name, extracted_table.schema, engine)
+            remainder_table_oid = get_oid_from_table(remainder_table.name, remainder_table.schema, engine)
+            reflect_db_objects(skip_cache_check=True)
+            extracted_table_obj = Table.objects.get(oid=extracted_table_oid)
+            remainder_table_obj = Table.objects.get(oid=remainder_table_oid)
+            split_table_response = {'extracted_table': extracted_table_obj.id, 'remainder_table': remainder_table_obj.id}
+            response_serializer = SplitTableResponseSerializer(data=split_table_response)
+            response_serializer.is_valid(True)
+            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     @action(methods=['post'], detail=True)
     def previews(self, request, pk=None):

--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -67,7 +67,7 @@ class TableViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, viewset
             # We need to get the column names before splitting the table,
             # as they are the only reference to the new column after it is moved to a new table
             extracted_column_names = [column.name for column in serializer.validated_data['extract_columns']]
-
+            remainder_column_names = column_names_id_map.keys() - extracted_column_names
             extracted_table_name = serializer.validated_data['extracted_table_name']
             remainder_table_name = serializer.validated_data['remainder_table_name']
             drop_original_table = serializer.validated_data['drop_original_table']
@@ -84,10 +84,16 @@ class TableViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, viewset
             if drop_original_table:
                 table.oid = remainder_table_oid
                 table.save()
-                reflect_tables_from_schema(table.schema)
-                extracted_table = Table.objects.get(oid=extracted_table_oid)
+            # Reflect tables so that the newly created/extracted tables objects are created
+            reflect_tables_from_schema(table.schema)
+
+            if drop_original_table:
+                extracted_table = Table.current_objects.get(oid=extracted_table_oid)
                 # Update attnum as it would have changed due to columns moving to a new table.
-                extracted_table.update_moved_column_reference(extracted_column_names, column_names_id_map)
+                extracted_table.update_column_reference(extracted_column_names, column_names_id_map)
+
+            remainder_table = Table.current_objects.get(oid=remainder_table_oid)
+            remainder_table.update_column_reference(remainder_column_names, column_names_id_map)
 
             reflect_db_objects(skip_cache_check=True)
             extracted_table = Table.objects.get(oid=extracted_table_oid)

--- a/mathesar/api/exceptions/error_codes.py
+++ b/mathesar/api/exceptions/error_codes.py
@@ -41,3 +41,4 @@ class ErrorCodes(Enum):
     UnknownDBType = 4408
     InvalidLinkChoice = 4409
     IncompatibleFractionDigitValues = 4410
+    RemainderTableNameRequired = 4411

--- a/mathesar/api/exceptions/validation_exceptions/exceptions.py
+++ b/mathesar/api/exceptions/validation_exceptions/exceptions.py
@@ -85,3 +85,15 @@ class IncompatibleFractionDigitValuesAPIException(MathesarValidationException):
             details=None,
     ):
         super().__init__(None, self.error_code, message, field, details)
+
+
+class RemainderTableNameRequiredAPIException(MathesarValidationException):
+    error_code = ErrorCodes.RemainderTableNameRequired.value
+
+    def __init__(
+            self,
+            message="Remainder Table name is required when old table is not dropped",
+            field=None,
+            details=None,
+    ):
+        super().__init__(None, self.error_code, message, field, details)

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -16,7 +16,7 @@ from mathesar.api.exceptions.validation_exceptions import base_exceptions as bas
 from mathesar.api.exceptions.generic_exceptions import base_exceptions as base_api_exceptions
 from mathesar.api.exceptions.mixins import MathesarErrorMessageMixin
 from mathesar.api.serializers.columns import SimpleColumnSerializer
-from mathesar.models import Table, DataFile
+from mathesar.models import Column, Table, DataFile
 from mathesar.utils.tables import gen_table_name, create_table_from_datafile, create_empty_table
 
 
@@ -153,3 +153,15 @@ class TablePreviewSerializer(MathesarErrorMessageMixin, serializers.Serializer):
             if db_type is None:
                 raise UnknownDatabaseTypeIdentifier(db_type_id=db_type_id)
         return columns
+
+
+class SplitTableRequestSerializer(MathesarErrorMessageMixin, serializers.Serializer):
+    extract_columns = serializers.PrimaryKeyRelatedField(queryset=Column.current_objects.all(), many=True)
+    extract_table_name = serializers.CharField()
+    remainder_table_name = serializers.CharField()
+    drop_original_table = serializers.BooleanField()
+
+
+class SplitTableResponseSerializer(MathesarErrorMessageMixin, serializers.Serializer):
+    extracted_table = serializers.PrimaryKeyRelatedField(queryset=Table.current_objects.all())
+    remainder_table = serializers.PrimaryKeyRelatedField(queryset=Table.current_objects.all())

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -157,7 +157,7 @@ class TablePreviewSerializer(MathesarErrorMessageMixin, serializers.Serializer):
 
 class SplitTableRequestSerializer(MathesarErrorMessageMixin, serializers.Serializer):
     extract_columns = serializers.PrimaryKeyRelatedField(queryset=Column.current_objects.all(), many=True)
-    extract_table_name = serializers.CharField()
+    extracted_table_name = serializers.CharField()
     remainder_table_name = serializers.CharField()
     drop_original_table = serializers.BooleanField()
 

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -8,7 +8,7 @@ from db.types.base import get_db_type_enum_from_id
 
 from mathesar.api.exceptions.validation_exceptions.exceptions import (
     ColumnSizeMismatchAPIException, DistinctColumnRequiredAPIException,
-    MultipleDataFileAPIException, UnknownDatabaseTypeIdentifier
+    MultipleDataFileAPIException, RemainderTableNameRequiredAPIException, UnknownDatabaseTypeIdentifier,
 )
 from mathesar.api.exceptions.database_exceptions.exceptions import DuplicateTableAPIException
 from mathesar.api.exceptions.database_exceptions.base_exceptions import ProgrammingAPIException
@@ -160,6 +160,11 @@ class SplitTableRequestSerializer(MathesarErrorMessageMixin, serializers.Seriali
     extract_table_name = serializers.CharField()
     remainder_table_name = serializers.CharField()
     drop_original_table = serializers.BooleanField()
+
+    def validate(self, attrs):
+        if not attrs['drop_original_table'] and not attrs['remainder_table_name']:
+            raise RemainderTableNameRequiredAPIException()
+        return super().validate(attrs)
 
 
 class SplitTableResponseSerializer(MathesarErrorMessageMixin, serializers.Serializer):

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -25,6 +25,7 @@ from db.schemas import utils as schema_utils
 from db.tables import utils as table_utils
 from db.tables.operations.drop import drop_table
 from db.tables.operations.select import get_oid_from_table, reflect_table_from_oid
+from db.tables.operations.split import extract_columns_from_table
 from mathesar import reflection
 from mathesar.utils import models as model_utils
 from mathesar.database.base import create_mathesar_engine
@@ -355,6 +356,40 @@ class Table(DatabaseObject):
             for col_name
             in name_list
         ]
+
+    def split_table(
+            self,
+            columns_to_extract,
+            extracted_table_name,
+            remainder_table_name,
+            drop_original_table
+    ):
+        columns_name_to_extract = [column.name for column in columns_to_extract]
+        return extract_columns_from_table(
+            self.name,
+            columns_name_to_extract,
+            extracted_table_name,
+            remainder_table_name,
+            self.schema.name,
+            self._sa_engine,
+            drop_original_table=drop_original_table
+        )
+
+    def update_moved_column_reference(self, columns_name, column_name_id_map):
+        extracted_columns_name_attnum_map = get_columns_attnum_from_names(
+            self.oid,
+            columns_name,
+            self._sa_engine,
+            return_as_name_map=True
+        )
+        extracted_column_objs = []
+        for extracted_column_name, extracted_column_attnum in extracted_columns_name_attnum_map.items():
+            column_id = column_name_id_map[extracted_column_name]
+            column = Column.current_objects.get(id=column_id)
+            column.table_id = self.id
+            column.attnum = extracted_column_attnum
+            extracted_column_objs.append(column)
+        Column.current_objects.bulk_update(extracted_column_objs, fields=['table_id', 'attnum'])
 
 
 class Column(ReflectionManagerMixin, BaseModel):

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -375,21 +375,21 @@ class Table(DatabaseObject):
             drop_original_table=drop_original_table
         )
 
-    def update_moved_column_reference(self, columns_name, column_name_id_map):
-        extracted_columns_name_attnum_map = get_columns_attnum_from_names(
+    def update_column_reference(self, columns_name, column_name_id_map):
+        columns_name_attnum_map = get_columns_attnum_from_names(
             self.oid,
             columns_name,
             self._sa_engine,
             return_as_name_map=True
         )
-        extracted_column_objs = []
-        for extracted_column_name, extracted_column_attnum in extracted_columns_name_attnum_map.items():
-            column_id = column_name_id_map[extracted_column_name]
+        column_objs = []
+        for column_name, column_attnum in columns_name_attnum_map.items():
+            column_id = column_name_id_map[column_name]
             column = Column.current_objects.get(id=column_id)
             column.table_id = self.id
-            column.attnum = extracted_column_attnum
-            extracted_column_objs.append(column)
-        Column.current_objects.bulk_update(extracted_column_objs, fields=['table_id', 'attnum'])
+            column.attnum = column_attnum
+            column_objs.append(column)
+        Column.current_objects.bulk_update(column_objs, fields=['table_id', 'attnum'])
 
 
 class Column(ReflectionManagerMixin, BaseModel):

--- a/mathesar/reflection.py
+++ b/mathesar/reflection.py
@@ -121,8 +121,8 @@ def reflect_new_table_constraints(table):
     return constraints
 
 
-def reflect_db_objects():
-    if not cache.get(DB_REFLECTION_KEY):
+def reflect_db_objects(skip_cache_check=False):
+    if skip_cache_check or not cache.get(DB_REFLECTION_KEY):
         reflect_databases()
         for database in models.Database.current_objects.filter(deleted=False):
             reflect_schemas_from_database(database.name)

--- a/mathesar/tests/api/conftest.py
+++ b/mathesar/tests/api/conftest.py
@@ -142,8 +142,8 @@ def column_test_table_with_service_layer_options(patent_schema):
         Column("mycolumn6", TIMESTAMP),
     ]
     column_data_list = [{},
-                        {'display_options': {'input': "dropdown", "custom_labels": {"TRUE": "yes", "FALSE": "no"}}},
-                        {'display_options': {"show_as_percentage": True, "locale": "en_US"}},
+                        {'display_options': {'input': "dropdown", 'custom_labels': {"TRUE": "yes", "FALSE": "no"}}},
+                        {'display_options': {'show_as_percentage': True, 'number_format': 'english'}},
                         {},
                         {},
                         {},

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -1320,7 +1320,7 @@ def test_table_extract_columns(create_patents_table, client):
     assert expected_extracted_columns_name == extracted_columns_name
     remainder_columns = remainder_table.columns.all()
     remainder_columns_name = [remainder_column.name for remainder_column in remainder_columns]
-    expected_remainder_columns = (set(existing_columns) - set(columns_names_to_extract)) | {'Patent Status_id'}
+    expected_remainder_columns = (set(existing_columns) - set(columns_names_to_extract)) | {'Patent Info_id'}
     assert set(expected_remainder_columns) == set(remainder_columns_name)
 
 

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -1286,3 +1286,39 @@ def test_table_patch_columns_invalid_type_with_multiple_changes(create_data_type
     # The table should not have changed
     original_column_data = _get_data_types_column_data(table)
     _check_columns(current_table_response.json()['columns'], original_column_data)
+
+
+def test_table_extract_columns(create_patents_table, client):
+    table_name = 'Patents'
+    table = create_patents_table(table_name)
+    column_name_id_map = table.get_column_name_id_bidirectional_map()
+    existing_columns = table.columns.all()
+    existing_columns = [existing_column.name for existing_column in existing_columns]
+    columns_names_to_extract = ['Patent Number', 'Title', 'Patent Expiration Date']
+    columns_id_to_extract = [column_name_id_map[name] for name in columns_names_to_extract]
+
+    extract_table_name = "Patent Status"
+    remainder_table_name = "Patent Info"
+    split_data = {
+        'extract_columns': columns_id_to_extract,
+        'extract_table_name': extract_table_name,
+        "remainder_table_name": remainder_table_name,
+        'drop_original_table': False
+    }
+    current_table_response = client.post(f'/api/db/v0/tables/{table.id}/split_table/', data=split_data)
+    assert current_table_response.status_code == 201
+    response_data = current_table_response.json()
+    extracted_table_id = response_data['extracted_table']
+    extracted_table = Table.objects.get(id=extracted_table_id)
+    assert extract_table_name == extracted_table.name
+    remainder_table_id = response_data['remainder_table']
+    remainder_table = Table.objects.get(id=remainder_table_id)
+    assert remainder_table_name == remainder_table.name
+    extracted_columns = extracted_table.columns.all()
+    extracted_columns_name = [extracted_column.name for extracted_column in extracted_columns]
+    expected_extracted_columns_name = ['id'] + columns_names_to_extract
+    assert expected_extracted_columns_name == extracted_columns_name
+    remainder_columns = remainder_table.columns.all()
+    remainder_columns_name = [remainder_column.name for remainder_column in remainder_columns]
+    expected_remainder_columns = (set(existing_columns) - set(columns_names_to_extract)) | {'Patent Status_id'}
+    assert set(expected_remainder_columns) == set(remainder_columns_name)

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -10,7 +10,7 @@ from db.types.base import PostgresType, MathesarCustomType
 from mathesar import reflection
 from mathesar import models
 from mathesar.api.exceptions.error_codes import ErrorCodes
-from mathesar.models import Table, DataFile
+from mathesar.models import Column, Table, DataFile
 
 
 @pytest.fixture
@@ -1297,8 +1297,8 @@ def test_table_extract_columns(create_patents_table, client):
     columns_names_to_extract = ['Patent Number', 'Title', 'Patent Expiration Date']
     columns_id_to_extract = [column_name_id_map[name] for name in columns_names_to_extract]
 
-    extract_table_name = "Patent Status"
-    remainder_table_name = "Patent Info"
+    extract_table_name = "Patent Info"
+    remainder_table_name = "Patent Status"
     split_data = {
         'extract_columns': columns_id_to_extract,
         'extract_table_name': extract_table_name,
@@ -1322,3 +1322,31 @@ def test_table_extract_columns(create_patents_table, client):
     remainder_columns_name = [remainder_column.name for remainder_column in remainder_columns]
     expected_remainder_columns = (set(existing_columns) - set(columns_names_to_extract)) | {'Patent Status_id'}
     assert set(expected_remainder_columns) == set(remainder_columns_name)
+
+
+def test_table_extract_columns_with_display_options(create_patents_table, client):
+    table_name = 'Patents'
+    table = create_patents_table(table_name)
+    column_name_id_map = table.get_column_name_id_bidirectional_map()
+    existing_columns = table.columns.all()
+    existing_columns = [existing_column.name for existing_column in existing_columns]
+    columns_names_to_extract = ['Patent Number', 'Title', 'Patent Expiration Date']
+    columns_id_to_extract = [column_name_id_map[name] for name in columns_names_to_extract]
+    extract_column_display_options = {'show_as_percentage': True, 'number_format': 'english'}
+    extract_column_name_with_display_options = columns_names_to_extract[0]
+    extract_column_id_with_display_options = column_name_id_map[extract_column_name_with_display_options]
+    Column.objects.filter(id=extract_column_id_with_display_options).update(display_options=extract_column_display_options)
+    extract_table_name = "Patent Info"
+    remainder_table_name = "Patent Status"
+    split_data = {
+        'extract_columns': columns_id_to_extract,
+        'extract_table_name': extract_table_name,
+        "remainder_table_name": remainder_table_name,
+        'drop_original_table': True
+    }
+    current_table_response = client.post(f'/api/db/v0/tables/{table.id}/split_table/', data=split_data)
+    assert current_table_response.status_code == 201
+    response_data = current_table_response.json()
+    extracted_table_id = response_data['extracted_table']
+    extracted_table = Table.objects.get(id=extracted_table_id)
+    assert extracted_table.get_column_name_id_bidirectional_map()[extract_column_name_with_display_options] == extract_column_id_with_display_options

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -1376,8 +1376,6 @@ def test_table_extract_columns_with_display_options(create_patents_table, client
     column_name_id_map = table.get_column_name_id_bidirectional_map()
     column_names_to_extract = ['Patent Number', 'Title', 'Patent Expiration Date']
     column_ids_to_extract = [column_name_id_map[name] for name in column_names_to_extract]
-    existing_columns = table.columns.all()
-    existing_columns = [existing_column.name for existing_column in existing_columns]
     column_name_with_display_options = column_names_to_extract[0]
     column_id_with_display_options = column_name_id_map[column_name_with_display_options]
 

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.core.files.base import File, ContentFile
 from sqlalchemy import text
 
+from db.columns.operations.select import get_columns_attnum_from_names
 from db.types.base import PostgresType, MathesarCustomType
 
 from mathesar import reflection
@@ -1288,7 +1289,7 @@ def test_table_patch_columns_invalid_type_with_multiple_changes(create_data_type
     _check_columns(current_table_response.json()['columns'], original_column_data)
 
 
-def test_table_extract_columns(create_patents_table, client):
+def test_table_extract_columns_retain_original_table(create_patents_table, client):
     table_name = 'Patents'
     table = create_patents_table(table_name)
     column_name_id_map = table.get_column_name_id_bidirectional_map()
@@ -1314,16 +1315,59 @@ def test_table_extract_columns(create_patents_table, client):
     remainder_table_id = response_data['remainder_table']
     remainder_table = Table.objects.get(id=remainder_table_id)
     assert remainder_table_name == remainder_table.name
-
+    assert remainder_table.id != table.id
+    assert Table.objects.filter(id=table.id).count() == 1
     extracted_columns = extracted_table.columns.all()
-    extracted_columns_name = [extracted_column.name for extracted_column in extracted_columns]
+    extracted_column_names = [extracted_column.name for extracted_column in extracted_columns]
     expected_extracted_column_names = ['id'] + column_names_to_extract
-    assert expected_extracted_column_names == extracted_columns_name
+    assert expected_extracted_column_names == extracted_column_names
 
     remainder_columns = remainder_table.columns.all()
     remainder_column_names = [remainder_column.name for remainder_column in remainder_columns]
     expected_remainder_columns = (set(existing_columns) - set(column_names_to_extract)) | {'Patent Info_id'}
     assert set(expected_remainder_columns) == set(remainder_column_names)
+
+
+def test_table_extract_columns_drop_original_table(create_patents_table, client):
+    table_name = 'Patents'
+    table = create_patents_table(table_name)
+    column_name_id_map = table.get_column_name_id_bidirectional_map()
+    column_names_to_extract = ['Patent Number', 'Title', 'Patent Expiration Date']
+    column_ids_to_extract = [column_name_id_map[name] for name in column_names_to_extract]
+    existing_columns = table.columns.all()
+    existing_columns = [existing_column.name for existing_column in existing_columns]
+    remainder_column_names = (set(existing_columns) - set(column_names_to_extract))
+
+    extract_table_name = "Patent Info"
+    remainder_table_name = "Patent Status"
+    split_data = {
+        'extract_columns': column_ids_to_extract,
+        'extracted_table_name': extract_table_name,
+        "remainder_table_name": remainder_table_name,
+        'drop_original_table': True
+    }
+    current_table_response = client.post(f'/api/db/v0/tables/{table.id}/split_table/', data=split_data)
+    assert current_table_response.status_code == 201
+    response_data = current_table_response.json()
+    extracted_table_id = response_data['extracted_table']
+    extracted_table = Table.objects.get(id=extracted_table_id)
+    remainder_table_id = response_data['remainder_table']
+    remainder_table = Table.objects.get(id=remainder_table_id)
+
+    remainder_columns = remainder_table.columns.all()
+    remainder_columns_map = {column.name: column for column in remainder_columns}
+    columns_with_attnum = get_columns_attnum_from_names(remainder_table.oid, remainder_column_names, remainder_table._sa_engine, return_as_name_map=True)
+    for remainder_column_name in remainder_column_names:
+        remainder_column = remainder_columns_map[remainder_column_name]
+        assert remainder_column.attnum == columns_with_attnum[remainder_column.name]
+        assert remainder_column.id == column_name_id_map[remainder_column.name]
+
+    extracted_columns = extracted_table.columns.all()
+    columns_with_attnum = get_columns_attnum_from_names(extracted_table.oid, column_names_to_extract, extracted_table._sa_engine, return_as_name_map=True)
+    for extracted_column in extracted_columns:
+        if extracted_column.name != 'id':
+            assert extracted_column.attnum == columns_with_attnum[extracted_column.name]
+            assert extracted_column.id == column_name_id_map[extracted_column.name]
 
 
 def test_table_extract_columns_with_display_options(create_patents_table, client):
@@ -1332,7 +1376,8 @@ def test_table_extract_columns_with_display_options(create_patents_table, client
     column_name_id_map = table.get_column_name_id_bidirectional_map()
     column_names_to_extract = ['Patent Number', 'Title', 'Patent Expiration Date']
     column_ids_to_extract = [column_name_id_map[name] for name in column_names_to_extract]
-
+    existing_columns = table.columns.all()
+    existing_columns = [existing_column.name for existing_column in existing_columns]
     column_name_with_display_options = column_names_to_extract[0]
     column_id_with_display_options = column_name_id_map[column_name_with_display_options]
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1428 

Adds API support for splitting tables. 


Note: The PR does not convert the parameters of the `extract_columns_from_table` function to use database identifiers like `oid` and `attnum` instead of `names` due to a lot of changes required in functions like `move_columns_between_related_tables` that make use of `extract_columns_from_table`. I will be addressing the conversion from name to oid in a different PR.

**Technical Details**
The API schema for splitting tables



```typescript
// POST /tables/{id}/split_table/
interface SplitTableRequest {
        'extract_columns': number[],
        'extracted_table_name': string,
        "remainder_table_name": string,
        'drop_original_table': boolean
}

// returns
interface SplitTableResponse {
        'extracted_table': number,
        'remainder_table': number
}

```