### PR TITLE
Improve Records Summary API performance - Part 1

### DIFF
--- a/mathesar/api/db/viewsets/records.py
+++ b/mathesar/api/db/viewsets/records.py
@@ -49,7 +49,6 @@ class RecordViewSet(viewsets.ViewSet):
         column_names_to_ids = table.get_column_name_id_bidirectional_map()
         column_ids_to_names = column_names_to_ids.inverse
         if filter_unprocessed:
-            table = get_table_or_404(table_pk)
             filter_processed = rewrite_db_function_spec_column_ids_to_names(
                 column_ids_to_names=column_ids_to_names,
                 spec=filter_unprocessed,

--- a/mathesar/api/pagination.py
+++ b/mathesar/api/pagination.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from db.records.operations.group import GroupBy
 from mathesar.api.utils import get_table_or_404, process_annotated_records
-from mathesar.models.base import Table
+from mathesar.models.base import Column, Table
 from mathesar.models.query import UIQuery
 from mathesar.utils.preview import get_preview_info
 
@@ -78,7 +78,7 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
         preview_metadata = None
         # Only tables have columns on the Service layer that hold data necessary for preview template.
         if isinstance(table, Table):
-            columns_query = table.columns.all()
+            columns_query = Column.objects.filter(table=table).prefetch('name')
             preview_metadata, preview_columns = get_preview_info(table)
             table_columns = [{'id': column.id, 'alias': column.name} for column in columns_query]
             columns_to_fetch = table_columns + preview_columns

--- a/mathesar/api/pagination.py
+++ b/mathesar/api/pagination.py
@@ -79,7 +79,7 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
         # Only tables have columns on the Service layer that hold data necessary for preview template.
         if isinstance(table, Table):
             columns_query = table.columns.all()
-            preview_metadata, preview_columns = get_preview_info(table.id)
+            preview_metadata, preview_columns = get_preview_info(table)
             table_columns = [{'id': column.id, 'alias': column.name} for column in columns_query]
             columns_to_fetch = table_columns + preview_columns
 

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -527,8 +527,7 @@ class Table(DatabaseObject, Relation):
         return result
 
     def get_column_name_id_bidirectional_map(self):
-        # TODO: Prefetch column names to avoid N+1 queries
-        columns = Column.objects.filter(table_id=self.id)
+        columns = Column.objects.filter(table_id=self.id).prefetch('name')
         columns_map = bidict({column.name: column.id for column in columns})
         return columns_map
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1763

Partially improves the performance of the `records` endpoint. The PR primarily focuses on improving performance by prefetching objects related to record summary.



**Technical details**
Prefetches the column and table objects required for the summary records. There are also a few preview -> summary nomenclature changes since we are using "record summary" as the naming convention.

I have also added some easy performance improvements like prefetching related objects.

There is also some scope for performance improvement with the `UIQuery` which will be addressed in a separate PR

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
