### PR TITLE
Prefetch SQLAlchemy Table when fetching a list of Django Tables

### DIFF
--- a/THIRDPARTY
+++ b/THIRDPARTY
@@ -33,3 +33,11 @@ License: MIT
 License Text: https://github.com/sdecima/javascript-detect-element-resize/blob/master/LICENSE
 Derivative files:
     /mathesar_ui/src/sections/table-view/virtual-list/detectElementResize.ts
+
+Component: django-prefetch
+Version: 1.2.3
+Copyright: 2012-2021, Ionel Cristian Mărieș
+License: BSD 2-Clause
+License Text: https://github.com/ionelmc/django-prefetch/blob/master/LICENSE
+Derivative files:
+    /mathesar/utils/prefetch.py

--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -38,7 +38,7 @@ class TableViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, viewset
     filterset_class = TableFilter
 
     def get_queryset(self):
-        return Table.objects.all().order_by('-created_at')
+        return Table.objects.prefetch('_sa_table').order_by('-created_at')
 
     def partial_update(self, request, pk=None):
         table = self.get_object()

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -43,6 +43,7 @@ from db.tables.utils import get_primary_key_column
 from mathesar import reflection
 from mathesar.models.relation import Relation
 from mathesar.utils import models as model_utils
+from mathesar.utils.prefetch import PrefetchManager, Prefetcher
 from mathesar.database.base import create_mathesar_engine
 from mathesar.database.types import UIType, get_ui_type_from_db_type
 

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -6,8 +6,6 @@ from django.db import models
 from django.db.models import JSONField, Deferrable
 from django.utils.functional import cached_property
 from django.contrib.auth.models import User
-from prefetch import PrefetchManager, Prefetcher
-from sqlalchemy import MetaData
 
 from db.columns import utils as column_utils
 from db.columns.operations.create import create_column, duplicate_column

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -6,6 +6,8 @@ from django.db import models
 from django.db.models import JSONField, Deferrable
 from django.utils.functional import cached_property
 from django.contrib.auth.models import User
+from prefetch import PrefetchManager, Prefetcher
+from sqlalchemy import MetaData
 
 from db.columns import utils as column_utils
 from db.columns.operations.create import create_column, duplicate_column
@@ -28,7 +30,12 @@ from db.schemas import utils as schema_utils
 from db.tables import utils as table_utils
 from db.tables.operations.drop import drop_table
 from db.tables.operations.move_columns import move_columns_between_related_tables
-from db.tables.operations.select import get_oid_from_table, reflect_table_from_oid, get_table_description
+from db.tables.operations.select import (
+    get_oid_from_table,
+    reflect_table_from_oid,
+    get_table_description,
+    reflect_tables_from_oids
+)
 from db.tables.operations.split import extract_columns_from_table
 from db.records.operations.insert import insert_from_select
 from db.tables.utils import get_primary_key_column
@@ -51,7 +58,7 @@ class BaseModel(models.Model):
         abstract = True
 
 
-class DatabaseObjectManager(models.Manager):
+class DatabaseObjectManager(PrefetchManager):
     def get_queryset(self):
         reflection.reflect_db_objects()
         return super().get_queryset()
@@ -182,7 +189,20 @@ class Schema(DatabaseObject):
 class Table(DatabaseObject, Relation):
     # These are fields whose source of truth is in the model
     MODEL_FIELDS = ['import_verified']
-
+    current_objects = models.Manager()
+    objects = DatabaseObjectManager(
+        _sa_table=Prefetcher(
+            filter=lambda oids, tables: reflect_tables_from_oids(oids, list(tables)[0]._sa_engine),
+            mapper=lambda table: table.oid,
+            # A filler statement, just used to satisfy the library. It does not affect the prefetcher in any way as we bypass reverse mapping if the prefetcher returns a dictionary
+            reverse_mapper=lambda table: table.oid,
+            decorator=lambda table, _sa_table: setattr(
+                table,
+                '_sa_table',
+                _sa_table
+            )
+        )
+    )
     schema = models.ForeignKey('Schema', on_delete=models.CASCADE,
                                related_name='tables')
     import_verified = models.BooleanField(blank=True, null=True)

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -190,8 +190,10 @@ class Table(DatabaseObject, Relation):
     MODEL_FIELDS = ['import_verified']
     current_objects = models.Manager()
     objects = DatabaseObjectManager(
+        # TODO Move the Prefetcher into a separate class and replace lambdas with proper function
         _sa_table=Prefetcher(
-            filter=lambda oids, tables: reflect_tables_from_oids(oids, list(tables)[0]._sa_engine),
+            filter=lambda oids, tables: reflect_tables_from_oids(oids, list(tables)[0]._sa_engine)
+            if len(tables) > 0 else [],
             mapper=lambda table: table.oid,
             # A filler statement, just used to satisfy the library. It does not affect the prefetcher in any way as we bypass reverse mapping if the prefetcher returns a dictionary
             reverse_mapper=lambda table: table.oid,

--- a/mathesar/utils/prefetch.py
+++ b/mathesar/utils/prefetch.py
@@ -252,16 +252,15 @@ class Prefetcher(object):
                 else:
                     data_mapping[self.mapper(obj)] = obj
 
-
             t2 = time.time()
             logger.debug("Creating data_mapping for %s query took %.3f secs for the %s prefetcher.",
-                         model.__name__, t2-t1, name)
+                         model.__name__, t2 - t1, name)
             t1 = time.time()
             related_data = self.filter(data_mapping.keys(), data_mapping.values())
             related_data_len = len(related_data)
             t2 = time.time()
             logger.debug("Filtering for %s related objects for %s query took %.3f secs for the %s prefetcher.",
-                         related_data_len, model.__name__, t2-t1, name)
+                         related_data_len, model.__name__, t2 - t1, name)
             relation_mapping = collections.defaultdict(list)
 
             t1 = time.time()
@@ -282,7 +281,7 @@ class Prefetcher(object):
 
             t2 = time.time()
             logger.debug("Adding the related objects on the %s query took %.3f secs for the %s prefetcher.",
-                         model.__name__, t2-t1, name)
+                         model.__name__, t2 - t1, name)
             return dataset
         except Exception:
             logger.exception("Prefetch failed for %s prefetch on the %s model:", name, model.__name__)

--- a/mathesar/utils/prefetch.py
+++ b/mathesar/utils/prefetch.py
@@ -1,0 +1,289 @@
+import collections
+import time
+from logging import getLogger
+
+import django
+from django.db import models
+from django.db.models import query
+from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
+
+__version__ = '1.2.3'
+
+logger = getLogger(__name__)
+
+
+class PrefetchManagerMixin(models.Manager):
+    use_for_related_fields = True
+    prefetch_definitions = {}
+
+    @classmethod
+    def get_queryset_class(cls):
+        return PrefetchQuerySet
+
+    def __init__(self):
+        super(PrefetchManagerMixin, self).__init__()
+        for name, prefetcher in self.prefetch_definitions.items():
+            if prefetcher.__class__ is not Prefetcher and not callable(prefetcher):
+                raise InvalidPrefetch("Invalid prefetch definition %s. This prefetcher needs to be a class not an instance." % name)
+
+    def get_queryset(self):
+        qs = self.get_queryset_class()(
+            self.model, prefetch_definitions=self.prefetch_definitions
+        )
+
+        if getattr(self, '_db', None) is not None:
+            qs = qs.using(self._db)
+        return qs
+
+    def prefetch(self, *args):
+        return self.get_queryset().prefetch(*args)
+
+
+class PrefetchManager(PrefetchManagerMixin):
+    def __init__(self, **kwargs):
+        self.prefetch_definitions = kwargs
+        super(PrefetchManager, self).__init__()
+
+
+class PrefetchIterable(query.ModelIterable):
+    def __iter__(self):
+        data = list(super(PrefetchIterable, self).__iter__())
+        for name, (forwarders, prefetcher) in self.queryset._prefetch.items():
+            prefetcher.fetch(data, name, self.queryset.model, forwarders,
+                             getattr(self.queryset, '_db', None))
+        return iter(data)
+
+
+class InvalidPrefetch(Exception):
+    pass
+
+
+class PrefetchOption(object):
+    def __init__(self, name, *args, **kwargs):
+        self.name = name
+        self.args = args
+        self.kwargs = kwargs
+
+
+P = PrefetchOption
+
+
+class PrefetchQuerySet(query.QuerySet):
+    def __init__(self, model=None, query=None, using=None,
+                 prefetch_definitions=None, **kwargs):
+        super(PrefetchQuerySet, self).__init__(model, query, using, **kwargs)
+        self._prefetch = {}
+        self.prefetch_definitions = prefetch_definitions
+        self._iterable_class = PrefetchIterable
+
+    if django.VERSION < (2, 0):
+        def _clone(self, **kwargs):
+            return super(PrefetchQuerySet, self). \
+                _clone(_prefetch=self._prefetch,
+                       prefetch_definitions=self.prefetch_definitions, **kwargs)
+    else:
+        def _clone(self):
+            c = super(PrefetchQuerySet, self)._clone()
+            c._prefetch = self._prefetch
+            c.prefetch_definitions = self.prefetch_definitions
+            return c
+
+    def prefetch(self, *names):
+        obj = self._clone()
+
+        for opt in names:
+            if isinstance(opt, PrefetchOption):
+                name = opt.name
+            else:
+                name = opt
+                opt = None
+            parts = name.split('__')
+            forwarders = []
+            prefetcher = None
+            model = self.model
+            prefetch_definitions = self.prefetch_definitions
+
+            for what in parts:
+                if not prefetcher:
+                    if what in prefetch_definitions:
+                        prefetcher = prefetch_definitions[what]
+                        continue
+                    descriptor = getattr(model, what, None)
+                    if isinstance(descriptor, ForwardManyToOneDescriptor):
+                        field = descriptor.field
+                        forwarders.append(field.name)
+                        model = field.remote_field.model
+                        manager = model.objects
+                        if not isinstance(manager, PrefetchManagerMixin):
+                            raise InvalidPrefetch('Manager for %s is not a PrefetchManagerMixin instance.' % model)
+                        prefetch_definitions = manager.prefetch_definitions
+                    else:
+                        raise InvalidPrefetch("Invalid part %s in prefetch call for %s on model %s. "
+                                              "The name is not a prefetcher nor a forward relation (fk)." % (
+                                                  what, name, self.model))
+                else:
+                    raise InvalidPrefetch("Invalid part %s in prefetch call for %s on model %s. "
+                                          "You cannot have any more relations after the prefetcher." % (
+                                              what, name, self.model))
+            if not prefetcher:
+                raise InvalidPrefetch("Invalid prefetch call with %s for on model %s. "
+                                      "The last part isn't a prefetch definition." % (name, self.model))
+            if opt:
+                if prefetcher.__class__ is Prefetcher:
+                    raise InvalidPrefetch("Invalid prefetch call with %s for on model %s. "
+                                          "This prefetcher (%s) needs to be a subclass of Prefetcher." % (
+                                              name, self.model, prefetcher))
+
+                obj._prefetch[name] = forwarders, prefetcher(*opt.args, **opt.kwargs)
+            else:
+                obj._prefetch[name] = forwarders, prefetcher if prefetcher.__class__ is Prefetcher else prefetcher()
+
+        for forwarders, prefetcher in obj._prefetch.values():
+            if forwarders:
+                obj = obj.select_related('__'.join(forwarders))
+        return obj
+
+    def iterator(self):
+        return self._iterable_class(self)
+
+
+class Prefetcher(object):
+    """
+    Prefetch definitition. For convenience you can either subclass this and
+    define the methods on the subclass or just pass the functions to the
+    contructor.
+
+    Eg, subclassing::
+
+        class GroupPrefetcher(Prefetcher):
+
+            @staticmethod
+            def filter(ids):
+                return User.groups.through.objects.filter(user__in=ids).select_related('group')
+
+            @staticmethod
+            def reverse_mapper(user_group_association):
+                return [user_group_association.user_id]
+
+            @staticmethod
+            def decorator(user, user_group_associations=()):
+                setattr(user, 'prefetched_groups', [i.group for i in user_group_associations])
+
+    Or with contructor::
+
+        Prefetcher(
+            filter = lambda ids: User.groups.through.objects.filter(user__in=ids).select_related('group'),
+            reverse_mapper = lambda user_group_association: [user_group_association.user_id],
+            decorator = lambda user, user_group_associations=(): setattr(user, 'prefetched_groups', [
+                i.group for i in user_group_associations
+            ])
+        )
+
+
+    Glossary:
+
+    * filter(list_of_ids):
+
+        A function that returns a queryset containing all the related data for a given list of keys.
+        Takes a list of ids as argument.
+
+    * reverse_mapper(related_object):
+
+        A function that takes the related object as argument and returns a list
+        of keys that maps that related object to the objects in the queryset.
+
+    * mapper(object):
+
+        Optional (defaults to ``lambda obj: obj.pk``).
+
+        A function that returns the key for a given object in your query set.
+
+    * decorator(object, list_of_related_objects):
+
+        A function that will save the related data on each of your objects in
+        your queryset. Takes the object and a list of related objects as
+        arguments. Note that you should not override existing attributes on the
+        model instance here.
+
+    """
+    collect = False
+
+    def __init__(self, filter=None, reverse_mapper=None, decorator=None, mapper=None, collect=None):
+        if filter:
+            self.filter = filter
+        elif not hasattr(self, 'filter'):
+            raise RuntimeError("You must define a filter function")
+
+        if reverse_mapper:
+            self.reverse_mapper = reverse_mapper
+        elif not hasattr(self, 'reverse_mapper'):
+            raise RuntimeError("You must define a reverse_mapper function")
+
+        if decorator:
+            self.decorator = decorator
+        elif not hasattr(self, 'decorator'):
+            raise RuntimeError("You must define a decorator function")
+
+        if mapper:
+            self.mapper = mapper
+
+        if collect is not None:
+            self.collect = collect
+
+    @staticmethod
+    def mapper(obj):
+        return obj.pk
+
+    def fetch(self, dataset, name, model, forwarders, db):
+        collect = self.collect or forwarders
+
+        try:
+            data_mapping = collections.defaultdict(list)
+            t1 = time.time()
+            for obj in dataset:
+                for field in forwarders:
+                    obj = getattr(obj, field, None)
+
+                if not obj:
+                    continue
+
+                if collect:
+                    data_mapping[self.mapper(obj)].append(obj)
+                else:
+                    data_mapping[self.mapper(obj)] = obj
+
+
+            t2 = time.time()
+            logger.debug("Creating data_mapping for %s query took %.3f secs for the %s prefetcher.",
+                         model.__name__, t2-t1, name)
+            t1 = time.time()
+            related_data = self.filter(data_mapping.keys(), data_mapping.values())
+            related_data_len = len(related_data)
+            t2 = time.time()
+            logger.debug("Filtering for %s related objects for %s query took %.3f secs for the %s prefetcher.",
+                         related_data_len, model.__name__, t2-t1, name)
+            relation_mapping = collections.defaultdict(list)
+
+            t1 = time.time()
+            if isinstance(related_data, dict):
+                relation_mapping = related_data
+            else:
+                for obj in related_data:
+                    for id_ in self.reverse_mapper(obj):
+                        if id_:
+                            relation_mapping[id_].append(obj)
+            for id_, related_items in relation_mapping.items():
+                if id_ in data_mapping:
+                    if collect:
+                        for item in data_mapping[id_]:
+                            self.decorator(item, related_items)
+                    else:
+                        self.decorator(data_mapping[id_], related_items)
+
+            t2 = time.time()
+            logger.debug("Adding the related objects on the %s query took %.3f secs for the %s prefetcher.",
+                         model.__name__, t2-t1, name)
+            return dataset
+        except Exception:
+            logger.exception("Prefetch failed for %s prefetch on the %s model:", name, model.__name__)
+            raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ clevercsv==0.6.8
 Django==3.1.14
 dj-database-url==0.5.0
 django-filter==2.4.0
+django-prefetch==1.2.3
 django-property-filter==1.1.0
 djangorestframework==3.12.4
 drf-friendly-errors==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ clevercsv==0.6.8
 Django==3.1.14
 dj-database-url==0.5.0
 django-filter==2.4.0
-django-prefetch==1.2.3
 django-property-filter==1.1.0
 djangorestframework==3.12.4
 drf-friendly-errors==0.14


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #802 

PR improves performance when fetching multiple tables by prefetching the underlying SqlAlchemy tables in bulk instead of fetching each table object during serialization. 

**Technical details**
I have added a modified version of the `django-prefetch` library which is serving as a temporary duct tape for prefetching. I would be replacing most of that code in future PR, so the review can be skipped for the `utils/prefetch.py` file

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
