### PR TITLE
Fix bug disallowing initial_column's display_name

### DIFF
--- a/mathesar/api/serializers/queries.py
+++ b/mathesar/api/serializers/queries.py
@@ -32,10 +32,3 @@ class QuerySerializer(serializers.ModelSerializer):
             return request.build_absolute_uri(reverse('query-columns', kwargs={'pk': obj.pk}))
         else:
             return None
-
-    # TODO consider moving to UIQuery field validation:
-    # see https://docs.djangoproject.com/en/4.0/ref/validators/
-    def validate_display_options(self, display_options):
-        if not isinstance(display_options, dict):
-            raise serializers.ValidationError("display_options should be a dict.")
-        return display_options

--- a/mathesar/tests/api/query/conftest.py
+++ b/mathesar/tests/api/query/conftest.py
@@ -9,12 +9,12 @@ def minimal_patents_query(create_patents_table, get_uid):
         {
             'id': base_table.get_column_by_name('Center').id,
             'alias': 'col1',
-            'name': 'Column 1',
+            'display_name': 'Column 1',
         },
         {
             'id': base_table.get_column_by_name('Case Number').id,
             'alias': 'col2',
-            'name': 'Column 2',
+            'display_name': 'Column 2',
         },
     ]
     display_options = {

--- a/mathesar/tests/api/query/test_query_columns_api.py
+++ b/mathesar/tests/api/query/test_query_columns_api.py
@@ -9,14 +9,14 @@ def test_columns(client, minimal_patents_query):
     assert response_json == [
         {
             'alias': 'col1',
-            'name': 'Column 1',
+            'display_name': 'Column 1',
             'type': PostgresType.TEXT.id,
             'type_options': None,
             'display_options': dict(a=1),
         },
         {
             'alias': 'col2',
-            'name': 'Column 2',
+            'display_name': 'Column 2',
             'type': PostgresType.TEXT.id,
             'type_options': None,
             'display_options': dict(b=2),

--- a/mathesar/tests/query/test_base.py
+++ b/mathesar/tests/query/test_base.py
@@ -11,12 +11,12 @@ def test_convert_to_db_query(create_patents_table, get_uid):
         {
             'id': col1_dj.id,
             'alias': 'col1',
-            'name': 'Column 1',
+            'display_name': 'Column 1',
         },
         {
             'id': col2_dj.id,
             'alias': 'col2',
-            'name': 'Column 2',
+            'display_name': 'Column 2',
         },
     ]
     initial_columns = [


### PR DESCRIPTION
Fixes a bug where you couldn't give initial columns display names. Also, renames the initial_column's display name field from `name` to `display_name`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
