### PR TITLE
add Null violation detail

### DIFF
--- a/mathesar/api/db/viewsets/columns.py
+++ b/mathesar/api/db/viewsets/columns.py
@@ -180,6 +180,8 @@ class ColumnViewSet(viewsets.ModelViewSet):
                         status_code=status.HTTP_400_BAD_REQUEST,
                         table=table,
                     )
+                else:
+                    raise base_api_exceptions.MathesarAPIException(e)
             except Exception as e:
                 raise base_api_exceptions.MathesarAPIException(e)
 

--- a/mathesar/api/exceptions/database_exceptions/exceptions.py
+++ b/mathesar/api/exceptions/database_exceptions/exceptions.py
@@ -269,7 +269,7 @@ class NotNullViolationAPIException(MathesarAPIException):
             table.schema._sa_engine,
             metadata=get_cached_metadata(),
         )
-        column = Column.objects.get(attnum=column_attnum)
+        column = Column.objects.get(attnum=column_attnum, table=table)
         details = {
             'record_detail': exception_diagnostics.message_detail,
             'column_id': column.id

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -484,6 +484,29 @@ def test_column_update_invalid_type(create_patents_table, client):
     assert response_json[0]['message'] == "This type casting is invalid."
 
 
+def test_column_update_invalid_nullable(create_patents_table, client):
+    table = create_patents_table('Column Invalid Nullable')
+    body = {"nullable": False}
+    response = client.get(
+        f"/api/db/v0/tables/{table.id}/columns/"
+    )
+    assert response.status_code == 200
+    columns = response.json()['results']
+    column_index = 4
+    column_id = columns[column_index]['id']
+    response = client.patch(
+        f"/api/db/v0/tables/{table.id}/columns/{column_id}/",
+        body
+    )
+    assert response.status_code == 400
+    response_json = response.json()
+    assert response_json[0]['code'] == ErrorCodes.NotNullViolation.value
+    assert response_json[0]['message'] == (
+        'column "Patent Number" of relation'
+        ' "Column Invalid Nullable" contains null values'
+    )
+
+
 def test_column_update_returns_table_dependent_fields(column_test_table, client):
     expt_default = 5
     data = {"default": {"value": expt_default}}


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1394

<!-- Concisely describe what the pull request does. -->

This adds `NotNullViolation` exception handling when patching a column to be nullable.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
