### PR TITLE
Don't force Table Inspector to be visible after fetching columns

### DIFF
--- a/mathesar_ui/src/stores/table-data/tabularData.ts
+++ b/mathesar_ui/src/stores/table-data/tabularData.ts
@@ -99,9 +99,6 @@ export class TabularData {
     this.columnsDataStore.on('columnPatched', async () => {
       await this.recordsData.fetch();
     });
-    this.columnsDataStore.on('columnsFetched', async () => {
-      this.display.isTableInspectorVisible.set(true);
-    });
   }
 
   refresh(): Promise<


### PR DESCRIPTION
This is a small follow-up to this thread: https://github.com/centerofci/mathesar/pull/1591#discussion_r963985859

## Before this PR

1. Open Table Page
1. Hide Table Inspector
1. Click the refresh button within the Actions Pane
1. Expect Table Inspector to remain hidden
1. Observe the Table Inspector to become visible again.

## After this PR

- The Table Inspector still opens initially because of [this line](https://github.com/centerofci/mathesar/blob/9c5f1e170024a6ef21384cdb8b41b50e349efd60/mathesar_ui/src/stores/table-data/display.ts#L188): 

    ```ts
    this.isTableInspectorVisible = writable(true);
    ```

- Refreshing the table no longer forces the Table Inspector to be visible again.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

