### PR TITLE
add non-preprocessed columns to further steps in grouping

### DIFF
--- a/db/records/operations/group.py
+++ b/db/records/operations/group.py
@@ -251,11 +251,17 @@ def get_group_augmented_records_pg_query(table, group_by):
 
 
 def _get_distinct_group_select(table, grouping_columns, preproc):
+    def _get_processed_column(proc, col):
+        if proc is not None:
+            pcol = get_db_function_subclass_by_id(proc).to_sa_expression(col)
+        else:
+            pcol = col
+        return pcol
+
     if preproc is not None:
         processed_columns = [
-            get_db_function_subclass_by_id(proc).to_sa_expression(col)
+            _get_processed_column(proc, col)
             for proc, col in zip(preproc, grouping_columns)
-            if proc is not None
         ]
     else:
         processed_columns = grouping_columns

--- a/db/tests/records/operations/test_group.py
+++ b/db/tests/records/operations/test_group.py
@@ -531,6 +531,14 @@ group_by_num_list = [
             mode=group.GroupMode.DISTINCT.value,
             preproc=[None, 'extract_email_domain']
         ),
+        259
+    ),
+    (
+        group.GroupBy(
+            ['Student Email'],
+            mode=group.GroupMode.DISTINCT.value,
+            preproc=['extract_email_domain']
+        ),
         3
     ),
     (


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1559 

<!-- Concisely describe what the pull request does. -->

This fixes a bug where preprocessing some columns but not others resulted in the non-preprocessed columns being ignored for certain grouping operations.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
