### PR TITLE
Reinstate functionality to synchronize the URL with the table's grouping/sorting/filtering/pagination

### DIFF
--- a/mathesar_ui/src/AppTypes.ts
+++ b/mathesar_ui/src/AppTypes.ts
@@ -16,11 +16,6 @@ export interface SchemaEntry extends DBObjectEntry {
   has_dependencies: boolean;
 }
 
-export interface ViewEntry extends DBObjectEntry {
-  // TODO: Temporary, update when view endpoints are ready.
-  columns: { name: string }[];
-}
-
 export interface SchemaResponse extends SchemaEntry, TreeItem {
   tables: DBObjectEntry[];
 }

--- a/mathesar_ui/src/pages/import/importUtils.ts
+++ b/mathesar_ui/src/pages/import/importUtils.ts
@@ -30,7 +30,6 @@ import type {
   FileUploadAddDetail,
   FileUploadProgress,
 } from '@mathesar-component-library/types';
-import { TabularType } from '@mathesar/stores/table-data';
 import { getErrorMessage } from '@mathesar/utils/errors';
 
 function completionCallback(

--- a/mathesar_ui/src/pages/table/TablePage.svelte
+++ b/mathesar_ui/src/pages/table/TablePage.svelte
@@ -1,32 +1,23 @@
 <script lang="ts">
+  import { router } from 'tinro';
+
   import type { TableEntry } from '@mathesar/api/tables/tableList';
   import type { Database, SchemaEntry } from '@mathesar/AppTypes';
   import LayoutWithHeader from '@mathesar/layouts/LayoutWithHeader.svelte';
   import { getSchemaPageUrl } from '@mathesar/routes/urls';
   import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
-  import { Filtering, Grouping, Sorting } from '@mathesar/stores/table-data';
   import { TabularData } from '@mathesar/stores/table-data/tabularData';
   import TableView from '@mathesar/systems/table-view/TableView.svelte';
-  import Pagination from '@mathesar/utils/Pagination';
-  import { router } from 'tinro';
 
   export let database: Database;
   export let schema: SchemaEntry;
   export let table: TableEntry;
 
   $: abstractTypesMap = $currentDbAbstractTypes.data;
-  $: tabularData = new TabularData(
-    {
-      id: table.id,
-      metaProps: {
-        pagination: new Pagination(),
-        sorting: new Sorting(),
-        grouping: new Grouping(),
-        filtering: new Filtering(),
-      },
-    },
+  $: tabularData = new TabularData({
+    id: table.id,
     abstractTypesMap,
-  );
+  });
 
   function handleDeleteTable() {
     router.goto(getSchemaPageUrl(database.name, schema.id));

--- a/mathesar_ui/src/pages/table/TablePage.svelte
+++ b/mathesar_ui/src/pages/table/TablePage.svelte
@@ -4,12 +4,7 @@
   import LayoutWithHeader from '@mathesar/layouts/LayoutWithHeader.svelte';
   import { getSchemaPageUrl } from '@mathesar/routes/urls';
   import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
-  import {
-    Filtering,
-    Grouping,
-    Sorting,
-    TabularType,
-  } from '@mathesar/stores/table-data';
+  import { Filtering, Grouping, Sorting } from '@mathesar/stores/table-data';
   import { TabularData } from '@mathesar/stores/table-data/tabularData';
   import TableView from '@mathesar/systems/table-view/TableView.svelte';
   import Pagination from '@mathesar/utils/Pagination';
@@ -22,7 +17,6 @@
   $: abstractTypesMap = $currentDbAbstractTypes.data;
   $: tabularData = new TabularData(
     {
-      type: TabularType.Table,
       id: table.id,
       metaProps: {
         pagination: new Pagination(),

--- a/mathesar_ui/src/pages/table/TablePage.svelte
+++ b/mathesar_ui/src/pages/table/TablePage.svelte
@@ -6,6 +6,7 @@
   import LayoutWithHeader from '@mathesar/layouts/LayoutWithHeader.svelte';
   import { getSchemaPageUrl } from '@mathesar/routes/urls';
   import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
+  import { Meta } from '@mathesar/stores/table-data';
   import { TabularData } from '@mathesar/stores/table-data/tabularData';
   import TableView from '@mathesar/systems/table-view/TableView.svelte';
 
@@ -14,10 +15,19 @@
   export let table: TableEntry;
 
   $: abstractTypesMap = $currentDbAbstractTypes.data;
+  $: ({ hash } = $router);
+  $: meta = Meta.fromSerialization(hash);
   $: tabularData = new TabularData({
     id: table.id,
     abstractTypesMap,
+    meta,
   });
+
+  function handleMetaSerializationChange(s: string) {
+    router.location.hash.set(s);
+  }
+  $: metaSerialization = tabularData.meta.serialization;
+  $: handleMetaSerializationChange($metaSerialization);
 
   function handleDeleteTable() {
     router.goto(getSchemaPageUrl(database.name, schema.id));

--- a/mathesar_ui/src/stores/table-data/TabularType.ts
+++ b/mathesar_ui/src/stores/table-data/TabularType.ts
@@ -1,4 +1,0 @@
-export enum TabularType {
-  Table = 1,
-  View = 2,
-}

--- a/mathesar_ui/src/stores/table-data/columns.ts
+++ b/mathesar_ui/src/stores/table-data/columns.ts
@@ -12,7 +12,6 @@ import {
   postAPI,
   States,
 } from '@mathesar/utils/api';
-import { TabularType } from './TabularType';
 
 export interface ColumnsData {
   state: States;
@@ -47,8 +46,6 @@ export class ColumnsDataStore
   }>
   implements Writable<ColumnsData>
 {
-  private type: TabularType;
-
   private parentId: DBObjectEntry['id'];
 
   private store: Writable<ColumnsData>;
@@ -60,20 +57,17 @@ export class ColumnsDataStore
   private fetchCallback: (storeData: ColumnsData) => void;
 
   constructor(
-    type: TabularType,
     parentId: number,
     fetchCallback: (storeData: ColumnsData) => void = () => {},
   ) {
     super();
-    this.type = type;
     this.parentId = parentId;
     this.store = writable({
       state: States.Loading,
       columns: [],
       primaryKey: undefined,
     });
-    const tabularEntity = this.type === TabularType.Table ? 'tables' : 'views';
-    this.api = api(`/api/db/v0/${tabularEntity}/${this.parentId}/columns/`);
+    this.api = api(`/api/db/v0/tables/${this.parentId}/columns/`);
     this.fetchCallback = fetchCallback;
     void this.fetch();
   }

--- a/mathesar_ui/src/stores/table-data/index.ts
+++ b/mathesar_ui/src/stores/table-data/index.ts
@@ -19,8 +19,6 @@ export { getCellKey, ID_ROW_CONTROL_COLUMN, ID_ADD_NEW_COLUMN } from './utils';
 
 export { getTabularData, initTabularData, removeTabularData } from './manager';
 export {
-  makeTabularDataProps,
-  makeTerseTabularDataProps,
   setTabularDataStoreInContext,
   getTabularDataStoreFromContext,
 } from './tabularData';

--- a/mathesar_ui/src/stores/table-data/index.ts
+++ b/mathesar_ui/src/stores/table-data/index.ts
@@ -24,4 +24,3 @@ export {
   setTabularDataStoreInContext,
   getTabularDataStoreFromContext,
 } from './tabularData';
-export { TabularType } from './TabularType';

--- a/mathesar_ui/src/stores/table-data/manager.ts
+++ b/mathesar_ui/src/stores/table-data/manager.ts
@@ -1,41 +1,33 @@
 import { get } from 'svelte/store';
-import type { DBObjectEntry, ViewEntry } from '@mathesar/AppTypes';
+import type { DBObjectEntry } from '@mathesar/AppTypes';
 import type { TableEntry } from '@mathesar/api/tables/tableList';
 import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
 import type { TabularDataProps } from './tabularData';
 import { TabularData } from './tabularData';
-import { TabularType } from './TabularType';
 
 const tableMap: Map<TableEntry['id'], TabularData> = new Map();
-const viewMap: Map<ViewEntry['id'], TabularData> = new Map();
 
 export function getTabularData(
   props: TabularDataProps,
 ): TabularData | undefined {
-  const tabularMap = props.type === TabularType.View ? viewMap : tableMap;
-  return tabularMap.get(props.id);
+  return tableMap.get(props.id);
 }
 
 export function initTabularData(props: TabularDataProps): TabularData {
   const abstractTypesMap = get(currentDbAbstractTypes).data;
-  const tabularMap = props.type === TabularType.View ? viewMap : tableMap;
-  let entry = tabularMap.get(props.id);
+  let entry = tableMap.get(props.id);
   if (!entry) {
     entry = new TabularData(props, abstractTypesMap);
-    tabularMap.set(props.id, entry);
+    tableMap.set(props.id, entry);
   }
   return entry;
 }
 
-export function removeTabularData(
-  type: TabularType,
-  id: DBObjectEntry['id'],
-): void {
-  const tabularMap = type === TabularType.View ? viewMap : tableMap;
+export function removeTabularData(id: DBObjectEntry['id']): void {
   // destroy all objects in table
-  const entry = tabularMap.get(id);
+  const entry = tableMap.get(id);
   if (entry) {
     entry.destroy();
-    tabularMap.delete(id);
+    tableMap.delete(id);
   }
 }

--- a/mathesar_ui/src/stores/table-data/manager.ts
+++ b/mathesar_ui/src/stores/table-data/manager.ts
@@ -1,7 +1,5 @@
-import { get } from 'svelte/store';
 import type { DBObjectEntry } from '@mathesar/AppTypes';
 import type { TableEntry } from '@mathesar/api/tables/tableList';
-import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
 import type { TabularDataProps } from './tabularData';
 import { TabularData } from './tabularData';
 
@@ -14,10 +12,9 @@ export function getTabularData(
 }
 
 export function initTabularData(props: TabularDataProps): TabularData {
-  const abstractTypesMap = get(currentDbAbstractTypes).data;
   let entry = tableMap.get(props.id);
   if (!entry) {
-    entry = new TabularData(props, abstractTypesMap);
+    entry = new TabularData(props);
     tableMap.set(props.id, entry);
   }
   return entry;

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -28,7 +28,6 @@ import type { ColumnsDataStore } from './columns';
 import type { Sorting } from './sorting';
 import type { Grouping as GroupingTODORename } from './grouping';
 import type { Filtering } from './filtering';
-import { TabularType } from './TabularType';
 
 export interface RecordsRequestParamsData {
   pagination: Pagination;
@@ -198,8 +197,6 @@ function prepareRowForRequest(row: Row): ApiRecord {
 }
 
 export class RecordsData {
-  private type: TabularType;
-
   private parentId: DBObjectEntry['id'];
 
   private url: string;
@@ -233,13 +230,11 @@ export class RecordsData {
   private requestParamsUnsubscriber: Unsubscriber;
 
   constructor(
-    type: TabularType,
     parentId: number,
     meta: Meta,
     columnsDataStore: ColumnsDataStore,
     fetchCallback?: (storeData: TableRecordsData) => void,
   ) {
-    this.type = type;
     this.parentId = parentId;
 
     this.state = writable(States.Loading);
@@ -251,8 +246,7 @@ export class RecordsData {
 
     this.meta = meta;
     this.columnsDataStore = columnsDataStore;
-    const tabularEntity = this.type === TabularType.Table ? 'tables' : 'views';
-    this.url = `/api/db/v0/${tabularEntity}/${this.parentId}/records/`;
+    this.url = `/api/db/v0/tables/${this.parentId}/records/`;
     this.fetchCallback = fetchCallback;
     void this.fetch();
 

--- a/mathesar_ui/src/stores/table-data/tabularData.ts
+++ b/mathesar_ui/src/stores/table-data/tabularData.ts
@@ -3,8 +3,7 @@ import type { Writable } from 'svelte/store';
 import { derived } from 'svelte/store';
 import type { DBObjectEntry } from '@mathesar/AppTypes';
 import type { AbstractTypesMap } from '@mathesar/stores/abstract-types/types';
-import type { TerseMetaProps, MetaProps } from './meta';
-import { makeMetaProps, makeTerseMetaProps, Meta } from './meta';
+import { Meta } from './meta';
 import type { ColumnsData } from './columns';
 import { ColumnsDataStore } from './columns';
 import type { TableRecordsData } from './records';
@@ -17,25 +16,8 @@ import { processColumn } from './processedColumns';
 
 export interface TabularDataProps {
   id: DBObjectEntry['id'];
-  metaProps?: MetaProps;
-}
-
-/** [ id, metaProps ] */
-export type TerseTabularDataProps = [DBObjectEntry['id'], TerseMetaProps];
-
-export function makeTabularDataProps(
-  t: TerseTabularDataProps,
-): TabularDataProps {
-  return {
-    id: t[0],
-    metaProps: makeMetaProps(t[1]),
-  };
-}
-
-export function makeTerseTabularDataProps(
-  p: TabularDataProps,
-): TerseTabularDataProps {
-  return [p.id, makeTerseMetaProps(p.metaProps)];
+  abstractTypesMap: AbstractTypesMap;
+  meta?: Meta;
 }
 
 export class TabularData {
@@ -53,9 +35,9 @@ export class TabularData {
 
   display: Display;
 
-  constructor(props: TabularDataProps, abstractTypeMap: AbstractTypesMap) {
+  constructor(props: TabularDataProps) {
     this.id = props.id;
-    this.meta = new Meta(props.metaProps);
+    this.meta = props.meta ?? new Meta();
     this.columnsDataStore = new ColumnsDataStore(this.id);
     this.constraintsDataStore = new ConstraintsDataStore(this.id);
     this.recordsData = new RecordsData(
@@ -75,7 +57,11 @@ export class TabularData {
         new Map(
           columnsData.columns.map((column) => [
             column.id,
-            processColumn(column, constraintsData.constraints, abstractTypeMap),
+            processColumn(
+              column,
+              constraintsData.constraints,
+              props.abstractTypesMap,
+            ),
           ]),
         ),
     );

--- a/mathesar_ui/src/stores/table-data/tabularData.ts
+++ b/mathesar_ui/src/stores/table-data/tabularData.ts
@@ -12,42 +12,33 @@ import { RecordsData } from './records';
 import { Display } from './display';
 import type { ConstraintsData } from './constraints';
 import { ConstraintsDataStore } from './constraints';
-import type { TabularType } from './TabularType';
 import type { ProcessedColumnsStore } from './processedColumns';
 import { processColumn } from './processedColumns';
 
 export interface TabularDataProps {
-  type: TabularType;
   id: DBObjectEntry['id'];
   metaProps?: MetaProps;
 }
 
-/** [ type, id, metaProps ] */
-export type TerseTabularDataProps = [
-  TabularType,
-  DBObjectEntry['id'],
-  TerseMetaProps,
-];
+/** [ id, metaProps ] */
+export type TerseTabularDataProps = [DBObjectEntry['id'], TerseMetaProps];
 
 export function makeTabularDataProps(
   t: TerseTabularDataProps,
 ): TabularDataProps {
   return {
-    type: t[0],
-    id: t[1],
-    metaProps: makeMetaProps(t[2]),
+    id: t[0],
+    metaProps: makeMetaProps(t[1]),
   };
 }
 
 export function makeTerseTabularDataProps(
   p: TabularDataProps,
 ): TerseTabularDataProps {
-  return [p.type, p.id, makeTerseMetaProps(p.metaProps)];
+  return [p.id, makeTerseMetaProps(p.metaProps)];
 }
 
 export class TabularData {
-  type: TabularType;
-
   id: DBObjectEntry['id'];
 
   meta: Meta;
@@ -63,13 +54,11 @@ export class TabularData {
   display: Display;
 
   constructor(props: TabularDataProps, abstractTypeMap: AbstractTypesMap) {
-    this.type = props.type;
     this.id = props.id;
     this.meta = new Meta(props.metaProps);
-    this.columnsDataStore = new ColumnsDataStore(this.type, this.id);
+    this.columnsDataStore = new ColumnsDataStore(this.id);
     this.constraintsDataStore = new ConstraintsDataStore(this.id);
     this.recordsData = new RecordsData(
-      this.type,
       this.id,
       this.meta,
       this.columnsDataStore,

--- a/mathesar_ui/src/stores/table-data/types.ts
+++ b/mathesar_ui/src/stores/table-data/types.ts
@@ -1,8 +1,4 @@
-export type {
-  TabularData,
-  TabularDataProps,
-  TerseTabularDataProps,
-} from './tabularData';
+export type { TabularData, TabularDataProps } from './tabularData';
 export type { RecordsData, Row } from './records';
 export type { ColumnsData, ColumnsDataStore } from './columns';
 export type {

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorController.ts
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorController.ts
@@ -5,12 +5,7 @@ import type { ModalController } from '@mathesar-component-library';
 import type { DBObjectEntry } from '@mathesar/AppTypes';
 import { TabularData } from '@mathesar/stores/table-data/tabularData';
 import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
-import {
-  Filtering,
-  Grouping,
-  Sorting,
-  TabularType,
-} from '@mathesar/stores/table-data';
+import { Filtering, Grouping, Sorting } from '@mathesar/stores/table-data';
 import Pagination from '@mathesar/utils/Pagination';
 
 interface RecordSelectorControllerProps {
@@ -43,7 +38,6 @@ export class RecordSelectorController {
       const abstractTypesMap = get(currentDbAbstractTypes).data;
       return new TabularData(
         {
-          type: TabularType.Table,
           id: tableId,
           metaProps: {
             pagination: new Pagination({ size: 10 }),

--- a/mathesar_ui/src/systems/record-selector/RecordSelectorController.ts
+++ b/mathesar_ui/src/systems/record-selector/RecordSelectorController.ts
@@ -5,7 +5,7 @@ import type { ModalController } from '@mathesar-component-library';
 import type { DBObjectEntry } from '@mathesar/AppTypes';
 import { TabularData } from '@mathesar/stores/table-data/tabularData';
 import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
-import { Filtering, Grouping, Sorting } from '@mathesar/stores/table-data';
+import { Meta } from '@mathesar/stores/table-data';
 import Pagination from '@mathesar/utils/Pagination';
 
 interface RecordSelectorControllerProps {
@@ -35,19 +35,11 @@ export class RecordSelectorController {
       if (!tableId) {
         return undefined;
       }
-      const abstractTypesMap = get(currentDbAbstractTypes).data;
-      return new TabularData(
-        {
-          id: tableId,
-          metaProps: {
-            pagination: new Pagination({ size: 10 }),
-            sorting: new Sorting(),
-            grouping: new Grouping(),
-            filtering: new Filtering(),
-          },
-        },
-        abstractTypesMap,
-      );
+      return new TabularData({
+        id: tableId,
+        abstractTypesMap: get(currentDbAbstractTypes).data,
+        meta: new Meta({ pagination: new Pagination({ size: 10 }) }),
+      });
     });
 
     this.tableName = derived(this.tableId, (id) =>

--- a/mathesar_ui/src/systems/table-view/constraints/NewFkConstraintModal.svelte
+++ b/mathesar_ui/src/systems/table-view/constraints/NewFkConstraintModal.svelte
@@ -18,7 +18,6 @@
   import {
     ColumnsDataStore,
     getTabularDataStoreFromContext,
-    TabularType,
   } from '@mathesar/stores/table-data';
   import type { Column } from '@mathesar/api/tables/columns';
   import { tables as tablesStore } from '@mathesar/stores/tables';
@@ -88,9 +87,7 @@
   $: columnsDataStore = $tabularData.columnsDataStore;
   $: baseTableColumns = $columnsDataStore.columns;
   $: targetTableColumnsStore = ensureReadable(
-    targetTable
-      ? new ColumnsDataStore(TabularType.Table, targetTable.id)
-      : undefined,
+    targetTable ? new ColumnsDataStore(targetTable.id) : undefined,
   );
   $: targetTableColumnsAreLoading =
     $targetTableColumnsStore?.state === States.Loading;

--- a/mathesar_ui/src/systems/table-view/link-table/LinkTableModal.svelte
+++ b/mathesar_ui/src/systems/table-view/link-table/LinkTableModal.svelte
@@ -29,7 +29,6 @@
     getTabularData,
     ColumnsDataStore,
     getTabularDataStoreFromContext,
-    TabularType,
   } from '@mathesar/stores/table-data';
   import { toast } from '@mathesar/stores/toast';
   import { postAPI, States } from '@mathesar/utils/api';
@@ -88,9 +87,7 @@
     $columnsDataStore.columns.map((c) => c.name),
   );
   $: thatTableColumnsStore = ensureReadable(
-    thatTable
-      ? new ColumnsDataStore(TabularType.Table, thatTable.id)
-      : undefined,
+    thatTable ? new ColumnsDataStore(thatTable.id) : undefined,
   );
   $: thatTableColumnsAreLoading =
     $thatTableColumnsStore?.state === States.Loading;
@@ -211,7 +208,6 @@
       return;
     }
     const tabularDataWithNewColumn = getTabularData({
-      type: TabularType.Table,
       id: tableWithNewColumn.id,
     });
     if (tabularDataWithNewColumn) {

--- a/mathesar_ui/src/systems/table-view/link-table/LinkTableModal.svelte
+++ b/mathesar_ui/src/systems/table-view/link-table/LinkTableModal.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { get } from 'svelte/store';
+
   import type { ModalController } from '@mathesar-component-library';
   import {
     CancelOrProceedButtonPair,
@@ -34,6 +36,7 @@
   import { postAPI, States } from '@mathesar/utils/api';
   import { getAvailableName } from '@mathesar/utils/db';
   import { getErrorMessage } from '@mathesar/utils/errors';
+  import { currentDbAbstractTypes } from '@mathesar/stores/abstract-types';
   import { iconTechnicalExplanation, iconTableLink } from '@mathesar/icons';
   import type { RelationshipType } from './linkTableUtils';
   import {
@@ -207,8 +210,10 @@
     if (!tableWithNewColumn) {
       return;
     }
+    const abstractTypesMap = get(currentDbAbstractTypes).data;
     const tabularDataWithNewColumn = getTabularData({
       id: tableWithNewColumn.id,
+      abstractTypesMap,
     });
     if (tabularDataWithNewColumn) {
       void tabularDataWithNewColumn.refresh();


### PR DESCRIPTION
## Before

- The synchronization of a table's grouping/sorting/filtering/pagination with the URL was broken as part of #1504

## After

- Writing the URL works -- the URL updates when grouping/sorting/filtering/pagination changes
- Reading the URL works -- grouping/sorting/filtering/pagination is set on first page load based on the URL
- It uses the URL hash now. That seemed more appropriate than a query param. I can change it back if needed.
- It disappears entirely when the grouping/sorting/filtering/pagination all have default values. I'm excited about this! Simpler URLs!
- It uses more declarative logic whereas we were previously doing this somewhat more imperatively.
- I also did some refactoring along the way:
    - I removed TabularType because it seems like we'll probably never use it
    - I simplified TabularDataProps a bit


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

