### PR TITLE
Fix Data Explorer API bug

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -257,6 +257,7 @@ FILE_DIR = os.path.abspath(os.path.dirname(__file__))
 RESOURCES = os.path.join(FILE_DIR, "db", "tests", "resources")
 ACADEMICS_SQL = os.path.join(RESOURCES, "academics_create.sql")
 
+
 @pytest.fixture
 def engine_with_academics(engine_with_schema):
     engine, schema = engine_with_schema
@@ -289,4 +290,3 @@ def academics_db_tables(engine_with_academics):
         for table_name
         in table_names
     }
-

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,12 @@
 import pytest
 import random
 import string
+import os
 
 # These imports come from the mathesar namespace, because our DB setup logic depends on it.
 from django.db import connection as dj_connection
 
+from sqlalchemy import MetaData, text, Table
 from sqlalchemy.exc import OperationalError
 from sqlalchemy_utils import database_exists, create_database, drop_database
 
@@ -249,3 +251,42 @@ def _create_engine(db_name):
 
 def _get_connection_string(username, password, hostname, database):
     return f"postgresql://{username}:{password}@{hostname}/{database}"
+
+
+FILE_DIR = os.path.abspath(os.path.dirname(__file__))
+RESOURCES = os.path.join(FILE_DIR, "db", "tests", "resources")
+ACADEMICS_SQL = os.path.join(RESOURCES, "academics_create.sql")
+
+@pytest.fixture
+def engine_with_academics(engine_with_schema):
+    engine, schema = engine_with_schema
+    with engine.begin() as conn, open(ACADEMICS_SQL) as f:
+        conn.execute(text(f"SET search_path={schema}"))
+        conn.execute(text(f.read()))
+    yield engine, schema
+
+
+@pytest.fixture
+def academics_db_tables(engine_with_academics):
+    def make_table(table_name):
+        return Table(
+            table_name,
+            metadata,
+            schema=schema,
+            autoload_with=engine,
+        )
+    engine, schema = engine_with_academics
+    metadata = MetaData(bind=engine)
+    table_names = {
+        'academics',
+        'articles',
+        'journals',
+        'publishers',
+        'universities',
+    }
+    return {
+        table_name: make_table(table_name)
+        for table_name
+        in table_names
+    }
+

--- a/db/columns/base.py
+++ b/db/columns/base.py
@@ -53,6 +53,9 @@ class MathesarColumn(Column):
             autoincrement=autoincrement,
             server_default=server_default
         )
+        if isinstance(self._proxies, tuple):
+            self._proxies = list(self._proxies)
+            #breakpoint()
 
     @classmethod
     def _constructor(cls, *args, **kwargs):
@@ -84,6 +87,8 @@ class MathesarColumn(Column):
             engine=engine,
         )
         new_column.original_table = column.table
+        if isinstance(new_column._proxies, tuple):
+            breakpoint()
         return new_column
 
     def to_sa_column(self):

--- a/db/columns/base.py
+++ b/db/columns/base.py
@@ -53,9 +53,12 @@ class MathesarColumn(Column):
             autoincrement=autoincrement,
             server_default=server_default
         )
+        # NOTE: For some reason, sometimes `self._proxies` is a tuple. SA expects it to be
+        # appendable, however. Was not able to track down the source of it. As a workaround, we
+        # convert it into a list here. I (Dom) offer a bounty of bragging rights to anyone who
+        # figures out what's causing `_proxies` to be tuples.
         if isinstance(self._proxies, tuple):
             self._proxies = list(self._proxies)
-            #breakpoint()
 
     @classmethod
     def _constructor(cls, *args, **kwargs):

--- a/db/tests/conftest.py
+++ b/db/tests/conftest.py
@@ -11,7 +11,6 @@ from db.columns.operations.alter import alter_column_type
 
 FILE_DIR = os.path.abspath(os.path.dirname(__file__))
 RESOURCES = os.path.join(FILE_DIR, "resources")
-ACADEMICS_SQL = os.path.join(RESOURCES, "academics_create.sql")
 ROSTER_SQL = os.path.join(RESOURCES, "roster_create.sql")
 URIS_SQL = os.path.join(RESOURCES, "uris_create.sql")
 TIMES_SQL = os.path.join(RESOURCES, "times_create.sql")
@@ -19,40 +18,6 @@ BOOLEANS_SQL = os.path.join(RESOURCES, "booleans_create.sql")
 FILTER_SORT_SQL = os.path.join(RESOURCES, "filter_sort_create.sql")
 MAGNITUDE_SQL = os.path.join(RESOURCES, "magnitude_testing_create.sql")
 JSON_SQL = os.path.join(RESOURCES, "json_sort.sql")
-
-
-@pytest.fixture
-def engine_with_academics(engine_with_schema):
-    engine, schema = engine_with_schema
-    with engine.begin() as conn, open(ACADEMICS_SQL) as f:
-        conn.execute(text(f"SET search_path={schema}"))
-        conn.execute(text(f.read()))
-    yield engine, schema
-
-
-@pytest.fixture
-def academics_tables(engine_with_academics):
-    def make_table(table_name):
-        return Table(
-            table_name,
-            metadata,
-            schema=schema,
-            autoload_with=engine,
-        )
-    engine, schema = engine_with_academics
-    metadata = MetaData(bind=engine)
-    table_names = {
-        'academics',
-        'articles',
-        'journals',
-        'publishers',
-        'universities',
-    }
-    return {
-        table_name: make_table(table_name)
-        for table_name
-        in table_names
-    }
 
 
 @pytest.fixture

--- a/mathesar/tests/api/query/conftest.py
+++ b/mathesar/tests/api/query/conftest.py
@@ -3,6 +3,15 @@ from mathesar.models.query import UIQuery
 
 
 @pytest.fixture
+def academics_ma_tables(db_table_to_dj_table, academics_db_tables):
+    return {
+        table_name: db_table_to_dj_table(db_table)
+        for table_name, db_table
+        in academics_db_tables.items()
+    }
+
+
+@pytest.fixture
 def minimal_patents_query(create_patents_table, get_uid):
     base_table = create_patents_table(table_name=get_uid())
     initial_columns = [

--- a/mathesar/tests/api/query/test_query_records_api.py
+++ b/mathesar/tests/api/query/test_query_records_api.py
@@ -1,6 +1,40 @@
 import pytest
 import json
 
+from mathesar.models.query import UIQuery
+
+
+@pytest.fixture
+def joining_patents_query(academics_ma_tables):
+    academics_table = academics_ma_tables['academics']
+    institutions_table = academics_ma_tables['universities']
+    initial_columns = [
+        {
+            'id': academics_table.get_column_by_name('name').id,
+            'alias': 'name',
+            'display_name': 'name',
+        },
+        {
+            'id': institutions_table.get_column_by_name('name').id,
+            'alias': 'institution_name',
+            'display_name': 'institution name',
+            'jp_path': [[
+                academics_table.get_column_by_name('institution').id,
+                institutions_table.get_column_by_name('id').id,
+            ]],
+        },
+    ]
+    display_options = {
+        'name': dict(a=1),
+        'institution_name': dict(b=2),
+    }
+    ui_query = UIQuery.objects.create(
+        base_table=academics_table,
+        initial_columns=initial_columns,
+        display_options=display_options,
+    )
+    return ui_query
+
 
 @pytest.mark.parametrize("limit", [None, 100, 500])
 def test_basics(client, minimal_patents_query, limit):
@@ -16,6 +50,25 @@ def test_basics(client, minimal_patents_query, limit):
         expected_result_count,
         total_rows_in_table
     )
+
+
+def test_query_with_joins(client, joining_patents_query):
+    ui_query = joining_patents_query
+    total_rows_in_table = 3
+    response = client.get(f'/api/db/v0/queries/{ui_query.id}/records/')
+    response_json = response.json()
+    assert response.status_code == 200
+    expected_result_count = 3
+    _assert_well_formed_records(
+        response_json,
+        expected_result_count,
+        total_rows_in_table
+    )
+    response_json['results'] == [
+        {'name': 'academic1', 'institution_name': 'uni1'},
+        {'name': 'academic2', 'institution_name': 'uni1'},
+        {'name': 'academic3', 'institution_name': 'uni2'},
+    ]
 
 
 def test_grouping(client, minimal_patents_query):

--- a/mathesar/tests/conftest.py
+++ b/mathesar/tests/conftest.py
@@ -195,6 +195,24 @@ def non_unicode_csv_filepath():
 
 
 @pytest.fixture
+def db_table_to_dj_table(engine, create_schema):
+    """
+    Factory creating Django Table models from DB/SA tables.
+    """
+    def _create_ma_table(db_table):
+        schema_name = db_table.schema
+        dj_schema = create_schema(schema_name)
+        db_table_oid = get_oid_from_table(
+            db_table.name, schema_name, engine
+        )
+        dj_table = Table.current_objects.create(
+            oid=db_table_oid, schema=dj_schema
+        )
+        return dj_table
+    yield _create_ma_table
+
+
+@pytest.fixture
 def empty_nasa_table(patent_schema, engine_with_schema):
     engine, _ = engine_with_schema
     NASA_TABLE = 'NASA Schema List'
@@ -219,10 +237,11 @@ def patent_schema(create_schema):
     yield create_schema(PATENT_SCHEMA)
 
 
+# TODO rename to create_ma_schema
 @pytest.fixture
 def create_schema(test_db_model, create_db_schema):
     """
-    Creates a DJ Schema model factory, making sure to track and clean up new instances
+    Creates a DJ Schema model factory, making sure to cache and clean up new instances.
     """
     engine = test_db_model._sa_engine
 
@@ -235,6 +254,7 @@ def create_schema(test_db_model, create_db_schema):
     # NOTE: Schema model is not cleaned up. Maybe invalidate cache?
 
 
+# TODO rename to create_mathesar_db_table
 @pytest.fixture
 def create_mathesar_table(create_db_schema):
     def _create_mathesar_table(
@@ -264,6 +284,7 @@ def create_patents_table(patents_csv_filepath, patent_schema, create_table):
     return _create_table
 
 
+# TODO rename to create_ma_table_from_csv
 @pytest.fixture
 def create_table(create_schema):
     def _create_table(table_name, schema_name, csv_filepath):


### PR DESCRIPTION
Fixes a bug where for some unknown reason, SQLAlchemy's private `MathesarColumn._proxies` is a tuple, while SA expects it to be a vector.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
