### PR TITLE
Increases breadcrumb selector max height

### DIFF
--- a/mathesar_ui/src/component-library/dropdown/Dropdown.scss
+++ b/mathesar_ui/src/component-library/dropdown/Dropdown.scss
@@ -37,7 +37,7 @@ button.dropdown.trigger {
   border-radius: 0.25rem;
   background: #fff;
   z-index: 100;
-  max-height: 210px;
+  max-height: calc(100vh - 5em);
   overflow: auto;
 
   &[data-popper-placement='top-start'] {

--- a/mathesar_ui/src/systems/app-header/breadcrumb/BreadcrumbSelector.svelte
+++ b/mathesar_ui/src/systems/app-header/breadcrumb/BreadcrumbSelector.svelte
@@ -46,21 +46,25 @@
       <div class="category-name">entities</div>
       <TextInput bind:value={filterString} bind:element={textInputEl} />
       {#each [...processedData] as [categoryName, items] (categoryName)}
-        <div class="category-name">{categoryName}</div>
-        <ul class="items">
-          {#each items as { href, label, icon } (href)}
-            <li class="item">
-              <a
-                {href}
-                on:click={() => {
-                  isOpen = false;
-                }}
-              >
-                <NameWithIcon {icon}>{label}</NameWithIcon>
-              </a>
-            </li>
-          {/each}
-        </ul>
+        <!-- data coming down from parent can have categories with 0 items: we
+        don't want to render that. -->
+        {#if items.length > 0}
+          <div class="category-name">{categoryName}</div>
+          <ul class="items">
+            {#each items as { href, label, icon } (href)}
+              <li class="item">
+                <a
+                  {href}
+                  on:click={() => {
+                    isOpen = false;
+                  }}
+                >
+                  <NameWithIcon {icon}>{label}</NameWithIcon>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        {/if}
       {/each}
     </div>
   </AttachableDropdown>

--- a/mathesar_ui/src/systems/app-header/breadcrumb/BreadcrumbSelector.svelte
+++ b/mathesar_ui/src/systems/app-header/breadcrumb/BreadcrumbSelector.svelte
@@ -41,7 +41,8 @@
 
   <AttachableDropdown bind:isOpen trigger={triggerElement}>
     <div class="entity-switcher-content">
-      <!-- TODO consider improving semantics of this css class -->
+      <!-- TODO consider improving semantics of this css class: it's less of a
+      category-name and more of a section-name. -->
       <div class="category-name">entities</div>
       <TextInput bind:value={filterString} bind:element={textInputEl} />
       {#each [...processedData] as [categoryName, items] (categoryName)}


### PR DESCRIPTION
Increases breadcrumb selector max height. Also, now that we usually can see all items in the selector, it's visible that categories without entities/items are sometimes rendered. This fixes that as well.

Master issue: https://github.com/centerofci/mathesar/issues/1516

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
