### PR TITLE
Filter before other operations

### DIFF
--- a/db/tests/tables/operations/test_select.py
+++ b/db/tests/tables/operations/test_select.py
@@ -224,7 +224,7 @@ def test_get_description_from_table(roster_table_name, engine_with_roster):
     roster_table_oid = ma_sel.get_oid_from_table(roster_table_name, schema, engine)
     expect_comment = 'my super comment'
     with engine.begin() as conn:
-        conn.execute(text(f'''COMMENT ON TABLE "{roster_table_name}" IS '{expect_comment}';'''))
+        conn.execute(text(f'''COMMENT ON TABLE "{schema}"."{roster_table_name}" IS '{expect_comment}';'''))
 
     actual_comment = ma_sel.get_table_description(roster_table_oid, engine)
 

--- a/db/transforms/operations/apply.py
+++ b/db/transforms/operations/apply.py
@@ -35,14 +35,14 @@ def apply_transformations_deprecated(
 
     transforms = []
 
+    if filter:
+        transforms.append(base.Filter(filter))
     if duplicate_only:
         transforms.append(base.DuplicateOnly(duplicate_only))
     if group_by:
         transforms.append(base.Group(group_by))
     if order_by:
         transforms.append(base.Order(order_by))
-    if filter:
-        transforms.append(base.Filter(filter))
     if search:
         transforms.append(base.Search([search, limit]))
     if columns_to_select:

--- a/mathesar/tests/api/test_record_api.py
+++ b/mathesar/tests/api/test_record_api.py
@@ -696,6 +696,7 @@ def test_group_filter_combo_order(create_patents_table, client):
 
     expect_group_counts = [2, 3, 2, 1, 7]
     actual_group_counts = [g['count'] for g in response_data['grouping']['groups']]
+    assert actual_group_counts == expect_group_counts
 
 
 def test_record_list_pagination_limit(create_patents_table, client):


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1599 

<!-- Concisely describe what the pull request does. -->

This changes the order in which transformations supplied via query string parameter are applied to a relation when calculating results to return.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

The main change is to move filtering to the top. This has the effects of

- modifying the group counts as per the linked issue, and
- If `duplicates_only` is selected, duplicates will be calculated after filtering.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
