### PR TITLE
Show table and queries count on db page from API

### DIFF
--- a/mathesar_ui/src/AppTypes.ts
+++ b/mathesar_ui/src/AppTypes.ts
@@ -14,6 +14,8 @@ export interface DBObjectEntry {
 
 export interface SchemaEntry extends DBObjectEntry {
   has_dependencies: boolean;
+  num_tables: number;
+  num_queries: number;
 }
 
 export interface SchemaResponse extends SchemaEntry, TreeItem {

--- a/mathesar_ui/src/pages/schema/SchemaPage.svelte
+++ b/mathesar_ui/src/pages/schema/SchemaPage.svelte
@@ -44,7 +44,7 @@
   </div>
 
   <div class="entity-list-wrapper">
-    <h2 class="entity-list-title">Tables ({tablesMap.size})</h2>
+    <h2 class="entity-list-title">Tables ({schema.num_tables})</h2>
     <ul class="entity-list">
       {#each [...tablesMap.values()] as table (table.id)}
         <li class="entity-list-item">
@@ -61,7 +61,7 @@
 
   <div class="entity-list-wrapper">
     <h2 class="entity-list-title">
-      Explorations ({[...queriesMap.values()].length})
+      Explorations ({schema.num_queries})
     </h2>
     <ul class="entity-list">
       {#each [...queriesMap.values()] as query (query.id)}


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
This PR pulls `num_queries` and `num_tables` from the API and shows them on the DB page as asked in #1604.

<!-- Concisely describe what the pull request does. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
<img width="612" alt="Screenshot 2022-09-14 at 1 17 42 PM" src="https://user-images.githubusercontent.com/11032856/190093549-dea253af-c5b0-4477-8e94-47834892aa6d.png">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
