### PR TITLE
Get a full graph of dependent database objects

### DIFF
--- a/db/dependents_utils.py
+++ b/db/dependents_utils.py
@@ -74,7 +74,7 @@ def get_dependents_hierarchy(name, schema, engine):
 
     bottomq = select(all_cte,
         literal_column('cte.level + 1').label('level'),
-        topq.c.chain + array([all_cte.c.objid])).where(topq.c.level < 10).where(all_cte.c.objid != any_(topq.c.chain))
+        topq.c.chain + array([all_cte.c.objid])).where(topq.c.level < 10).where(all_cte.c.objid != any_(topq.c.chain)).where(all_cte.c.objid != all_cte.c.refobjid)
     bottomq = bottomq.join(topq, all_cte.c.refobjid == topq.c.objid)
 
     recursive_q = topq.union(bottomq)

--- a/db/dependents_utils.py
+++ b/db/dependents_utils.py
@@ -1,0 +1,71 @@
+from sqlalchemy import MetaData, Table, any_, case, column, exists, func, select, true
+from db.tables.operations.select import get_oid_from_table
+
+
+def has_dependencies(name, schema, engine):
+    oid = get_oid_from_table(name, schema, engine)
+    
+    metadata = MetaData()
+    pg_depend = Table("pg_depend", metadata, autoload_with=engine)
+
+    stmt = select(
+        exists(
+            select().select_from(pg_depend) \
+    .where(pg_depend.c.refobjid == oid) \
+    .where(pg_depend.c.deptype == any_('{a,n}')) \
+    .where(pg_depend.c.objid >= 16384) \
+    .group_by(
+        pg_depend.c.objid,
+        pg_depend.c.deptype)
+        )) \
+
+    with engine.connect() as conn:
+        result = conn.execute(stmt)
+
+    return result
+
+
+def get_dependent_objects(name, schema, engine):
+    oid = get_oid_from_table(name, schema, engine)
+    
+    metadata = MetaData()
+    pg_depend = Table("pg_depend", metadata, autoload_with=engine)
+
+    pg_identify_object = select(
+            column("name"),
+            column("type"),
+            column("identity")) \
+        .select_from(func.pg_identify_object(
+            pg_depend.c.classid,
+            pg_depend.c.objid,
+            pg_depend.c.objsubid)) \
+        .lateral()
+
+    dependency_case = case(
+                    (pg_depend.c.deptype == 'n', 'normal'),
+                    (pg_depend.c.deptype == 'a', 'automatic')
+                ).label('dependency_type')
+
+    stmt = select(
+        pg_depend.c.objid,
+        func.array_agg(pg_depend.c.objsubid),
+        pg_identify_object.c.name,
+        pg_identify_object.c.type,
+        pg_identify_object.c.identity,
+        dependency_case) \
+    .select_from(pg_depend) \
+    .join(pg_identify_object, true()) \
+    .where(pg_depend.c.refobjid == oid) \
+    .where(pg_depend.c.deptype == any_('{a,n}')) \
+    .where(pg_depend.c.objid >= 16384) \
+    .group_by(
+        pg_depend.c.objid,
+        pg_identify_object.c.type,
+        pg_identify_object.c.name,
+        pg_identify_object.c.identity,
+        pg_depend.c.deptype)
+
+    with engine.connect() as conn:
+        result = conn.execute(stmt)
+
+    return result

--- a/db/dependents_utils.py
+++ b/db/dependents_utils.py
@@ -2,7 +2,9 @@ from sqlalchemy import MetaData, Table, any_, case, column, exists, func, select
 from db.tables.operations.select import get_oid_from_table
 
 
-def _get_tables_dependents(foreign_key_dependents, pg_constraint):
+# CTEs for getting dependents of a specific type
+
+def _get_table_dependents(foreign_key_dependents, pg_constraint):
     pg_identify_object = select(
         column("name"),
         column("schema"),
@@ -38,24 +40,16 @@ def _get_tables_dependents(foreign_key_dependents, pg_constraint):
 
 def _get_foreign_key_constraint_dependents(pg_identify_object, base):
     return base.where(pg_identify_object.c.type == 'table constraint')
-    
 
+
+# Full statements
 
 def get_all_dependent_objects(name, schema, engine):
     referenced_object_id = get_oid_from_table(name, schema, engine)
-    
     pg_depend = _get_pg_depend(engine)
     pg_identify_object = _get_pg_identify_object_lateral(pg_depend)
-    pg_constraint = _get_pg_constraint(engine)
-
-    base_stmt = _get_dependent_objects_base_statement(pg_depend, pg_identify_object, referenced_object_id)
-    foreign_key_constraint_dependents = _get_foreign_key_constraint_dependents(pg_identify_object, base_stmt).cte('foreign_key_constraint_dependents')
-    table_dependents = _get_tables_dependents(foreign_key_constraint_dependents, pg_constraint).cte('table_dependents')
-
-    combined = union(select(foreign_key_constraint_dependents), select(table_dependents)).cte("combined")
-    stmt = select(combined)
-
-
+    final = _get_all_dependent_objects_base_statement(pg_depend, pg_identify_object, referenced_object_id).cte()
+    stmt = select(final)
 
     with engine.connect() as conn:
         result = conn.execute(stmt)
@@ -63,17 +57,28 @@ def get_all_dependent_objects(name, schema, engine):
     return result
 
 def get_dependents_hierarchy(name, schema, engine):
-    top_level_dependents = get_all_dependent_objects(name, schema, engine)
+    referenced_object_id = get_oid_from_table(name, schema, engine)
+    pg_depend = _get_pg_depend(engine)
+    pg_identify_object = _get_pg_identify_object_lateral(pg_depend)
+    all = _get_all_dependent_objects_base_statement(pg_depend, pg_identify_object)
+    all_cte = all.cte(recursive=True, name='all')
 
-    select(
-        text('0').label('level'),
-        
-    )
+    topq = select(all_cte).where(all_cte.c.refobjid == referenced_object_id)
+    topq = topq.cte('cte')
 
-    pass
+    bottomq = select(all_cte)
+    bottomq = bottomq.join(topq, all_cte.c.refobjid == topq.c.objid)
+
+    recursive_q = topq.union(bottomq)
+    q = select(recursive_q)
+
+    with engine.connect() as conn:
+        result = conn.execute(q)
+
+    return result
 
 
-def _get_dependent_objects_base_statement(pg_depend, pg_identify_object, referenced_object_id):
+def _get_dependent_objects_by_id_base_statement(pg_depend, pg_identify_object, referenced_object_id):
     return select(
         pg_depend.c.objid,
         func.array_agg(pg_depend.c.objsubid).label('column_number'),
@@ -95,7 +100,33 @@ def _get_dependent_objects_base_statement(pg_depend, pg_identify_object, referen
         pg_identify_object.c.identity,
         pg_depend.c.deptype)
 
+def _get_all_dependent_objects_base_statement(pg_depend, pg_identify_object, referenced_object_id = None):
+    res = select(
+        pg_depend.c.objid,
+        pg_depend.c.refobjid,
+        func.array_agg(pg_depend.c.objsubid).label('column_number'),
+        pg_identify_object.c.name,
+        pg_identify_object.c.schema,
+        pg_identify_object.c.type,
+        pg_identify_object.c.identity,
+        _get_dependency_case(pg_depend).label('dependency_type')) \
+    .select_from(pg_depend) \
+    .join(pg_identify_object, true()) \
+    .where(pg_depend.c.deptype == any_('{a,n}')) \
+    .where(pg_depend.c.objid >= 16384) \
+    .group_by(
+        pg_depend.c.objid,
+        pg_depend.c.refobjid,
+        pg_identify_object.c.type,
+        pg_identify_object.c.name,
+        pg_identify_object.c.schema,
+        pg_identify_object.c.identity,
+        pg_depend.c.deptype)
 
+    return res if referenced_object_id is None else res.where(pg_depend.c.refobjid == referenced_object_id)
+
+
+# Getting helpers
 
 def _get_pg_depend(engine):
     metadata = MetaData()
@@ -125,6 +156,21 @@ def _get_dependency_case(pg_depend):
         (pg_depend.c.deptype == 'a', 'automatic')
     ).label('dependency_type')
 
+
+# Callers
+
+def _get_all_dependent_objects_stmt(name, schema, engine):
+    referenced_object_id = get_oid_from_table(name, schema, engine)
+    
+    pg_depend = _get_pg_depend(engine)
+    pg_identify_object = _get_pg_identify_object_lateral(pg_depend)
+    pg_constraint = _get_pg_constraint(engine)
+
+    base_stmt = _get_dependent_objects_by_id_base_statement(pg_depend, pg_identify_object, referenced_object_id)
+    foreign_key_constraint_dependents = _get_foreign_key_constraint_dependents(pg_identify_object, base_stmt).cte('foreign_key_constraint_dependents')
+    table_dependents = _get_table_dependents(foreign_key_constraint_dependents, pg_constraint).cte('table_dependents')
+
+    return union(select(foreign_key_constraint_dependents), select(table_dependents))
 
 def has_dependencies(name, schema, engine):
     oid = get_oid_from_table(name, schema, engine)

--- a/db/dependents_utils.py
+++ b/db/dependents_utils.py
@@ -1,71 +1,144 @@
-from sqlalchemy import MetaData, Table, any_, case, column, exists, func, select, true
+from sqlalchemy import MetaData, Table, any_, case, column, exists, func, select, text, true, union
 from db.tables.operations.select import get_oid_from_table
+
+
+def _get_tables_dependents(foreign_key_dependents, pg_constraint):
+    pg_identify_object = select(
+        column("name"),
+        column("schema"),
+        column("type"),
+        column("identity")) \
+    .select_from(func.pg_identify_object(
+        text('\'pg_class\'::regclass::oid'),
+        pg_constraint.c.conrelid,
+        0)) \
+    .lateral()
+
+    return select(
+        pg_constraint.c.conrelid.label('objid'),
+        foreign_key_dependents.c.column_number,
+        pg_identify_object.c.name,
+        pg_identify_object.c.schema,
+        pg_identify_object.c.type,
+        pg_identify_object.c.identity,
+        foreign_key_dependents.c.dependency_type
+    ).select_from(foreign_key_dependents) \
+    .join(pg_constraint, pg_constraint.c.oid == foreign_key_dependents.c.objid) \
+    .join(pg_identify_object, true()) \
+    .where(pg_constraint.c.confrelid != 0) \
+    .group_by(
+        pg_constraint.c.conrelid,
+        foreign_key_dependents.c.column_number,
+        pg_identify_object.c.type,
+        pg_identify_object.c.name,
+        pg_identify_object.c.schema,
+        pg_identify_object.c.identity,
+        foreign_key_dependents.c.dependency_type)
+
+
+def _get_foreign_key_constraint_dependents(pg_identify_object, base):
+    return base.where(pg_identify_object.c.type == 'table constraint')
+    
+
+
+def get_all_dependent_objects(name, schema, engine):
+    referenced_object_id = get_oid_from_table(name, schema, engine)
+    
+    pg_depend = _get_pg_depend(engine)
+    pg_identify_object = _get_pg_identify_object_lateral(pg_depend)
+    pg_constraint = _get_pg_constraint(engine)
+
+    base_stmt = _get_dependent_objects_base_statement(pg_depend, pg_identify_object, referenced_object_id)
+    foreign_key_constraint_dependents = _get_foreign_key_constraint_dependents(pg_identify_object, base_stmt).cte('foreign_key_constraint_dependents')
+    table_dependents = _get_tables_dependents(foreign_key_constraint_dependents, pg_constraint).cte('table_dependents')
+
+    combined = union(select(foreign_key_constraint_dependents), select(table_dependents)).cte("combined")
+    stmt = select(combined)
+
+
+
+    with engine.connect() as conn:
+        result = conn.execute(stmt)
+
+    return result
+
+def get_dependents_hierarchy(name, schema, engine):
+    top_level_dependents = get_all_dependent_objects(name, schema, engine)
+
+    select(
+        text('0').label('level'),
+        
+    )
+
+    pass
+
+
+def _get_dependent_objects_base_statement(pg_depend, pg_identify_object, referenced_object_id):
+    return select(
+        pg_depend.c.objid,
+        func.array_agg(pg_depend.c.objsubid).label('column_number'),
+        pg_identify_object.c.name,
+        pg_identify_object.c.schema,
+        pg_identify_object.c.type,
+        pg_identify_object.c.identity,
+        _get_dependency_case(pg_depend).label('dependency_type')) \
+    .select_from(pg_depend) \
+    .join(pg_identify_object, true()) \
+    .where(pg_depend.c.refobjid == referenced_object_id) \
+    .where(pg_depend.c.deptype == any_('{a,n}')) \
+    .where(pg_depend.c.objid >= 16384) \
+    .group_by(
+        pg_depend.c.objid,
+        pg_identify_object.c.type,
+        pg_identify_object.c.name,
+        pg_identify_object.c.schema,
+        pg_identify_object.c.identity,
+        pg_depend.c.deptype)
+
+
+
+def _get_pg_depend(engine):
+    metadata = MetaData()
+    return Table("pg_depend", metadata, autoload_with=engine)
+
+def _get_pg_constraint(engine):
+    metadata = MetaData()
+    return Table("pg_constraint", metadata, autoload_with=engine)
+
+
+def _get_pg_identify_object_lateral(source):
+    return select(
+        column("name"),
+        column("schema"),
+        column("type"),
+        column("identity")) \
+    .select_from(func.pg_identify_object(
+        source.c.classid,
+        source.c.objid,
+        source.c.objsubid)) \
+    .lateral()
+
+
+def _get_dependency_case(pg_depend):
+    return case(
+        (pg_depend.c.deptype == 'n', 'normal'),
+        (pg_depend.c.deptype == 'a', 'automatic')
+    ).label('dependency_type')
 
 
 def has_dependencies(name, schema, engine):
     oid = get_oid_from_table(name, schema, engine)
-    
-    metadata = MetaData()
-    pg_depend = Table("pg_depend", metadata, autoload_with=engine)
+    pg_depend = _get_pg_depend(engine)
 
     stmt = select(
         exists(
             select().select_from(pg_depend) \
-    .where(pg_depend.c.refobjid == oid) \
-    .where(pg_depend.c.deptype == any_('{a,n}')) \
-    .where(pg_depend.c.objid >= 16384) \
-    .group_by(
-        pg_depend.c.objid,
-        pg_depend.c.deptype)
-        )) \
+            .where(pg_depend.c.refobjid == oid) \
+            .where(pg_depend.c.deptype == any_('{a,n}')) \
+            .where(pg_depend.c.objid >= 16384)
+        ))
 
     with engine.connect() as conn:
         result = conn.execute(stmt)
 
-    return result
-
-
-def get_dependent_objects(name, schema, engine):
-    oid = get_oid_from_table(name, schema, engine)
-    
-    metadata = MetaData()
-    pg_depend = Table("pg_depend", metadata, autoload_with=engine)
-
-    pg_identify_object = select(
-            column("name"),
-            column("type"),
-            column("identity")) \
-        .select_from(func.pg_identify_object(
-            pg_depend.c.classid,
-            pg_depend.c.objid,
-            pg_depend.c.objsubid)) \
-        .lateral()
-
-    dependency_case = case(
-                    (pg_depend.c.deptype == 'n', 'normal'),
-                    (pg_depend.c.deptype == 'a', 'automatic')
-                ).label('dependency_type')
-
-    stmt = select(
-        pg_depend.c.objid,
-        func.array_agg(pg_depend.c.objsubid),
-        pg_identify_object.c.name,
-        pg_identify_object.c.type,
-        pg_identify_object.c.identity,
-        dependency_case) \
-    .select_from(pg_depend) \
-    .join(pg_identify_object, true()) \
-    .where(pg_depend.c.refobjid == oid) \
-    .where(pg_depend.c.deptype == any_('{a,n}')) \
-    .where(pg_depend.c.objid >= 16384) \
-    .group_by(
-        pg_depend.c.objid,
-        pg_identify_object.c.type,
-        pg_identify_object.c.name,
-        pg_identify_object.c.identity,
-        pg_depend.c.deptype)
-
-    with engine.connect() as conn:
-        result = conn.execute(stmt)
-
-    return result
+    return result is not None

--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -54,6 +54,11 @@ class TableViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, viewset
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(methods=['get'], detail=True)
+    def dependents(self, request, pk=None):
+        table = self.get_object()
+        return Response(table.dependents())
+
+    @action(methods=['get'], detail=True)
     def type_suggestions(self, request, pk=None):
         table = self.get_object()
         col_types = get_table_column_types(table)

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -27,6 +27,7 @@ class TableSerializer(MathesarErrorMessageMixin, serializers.ModelSerializer):
     columns_url = serializers.SerializerMethodField()
     type_suggestions_url = serializers.SerializerMethodField()
     previews_url = serializers.SerializerMethodField()
+    dependents_url = serializers.SerializerMethodField()
     name = serializers.CharField(required=False, allow_blank=True, default='')
     data_files = serializers.PrimaryKeyRelatedField(
         required=False, many=True, queryset=DataFile.objects.all()
@@ -37,7 +38,7 @@ class TableSerializer(MathesarErrorMessageMixin, serializers.ModelSerializer):
         fields = ['id', 'name', 'schema', 'created_at', 'updated_at', 'import_verified',
                   'columns', 'records_url', 'constraints_url', 'columns_url',
                   'type_suggestions_url', 'previews_url', 'data_files',
-                  'has_dependencies']
+                  'has_dependencies', 'dependents_url']
 
     def get_records_url(self, obj):
         if isinstance(obj, Table):
@@ -76,6 +77,13 @@ class TableSerializer(MathesarErrorMessageMixin, serializers.ModelSerializer):
             # Only get previews if we are serializing an existing table
             request = self.context['request']
             return request.build_absolute_uri(reverse('table-previews', kwargs={'pk': obj.pk}))
+        else:
+            return None
+
+    def get_dependents_url(self, obj):
+        if isinstance(obj, Table):
+            request = self.context['request']
+            return request.build_absolute_uri(reverse('table-dependents', kwargs={'pk': obj.pk}))
         else:
             return None
 

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -15,7 +15,7 @@ from db.constraints.operations.create import create_constraint
 from db.constraints.operations.drop import drop_constraint
 from db.constraints.operations.select import get_constraint_oid_by_name_and_table_oid, get_constraint_from_oid
 from db.constraints import utils as constraint_utils
-from db.dependents_utils import get_dependent_objects, has_dependencies
+from db.dependents_utils import get_all_dependent_objects, has_dependencies
 from db.records.operations.delete import delete_record
 from db.records.operations.insert import insert_record_or_records
 from db.records.operations.select import get_column_cast_records, get_count, get_record
@@ -244,7 +244,7 @@ class Table(DatabaseObject):
         )
 
     def dependents(self):
-        return get_dependent_objects(
+        return get_all_dependent_objects(
             self.name,
             self.schema.name,
             self.schema._sa_engine

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -15,7 +15,7 @@ from db.constraints.operations.create import create_constraint
 from db.constraints.operations.drop import drop_constraint
 from db.constraints.operations.select import get_constraint_oid_by_name_and_table_oid, get_constraint_from_oid
 from db.constraints import utils as constraint_utils
-from db.dependents_utils import get_all_dependent_objects, has_dependencies
+from db.dependents_utils import get_all_dependent_objects, has_dependencies, get_dependents_hierarchy
 from db.records.operations.delete import delete_record
 from db.records.operations.insert import insert_record_or_records
 from db.records.operations.select import get_column_cast_records, get_count, get_record
@@ -244,7 +244,7 @@ class Table(DatabaseObject):
         )
 
     def dependents(self):
-        return get_all_dependent_objects(
+        return get_dependents_hierarchy(
             self.name,
             self.schema.name,
             self.schema._sa_engine

--- a/mathesar/models.py
+++ b/mathesar/models.py
@@ -15,6 +15,7 @@ from db.constraints.operations.create import create_constraint
 from db.constraints.operations.drop import drop_constraint
 from db.constraints.operations.select import get_constraint_oid_by_name_and_table_oid, get_constraint_from_oid
 from db.constraints import utils as constraint_utils
+from db.dependents_utils import get_dependent_objects, has_dependencies
 from db.records.operations.delete import delete_record
 from db.records.operations.insert import insert_record_or_records
 from db.records.operations.select import get_column_cast_records, get_count, get_record
@@ -236,7 +237,18 @@ class Table(DatabaseObject):
     # TODO: This should check for dependencies once the depdency endpoint is implemeted
     @property
     def has_dependencies(self):
-        return True
+        return has_dependencies(
+            self.name,
+            self.schema.name,
+            self.schema._sa_engine
+        )
+
+    def dependents(self):
+        return get_dependent_objects(
+            self.name,
+            self.schema.name,
+            self.schema._sa_engine
+        )
 
     def add_column(self, column_data):
         return create_column(


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Blocked by #1452 

<!-- Concisely describe what the pull request does. -->
The `get_dependents_hierarchy` function is responsible for returning ten layers of dependent objects starting with a single one.
For now, it returns dependent constraints and tables.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
