### PR TITLE
modify API response format for preview data

### DIFF
--- a/mathesar/api/db/viewsets/records.py
+++ b/mathesar/api/db/viewsets/records.py
@@ -114,12 +114,11 @@ class RecordViewSet(viewsets.ViewSet):
             ]
         }
         column_names_to_ids = table.get_column_name_id_bidirectional_map()
-        column_ids_to_names = column_names_to_ids.inverse
         records = paginator.paginate_queryset(
             table,
             request,
             table,
-            column_ids_to_names,
+            column_names_to_ids,
             filters=record_filters
         )
         if not records:

--- a/mathesar/api/utils.py
+++ b/mathesar/api/utils.py
@@ -71,7 +71,11 @@ def process_annotated_records(record_list, column_name_id_map=None, preview_meta
             return _replace_column_names_with_ids(group_metadata_item)
         else:
             return group_metadata_item
-    if preview_metadata:
+
+    if preview_metadata and column_name_id_map is not None:
+        column_id_name_map = {i: n for n, i in column_name_id_map.items()}
+        # raise Exception(f"name_id_map: {column_id_name_map} \n id_name_map: {column_id_name_map}")
+        # raise Exception(f"name_id_map: {column_name_id_map} \n id_name_map: {column_id_name_map} \n name_id_map.items(): {column_name_id_map.items()}")
         # Extract preview data from the records
         # TODO Replace modifying the parameter directly
         for preview_colum_id, preview_info in preview_metadata.items():
@@ -81,13 +85,13 @@ def process_annotated_records(record_list, column_name_id_map=None, preview_meta
             # Move column id into the object so that dict can be flattened into a list
             preview_metadata[preview_colum_id]['column'] = preview_colum_id
             preview_data_column_aliases = column_alias_from_preview_template(preview_template)
-            preview_records = []
-            for record_index, record in enumerate(processed_records):
+            preview_records = {}
+            for record in processed_records:
                 column_preview_data = {}
                 for preview_data_column_alias in preview_data_column_aliases:
-                    preview_value = processed_records[record_index].pop(preview_data_column_alias)
+                    preview_value = record.pop(preview_data_column_alias)
                     column_preview_data.update({preview_data_column_alias: preview_value})
-                preview_records.append(column_preview_data)
+                preview_records[str(record[column_id_name_map[preview_colum_id]])] = column_preview_data
             preview_metadata[preview_colum_id]['data'] = preview_records
         # Flatten the preview objects
         preview_metadata = preview_metadata.values()

--- a/mathesar/api/utils.py
+++ b/mathesar/api/utils.py
@@ -74,8 +74,6 @@ def process_annotated_records(record_list, column_name_id_map=None, preview_meta
 
     if preview_metadata and column_name_id_map is not None:
         column_id_name_map = {i: n for n, i in column_name_id_map.items()}
-        # raise Exception(f"name_id_map: {column_id_name_map} \n id_name_map: {column_id_name_map}")
-        # raise Exception(f"name_id_map: {column_name_id_map} \n id_name_map: {column_id_name_map} \n name_id_map.items(): {column_name_id_map.items()}")
         # Extract preview data from the records
         # TODO Replace modifying the parameter directly
         for preview_colum_id, preview_info in preview_metadata.items():

--- a/mathesar/tests/api/test_record_api.py
+++ b/mathesar/tests/api/test_record_api.py
@@ -806,7 +806,7 @@ def test_foreign_key_record_api_all_column_previews(publication_tables, client):
     preview_column_alias = f'{{{publication_title_alias}}} Published By: {{{ publisher_name_alias}}} and Authored by Full Name: {{{author_first_name_alias}}} {{{author_last_name_alias}}} along with Full Name: {{{co_author_first_name_alias}}} {{{co_author_last_name_alias}}}'
 
     assert preview_column['template'] == preview_column_alias
-    preview_data = preview_column['data'][0]
+    preview_data = preview_column['data']['1']
     assert all([key in preview_data for key in [publication_title_alias, publisher_name_alias, author_first_name_alias, author_last_name_alias, co_author_first_name_alias, co_author_last_name_alias]])
 
     expected_preview_data = {publication_title_alias: 'Pressure Should Old', publisher_name_alias: 'Ruiz', author_first_name_alias: 'Matthew', author_last_name_alias: 'Brown', co_author_first_name_alias: 'Mark', co_author_last_name_alias: 'Smith'}


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1737 

<!-- Concisely describe what the pull request does. -->

This modifies the API response as per the issue description. 

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

The change of this PR is to use an object for `preview_data.[0].data` instead of an array. Keys are the fkey value for a given column associated with a given preview, and values are an object mapping tempate keys to the value to fill in.

Example response to  `GET /api/db/v0/tables/<id>/records/`:
```json
{
    "count": 104,
    "grouping": null,
    "preview_data": [
        {
            "template": "{20__1___2__13___14__25__col__26}",
            "column": 20,
            "data": {
                "69": {
                    "20__1___2__13___14__25__col__26": "Rocha PLC"
                },
                "44": {
                    "20__1___2__13___14__25__col__26": "Rocha PLC"
                },
                "89": {
                    "20__1___2__13___14__25__col__26": "Rocha PLC"
                },
                "20": {
                    "20__1___2__13___14__25__col__26": "Stokes, Campos and Rich"
                },
                "66": {
                    "20__1___2__13___14__25__col__26": "Rocha PLC"
                }
            }
        },
        {
            "template": "{21__5__col__6}",
            "column": 21,
            "data": {
                "27": {
                    "21__5__col__6": "Andrew"
                },
                "15": {
                    "21__5__col__6": "Traci"
                },
                "20": {
                    "21__5__col__6": "Jesse"
                },
                "24": {
                    "21__5__col__6": "Joshua"
                },
                "9": {
                    "21__5__col__6": "Connor"
                }
            }
        }
    ],
    "results": [
        {
            "19": 32,
            "20": 69,
            "21": 27,
            "22": "2022-05-27T12:44:36.796756 AD",
            "23": "2022-06-10 AD",
            "24": "2022-06-11T10:59:03.315205 AD"
        },
        {
            "19": 33,
            "20": 44,
            "21": 15,
            "22": "2022-05-27T15:07:11.915359 AD",
            "23": "2022-06-10 AD",
            "24": "2022-06-25T13:06:10.755371 AD"
        },
        {
            "19": 34,
            "20": 89,
            "21": 20,
            "22": "2022-05-27T19:05:43.121606 AD",
            "23": "2022-06-10 AD",
            "24": "2022-07-12T12:53:40.561356 AD"
        },
        {
            "19": 35,
            "20": 20,
            "21": 24,
            "22": "2022-05-30T10:49:25.714241 AD",
            "23": "2022-06-13 AD",
            "24": "2022-06-15T15:15:38.867578 AD"
        },
        {
            "19": 36,
            "20": 66,
            "21": 9,
            "22": "2022-05-30T19:22:38.341382 AD",
            "23": "2022-06-13 AD",
            "24": "2022-06-15T22:38:40.98668 AD"
        }
    ]
}
```

Example response to `GET /api/db/v0/tables/<tid>/records/<rid>/`: 

```json
{
    "count": 1,
    "grouping": null,
    "preview_data": [
        {
            "template": "{20__1___2__13___14__25__col__26}",
            "column": 20,
            "data": {
                "98": {
                    "20__1___2__13___14__25__col__26": "Rocha PLC"
                }
            }
        },
        {
            "template": "{21__5__col__6}",
            "column": 21,
            "data": {
                "23": {
                    "21__5__col__6": "Eduardo"
                }
            }
        }
    ],
    "results": [
        {
            "19": 5,
            "20": 98,
            "21": 23,
            "22": "2022-05-04T13:16:07.300468 AD",
            "23": "2022-05-18 AD",
            "24": "2022-05-22T14:56:51.33729 AD"
        }
    ]
}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
