### PR TITLE
Data explorer performance

### DIFF
--- a/db/queries/base.py
+++ b/db/queries/base.py
@@ -16,6 +16,7 @@ class DBQuery:
             engine,
             transformations=None,
             name=None,
+            metadata=None
     ):
         self.base_table_oid = base_table_oid
         for initial_col in initial_columns:
@@ -24,6 +25,7 @@ class DBQuery:
         self.engine = engine
         self.transformations = transformations
         self.name = name
+        self.metadata = metadata
 
     # mirrors a method in db.records.operations.select
     def get_records(self, **kwargs):
@@ -97,8 +99,7 @@ class DBQuery:
 
     @property
     def initial_relation(self):
-        # TODO reuse metadata
-        metadata = get_empty_metadata()
+        metadata = self.metadata if self.metadata else get_empty_metadata()
         base_table = reflect_table_from_oid(
             self.base_table_oid, self.engine, metadata=metadata
         )
@@ -111,7 +112,7 @@ class DBQuery:
             We use the function-scoped metadata so all involved tables are aware
             of each other.
             """
-            return reflect_table_from_oid(oid, self.engine, metadata=metadata)
+            return reflect_table_from_oid(oid, self.engine, metadata=metadata, keep_existing=True)
 
         def _get_column_name(oid, attnum, metadata):
             return get_column_name_from_attnum(oid, attnum, self.engine, metadata=metadata)

--- a/db/tables/operations/select.py
+++ b/db/tables/operations/select.py
@@ -1,5 +1,5 @@
 from sqlalchemy import (
-    Table, select, join, inspect, and_, cast, func, Integer, literal, or_
+    Table, select, join, inspect, and_, cast, func, Integer, literal, or_,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -14,17 +14,31 @@ TARGET = 'target'
 MULTIPLE_RESULTS = 'multiple_results'
 
 
-def reflect_table(name, schema, engine, metadata, connection_to_use=None):
+def reflect_table(name, schema, engine, metadata, connection_to_use=None, keep_existing=False):
+    extend_existing = not keep_existing
     autoload_with = engine if connection_to_use is None else connection_to_use
-    return Table(name, metadata, schema=schema, autoload_with=autoload_with, extend_existing=True)
+    return Table(
+        name,
+        metadata,
+        schema=schema,
+        autoload_with=autoload_with,
+        extend_existing=extend_existing,
+        keep_existing=keep_existing
+    )
 
 
-def reflect_table_from_oid(oid, engine, metadata, connection_to_use=None):
-    tables = reflect_tables_from_oids([oid], engine, metadata=metadata, connection_to_use=connection_to_use)
+def reflect_table_from_oid(oid, engine, metadata, connection_to_use=None, keep_existing=False):
+    tables = reflect_tables_from_oids(
+        [oid],
+        engine,
+        metadata=metadata,
+        connection_to_use=connection_to_use,
+        keep_existing=keep_existing
+    )
     return tables.get(oid, None)
 
 
-def reflect_tables_from_oids(oids, engine, metadata, connection_to_use=None):
+def reflect_tables_from_oids(oids, engine, metadata, connection_to_use=None, keep_existing=False):
     oids_to_schema_and_table_names = (
         get_map_of_table_oid_to_schema_name_and_table_name(
             oids,
@@ -41,6 +55,7 @@ def reflect_tables_from_oids(oids, engine, metadata, connection_to_use=None):
             engine,
             metadata=metadata,
             connection_to_use=connection_to_use,
+            keep_existing=keep_existing
         )
     return table_oids_to_sa_tables
 

--- a/mathesar/models/query.py
+++ b/mathesar/models/query.py
@@ -222,21 +222,10 @@ class UIQuery(BaseModel, Relation):
 
     @property
     def _db_initial_columns(self):
-        self._prefetch_query_column_objs(self.initial_columns)
         return tuple(
             _db_initial_column_from_json(json_col)
             for json_col in self.initial_columns
         )
-
-    def _prefetch_query_column_objs(self, initial_columns_json):
-        column_ids_to_prefetch = set()
-        for json_col in initial_columns_json:
-            column_ids_to_prefetch.add(json_col["id"])
-            for edge in json_col.get("jp_path", []):
-                column_ids_to_prefetch.update(edge)
-        prefetched_columns = Column.objects.filter(id__in=column_ids_to_prefetch).select_related('table')
-        prefetched_columns_map = {col.id: col for col in prefetched_columns}
-        return prefetched_columns_map
 
     @property
     def _db_transformations(self):

--- a/mathesar/models/query.py
+++ b/mathesar/models/query.py
@@ -8,6 +8,7 @@ from mathesar.models.base import BaseModel, Column
 from mathesar.models.relation import Relation
 from mathesar.api.exceptions.validation_exceptions.exceptions import InvalidValueType, DictHasBadKeys
 from db.transforms.operations.deserialize import deserialize_transformation
+from mathesar.state import get_cached_metadata
 
 
 def _get_validator_for_list_of_dicts(field_name):
@@ -216,6 +217,7 @@ class UIQuery(BaseModel, Relation):
             engine=self._sa_engine,
             transformations=self._db_transformations,
             name=self.name,
+            metadata=get_cached_metadata()
         )
 
     @property

--- a/mathesar/models/query.py
+++ b/mathesar/models/query.py
@@ -220,10 +220,21 @@ class UIQuery(BaseModel, Relation):
 
     @property
     def _db_initial_columns(self):
+        self._prefetch_query_column_objs(self.initial_columns)
         return tuple(
             _db_initial_column_from_json(json_col)
             for json_col in self.initial_columns
         )
+
+    def _prefetch_query_column_objs(self, initial_columns_json):
+        column_ids_to_prefetch = set()
+        for json_col in initial_columns_json:
+            column_ids_to_prefetch.add(json_col["id"])
+            for edge in json_col.get("jp_path", []):
+                column_ids_to_prefetch.update(edge)
+        prefetched_columns = Column.objects.filter(id__in=column_ids_to_prefetch).select_related('table')
+        prefetched_columns_map = {col.id: col for col in prefetched_columns}
+        return prefetched_columns_map
 
     @property
     def _db_transformations(self):


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1841

I have added cached metadata to the function used within `DBQuery`. This improves the performance to a reasonable extent, especially when using multiple foreign key columns.

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
