### PR TITLE
Preproc grouping counting bugfix

### DIFF
--- a/db/records/operations/group.py
+++ b/db/records/operations/group.py
@@ -32,6 +32,7 @@ class GroupMetadataField(Enum):
     GEQ_VALUE = 'greater_than_eq_value'
     LT_VALUE = 'less_than_value'
     GT_VALUE = 'greater_than_value'
+    EQ_VALUE = 'eq_value'
 
 
 class GroupBy:
@@ -250,10 +251,6 @@ def get_group_augmented_records_pg_query(table, group_by):
 
 
 def _get_distinct_group_select(table, grouping_columns, preproc):
-    window_def = GroupingWindowDefinition(
-        order_by=grouping_columns, partition_by=grouping_columns
-    )
-
     if preproc is not None:
         processed_columns = [
             get_db_function_subclass_by_id(proc).to_sa_expression(col)
@@ -263,27 +260,56 @@ def _get_distinct_group_select(table, grouping_columns, preproc):
     else:
         processed_columns = grouping_columns
 
+    eq_expr = func.json_build_object(
+        *[
+            i for t in [
+                (literal(col.name), val)
+                for col, val in zip(grouping_columns, processed_columns)
+            ]
+            for i in t
+        ]
+    )
+
+    window_def = GroupingWindowDefinition(
+        order_by=grouping_columns, partition_by=processed_columns
+    )
+
     group_id_expr = func.dense_rank().over(
         order_by=processed_columns, range_=window_def.range_
     )
     return select(
         table,
-        _get_group_metadata_definition(window_def, grouping_columns, group_id_expr)
+        _get_group_metadata_definition(
+            window_def, grouping_columns, group_id_expr, eq_expr=eq_expr
+        )
     )
 
 
 def _get_extract_group_select(table, grouping_columns, extract_field):
-    window_def = GroupingWindowDefinition(
-        order_by=grouping_columns, partition_by=grouping_columns
-    )
     processed_columns = [extract(extract_field, grouping_columns[0])]
+
+    eq_expr = func.json_build_object(
+        *[
+            i for t in [
+                (literal(col.name), val)
+                for col, val in zip(grouping_columns, processed_columns)
+            ]
+            for i in t
+        ]
+    )
+
+    window_def = GroupingWindowDefinition(
+        order_by=grouping_columns, partition_by=processed_columns
+    )
     group_id_expr = func.dense_rank().over(
         order_by=processed_columns, range_=window_def.range_
     )
 
     return select(
         table,
-        _get_group_metadata_definition(window_def, grouping_columns, group_id_expr)
+        _get_group_metadata_definition(
+            window_def, grouping_columns, group_id_expr, eq_expr=eq_expr
+        )
     )
 
 
@@ -479,6 +505,7 @@ def _get_group_metadata_definition(
         geq_expr=None,
         lt_expr=None,
         gt_expr=None,
+        eq_expr=None,
 ):
     col_key_value_tuples = (
         (literal(str(col.name)), col) for col in grouping_columns
@@ -516,6 +543,8 @@ def _get_group_metadata_definition(
         lt_expr,
         literal(GroupMetadataField.GT_VALUE.value),
         gt_expr,
+        literal(GroupMetadataField.EQ_VALUE.value),
+        eq_expr,
     ).label(MATHESAR_GROUP_METADATA)
 
 

--- a/db/tests/records/operations/test_group.py
+++ b/db/tests/records/operations/test_group.py
@@ -298,6 +298,14 @@ def _group_lt_value(row):
     return row[group.MATHESAR_GROUP_METADATA][group.GroupMetadataField.LT_VALUE.value]
 
 
+def _group_eq_value(row):
+    return row[group.MATHESAR_GROUP_METADATA][group.GroupMetadataField.EQ_VALUE.value]
+
+
+def _group_count(row):
+    return row[group.MATHESAR_GROUP_METADATA][group.GroupMetadataField.COUNT.value]
+
+
 def _group_id(row):
     return row[group.MATHESAR_GROUP_METADATA][group.GroupMetadataField.GROUP_ID.value]
 
@@ -412,18 +420,33 @@ def test_smoke_get_group_augmented_records_pg_query_extract(times_table_obj):
 
 
 datetime_trunc_tests_def = [
-    ('date', 'truncate_to_year', 3),
-    ('timestamp', 'truncate_to_year', 3),
-    ('date', 'truncate_to_month', 4),
-    ('timestamp', 'truncate_to_month', 4),
-    ('date', 'truncate_to_day', 6),
-    ('timestamp', 'truncate_to_day', 6),
+    ('date', 'truncate_to_year', 3, 4, {'1999': 1, '2010': 1, '2013': 4}),
+    ('timestamp', 'truncate_to_year', 3, 4, {'1999': 1, '1980': 1, '1981': 4}),
+    (
+        'date', 'truncate_to_month', 4, 7,
+        {'1999-01': 1, '2010-01': 1, '2013-01': 3, '2013-02': 1},
+    ), (
+        'timestamp', 'truncate_to_month', 4, 7,
+        {'1999-01': 1, '1980-01': 1, '1981-01': 3, '1981-02': 1},
+    ), (
+        'date', 'truncate_to_day', 6, 10,
+        {
+            '1999-01-08': 1, '2010-01-08': 1, '2013-01-08': 1, '2013-01-09': 1,
+            '2013-01-10': 1, '2013-02-08': 1,
+        }
+    ), (
+        'timestamp', 'truncate_to_day', 6, 10,
+        {
+            '1999-01-08': 1, '1980-01-08': 1, '1981-01-08': 1, '1981-01-09': 1,
+            '1981-01-10': 1, '1981-02-08': 1,
+        }
+    ),
 ]
 
 
-@pytest.mark.parametrize('col,preproc,num', datetime_trunc_tests_def)
+@pytest.mark.parametrize('col,preproc,num,length,count_map', datetime_trunc_tests_def)
 def test_get_group_augmented_records_pg_query_datetimes_preproc(
-        times_table_obj, col, preproc, num
+        times_table_obj, col, preproc, num, length, count_map
 ):
     roster, engine = times_table_obj
     group_by = group.GroupBy(
@@ -436,6 +459,9 @@ def test_get_group_augmented_records_pg_query_datetimes_preproc(
         res = conn.execute(augmented_pg_query).fetchall()
 
     assert max([_group_id(row) for row in res]) == num
+    for row in res:
+        assert row[col][:length] == _group_eq_value(row)[col]
+        assert count_map[_group_eq_value(row)[col]] == _group_count(row)
 
 
 datetime_extract_tests_def = [


### PR DESCRIPTION
This PR fixes some grouping bugs found by @pavish during his work:

- the count for groups involving preproc is now accurate.
- There is a new field `eq_value` for distinct grouping using `preproc`. This gives the processed value. For non-preproc distinct grouping, it just gives the actual value the group is identified as being equal to (should be the same as first and last value of the group in that case).

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
