### PR TITLE
speed up reflection. Revert this later.

### DIFF
--- a/mathesar/reflection.py
+++ b/mathesar/reflection.py
@@ -13,7 +13,8 @@ from mathesar.api.serializers.shared_serializers import DisplayOptionsMappingSer
 from mathesar.database.base import create_mathesar_engine
 
 DB_REFLECTION_KEY = 'database_reflected_recently'
-DB_REFLECTION_INTERVAL = 60 * 5  # we reflect DB changes every 5 minutes
+# TODO Change this back to 60 * 5 later in the development process
+DB_REFLECTION_INTERVAL = 1 # we reflect DB changes every second
 
 
 # NOTE: All querysets used for reflection should use the .current_objects manager

--- a/mathesar/reflection.py
+++ b/mathesar/reflection.py
@@ -14,7 +14,7 @@ from mathesar.database.base import create_mathesar_engine
 
 DB_REFLECTION_KEY = 'database_reflected_recently'
 # TODO Change this back to 60 * 5 later in the development process
-DB_REFLECTION_INTERVAL = 1 # we reflect DB changes every second
+DB_REFLECTION_INTERVAL = 1  # we reflect DB changes every second
 
 
 # NOTE: All querysets used for reflection should use the .current_objects manager


### PR DESCRIPTION
This does nothing more than reduce the DB reflection interval from 5 minutes to 1 second.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
