### PR TITLE
Add record selector API.

### DIFF
--- a/db/records/operations/select.py
+++ b/db/records/operations/select.py
@@ -37,6 +37,7 @@ def get_query(
     filter=None,
     columns_to_select=None,
     group_by=None,
+    search={},
     duplicate_only=None
 ):
     if duplicate_only:
@@ -75,6 +76,7 @@ def get_records(
     order_by=[],
     filter=None,
     group_by=None,
+    search={},
     duplicate_only=None,
 ):
     """
@@ -87,6 +89,8 @@ def get_records(
         offset:          int, gives number of rows to skip
         order_by:        list of dictionaries, where each dictionary has a 'field' and
                          'direction' field.
+        search:          list of dictionaries, where each dictionary has a 'column' and
+                         'literal' field.
                          See: https://github.com/centerofci/sqlalchemy-filters#sort-format
         filter:          a dictionary with one key-value pair, where the key is the filter id and
                          the value is a list of parameters; supports composition/nesting.
@@ -113,6 +117,7 @@ def get_records(
         order_by=order_by,
         filter=filter,
         group_by=group_by,
+        search=search,
         duplicate_only=duplicate_only
     )
     return execute_query(engine, query)

--- a/mathesar/api/db/viewsets/records.py
+++ b/mathesar/api/db/viewsets/records.py
@@ -42,6 +42,7 @@ class RecordViewSet(viewsets.ViewSet):
         filter_unprocessed = serializer.validated_data['filter']
         order_by = serializer.validated_data['order_by']
         grouping = serializer.validated_data['grouping']
+        search_fuzzy = serializer.validated_data['search_fuzzy']
         filter_processed = None
         column_names_to_ids = table.get_column_name_id_bidirectional_map()
         column_ids_to_names = column_names_to_ids.inverse
@@ -57,6 +58,7 @@ class RecordViewSet(viewsets.ViewSet):
             group_by_columns_names = [column_ids_to_names[column_id] for column_id in grouping['columns']]
             name_converted_group_by = {**grouping, 'columns': group_by_columns_names}
         name_converted_order_by = [{**column, 'field': column_ids_to_names[column['field']]} for column in order_by]
+        name_converted_search = [{**search_fuzzy, 'column': column_ids_to_names[column['field']]} for column in search_fuzzy]
 
         try:
 
@@ -65,6 +67,7 @@ class RecordViewSet(viewsets.ViewSet):
                 filters=filter_processed,
                 order_by=name_converted_order_by,
                 grouping=name_converted_group_by,
+                search=name_converted_search,
                 duplicate_only=serializer.validated_data['duplicate_only'],
             )
         except (BadDBFunctionFormat, UnknownDBFunctionID, ReferencedColumnsDontExist) as e:

--- a/mathesar/api/pagination.py
+++ b/mathesar/api/pagination.py
@@ -45,6 +45,7 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
         filters=None,
         order_by=[],
         group_by=None,
+        search={},
         duplicate_only=None,
     ):
         self.limit = self.get_limit(request)
@@ -61,6 +62,7 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
             filter=filters,
             order_by=order_by,
             group_by=group_by,
+            search=search,
             duplicate_only=duplicate_only,
         )
 
@@ -86,6 +88,7 @@ class TableLimitOffsetGroupPagination(TableLimitOffsetPagination):
         filters=None,
         order_by=[],
         grouping={},
+        search={},
         duplicate_only=None,
     ):
         group_by = GroupBy(**grouping) if grouping else None
@@ -96,6 +99,7 @@ class TableLimitOffsetGroupPagination(TableLimitOffsetPagination):
             filters=filters,
             order_by=order_by,
             group_by=group_by,
+            search=search,
             duplicate_only=duplicate_only,
         )
 

--- a/mathesar/api/serializers/records.py
+++ b/mathesar/api/serializers/records.py
@@ -10,11 +10,17 @@ from mathesar.api.utils import follows_json_number_spec
 from mathesar.database.types import UIType
 
 
+class SearchParameterSerializer(MathesarErrorMessageMixin, serializers.Serializer):
+    column = serializers.PrimaryKeyRelatedField(queryset=Column.current_objects.all())
+    literal = serializers.CharField()
+
+
 class RecordListParameterSerializer(MathesarErrorMessageMixin, serializers.Serializer):
     filter = serializers.JSONField(required=False, default=None)
     order_by = serializers.JSONField(required=False, default=[])
     grouping = serializers.JSONField(required=False, default={})
     duplicate_only = serializers.JSONField(required=False, default=None)
+    search_fuzzy = SearchParameterSerializer(many=True)
 
 
 class RecordSerializer(MathesarErrorMessageMixin, serializers.BaseSerializer):

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -297,6 +297,7 @@ class Table(DatabaseObject):
         filter=None,
         order_by=[],
         group_by=None,
+        search={},
         duplicate_only=None,
     ):
         return db_get_records(
@@ -307,6 +308,7 @@ class Table(DatabaseObject):
             filter=filter,
             order_by=order_by,
             group_by=group_by,
+            search=search,
             duplicate_only=duplicate_only,
         )
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1440  

Adds `search_fuzzy` parameter to the `/records/` API.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
