### PR TITLE
Improve readability of custom JS error class

### DIFF
--- a/mathesar_ui/src/systems/table-view/table-inspector/column/ColumnType.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/column/ColumnType.svelte
@@ -2,7 +2,7 @@
   import { Button, Icon } from '@mathesar/component-library';
   import { iconEdit } from '@mathesar/icons';
   import type { ProcessedColumn } from '@mathesar/stores/table-data/types';
-  import { UnhandledError } from '@mathesar/utils/errors';
+  import { MissingExhaustiveConditionError } from '@mathesar/utils/errors';
   import AbstractTypeConfiguration from '../../header/header-cell/abstract-type-configuration/AbstractTypeConfiguration.svelte';
 
   export let column: ProcessedColumn;
@@ -17,7 +17,7 @@
         mode = 'read';
         break;
       default:
-        throw new UnhandledError(mode, 'ColumnType');
+        throw new MissingExhaustiveConditionError(mode, 'ColumnType');
     }
     return undefined;
   }

--- a/mathesar_ui/src/utils/errors.ts
+++ b/mathesar_ui/src/utils/errors.ts
@@ -77,14 +77,13 @@ export class ApiMultiError extends Error {
 }
 
 /**
- * This is meant to be a build time error
- * Generally use to make sure of exhaustive conditions handlint
+ * This error should be thrown when a union type has not been sufficiently
+ * narrowed by exhaustiveness checking.
  */
-export class UnhandledError extends Error {
-  constructor(value: never, message: string) {
-    super();
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    this.message = `Unhandled Error: ${value}. ${message}`;
+export class MissingExhaustiveConditionError extends Error {
+  constructor(value: never, message?: string) {
+    super(`${JSON.stringify(value)}${message ? ` ${message}` : ''}`);
+    this.name = 'MissingExhaustiveConditionError';
   }
 }
 


### PR DESCRIPTION
This is a follow-up to this thread: https://github.com/centerofci/mathesar/pull/1591#discussion_r964006125

## Before

- `UnhandledError` is a very generic name, which made it hard for me to understand its specific purpose (and made the argument type `never` less obviously correct).

    Having read your [comment](https://github.com/centerofci/mathesar/pull/1591#discussion_r964307977), now I understand that it's the _exhaustiveness checking_ that's "unhandled". That makes sense. When reading "UnhandledError", I was thinking it was the _error itself_ that we are describing as unhandled, so I saw it as an error that we would be throwing under lots of different scenarios. (My confusion might stem from the terminology that Python uses where "exceptions" are "raised" and then either "handled" or "unhandled".)

## After

- The error class has a clearer name, `MissingExhaustiveConditionError`.

- `value` is fully stringified, so that if it's an object, we can see its value.

- `message` is optional.

- The formatting and language within code comment is improved.



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

