### PR TITLE
Improve unique violation exception

### DIFF
--- a/mathesar/api/exceptions/database_exceptions/exceptions.py
+++ b/mathesar/api/exceptions/database_exceptions/exceptions.py
@@ -30,6 +30,7 @@ class UniqueViolationAPIException(MathesarAPIException):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
     ):
         if details is None and table is not None:
+            details = {}
             try:
                 constraint_oid = get_constraint_oid_by_name_and_table_oid(
                     exception.orig.diag.constraint_name,
@@ -39,7 +40,7 @@ class UniqueViolationAPIException(MathesarAPIException):
                 constraint = Constraint.objects.get(oid=constraint_oid)
                 details = {
                     "constraint": constraint.id,
-                    "original_details": exception.orig.diag.message_detail,
+                    "constraint_columns": [c.id for c in constraint.columns],
                 }
             except TypeError:
                 details = {

--- a/mathesar/api/serializers/records.py
+++ b/mathesar/api/serializers/records.py
@@ -34,6 +34,22 @@ class RecordSerializer(MathesarErrorMessageMixin, serializers.BaseSerializer):
                 e,
                 status_code=status.HTTP_400_BAD_REQUEST
             )
+        except IntegrityError as e:
+            if type(e.orig) == NotNullViolation:
+                raise database_api_exceptions.NotNullViolationAPIException(
+                    e,
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    table=table
+                )
+            elif type(e.orig) == UniqueViolation:
+                raise database_api_exceptions.UniqueViolationAPIException(
+                    e,
+                    message="The requested update violates a uniqueness constraint",
+                    table=table,
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                )
+            else:
+                raise database_api_exceptions.MathesarAPIException(e, status_code=status.HTTP_400_BAD_REQUEST)
         return record
 
     def create(self, validated_data):

--- a/mathesar/api/serializers/records.py
+++ b/mathesar/api/serializers/records.py
@@ -1,4 +1,4 @@
-from psycopg2.errors import NotNullViolation
+from psycopg2.errors import NotNullViolation, UniqueViolation
 from rest_framework import serializers
 from rest_framework import status
 from sqlalchemy.exc import IntegrityError
@@ -46,6 +46,13 @@ class RecordSerializer(MathesarErrorMessageMixin, serializers.BaseSerializer):
                     e,
                     status_code=status.HTTP_400_BAD_REQUEST,
                     table=table
+                )
+            elif type(e.orig) == UniqueViolation:
+                raise database_api_exceptions.UniqueViolationAPIException(
+                    e,
+                    message="The requested insert violates a uniqueness constraint",
+                    table=table,
+                    status_code=status.HTTP_400_BAD_REQUEST,
                 )
             else:
                 raise database_api_exceptions.MathesarAPIException(e, status_code=status.HTTP_400_BAD_REQUEST)

--- a/mathesar/tests/api/test_record_api.py
+++ b/mathesar/tests/api/test_record_api.py
@@ -1081,6 +1081,7 @@ def test_record_post_unique_violation(create_patents_table, client):
     actual_exception = response.json()[0]
     assert actual_exception['code'] == ErrorCodes.UniqueViolation.value
     assert actual_exception['message'] == 'The requested insert violates a uniqueness constraint'
+    assert actual_exception['detail']['constraint_columns'] == [id_column_id]
     constraint_id = actual_exception['detail']['constraint']
     actual_constraint_details = client.get(
         f'/api/db/v0/tables/{table.id}/constraints/{constraint_id}/'
@@ -1097,6 +1098,7 @@ def test_record_patch_unique_violation(create_patents_table, client):
     actual_exception = response.json()[0]
     assert actual_exception['code'] == ErrorCodes.UniqueViolation.value
     assert actual_exception['message'] == 'The requested update violates a uniqueness constraint'
+    assert actual_exception['detail']['constraint_columns'] == [id_column_id]
     constraint_id = actual_exception['detail']['constraint']
     actual_constraint_details = client.get(
         f'/api/db/v0/tables/{table.id}/constraints/{constraint_id}/'

--- a/mathesar/tests/api/test_record_api.py
+++ b/mathesar/tests/api/test_record_api.py
@@ -1070,3 +1070,35 @@ def test_record_patch_invalid_date_format(create_patents_table, client):
     assert response.status_code == 400
     assert response_data[0]['code'] == ErrorCodes.InvalidDateFormatError.value
     assert response_data[0]['message'] == 'Invalid date format'
+
+
+def test_record_post_unique_violation(create_patents_table, client):
+    table_name = 'NASA unique record POST'
+    table = create_patents_table(table_name)
+    id_column_id = table.get_column_name_id_bidirectional_map()['id']
+    data = {str(id_column_id): 1}
+    response = client.post(f'/api/db/v0/tables/{table.id}/records/', data=data)
+    actual_exception = response.json()[0]
+    assert actual_exception['code'] == ErrorCodes.UniqueViolation.value
+    assert actual_exception['message'] == 'The requested insert violates a uniqueness constraint'
+    constraint_id = actual_exception['detail']['constraint']
+    actual_constraint_details = client.get(
+        f'/api/db/v0/tables/{table.id}/constraints/{constraint_id}/'
+    ).json()
+    assert actual_constraint_details['name'] == 'NASA unique record POST_pkey'
+
+
+def test_record_patch_unique_violation(create_patents_table, client):
+    table_name = 'NASA unique record PATCH'
+    table = create_patents_table(table_name)
+    id_column_id = table.get_column_name_id_bidirectional_map()['id']
+    data = {str(id_column_id): 1}
+    response = client.patch(f'/api/db/v0/tables/{table.id}/records/{2}/', data=data)
+    actual_exception = response.json()[0]
+    assert actual_exception['code'] == ErrorCodes.UniqueViolation.value
+    assert actual_exception['message'] == 'The requested update violates a uniqueness constraint'
+    constraint_id = actual_exception['detail']['constraint']
+    actual_constraint_details = client.get(
+        f'/api/db/v0/tables/{table.id}/constraints/{constraint_id}/'
+    ).json()
+    assert actual_constraint_details['name'] == 'NASA unique record PATCH_pkey'


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1059 

<!-- Concisely describe what the pull request does. -->

This adds more info (namely the constraint violation ID) to the response when a Uniqueness constraint is violated by one of:
- `POST /api/db/v0/tables/<tid>/records/`, or
- `PATCH /api/db/v0/tables/<tid>/records/<rid>/`

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

Due to the nature of the actual response from the DB, we can only return _one_ constraint violation per request, even if more than one would have been violated. This is because PostgreSQL short circuits the evaluation when any violation occurs.

Example response:

```json
[
    {
        "code": 4208,
        "message": "The requested update violates a uniqueness constraint",
        "field": null,
        "detail": {
            "constraint": 8,
            "constraint_columns": [
                16
            ],
            "original_details": "Key (\"Email\"[)=(alexander.phillips38@alvarez.com](mailto:)=(alexander.phillips38@alvarez.com)) already exists."
        }
    }
]
```
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
