### PR TITLE
Records API performance improvements

### DIFF
--- a/db/constraints/operations/select.py
+++ b/db/constraints/operations/select.py
@@ -28,8 +28,8 @@ def get_constraint_from_oid(oid, engine, table):
     return None
 
 
-def get_constraint_record_from_oid(oid, engine):
-    metadata = get_empty_metadata()
+def get_constraint_record_from_oid(oid, engine, metadata=None):
+    metadata = metadata if metadata else get_empty_metadata()
     pg_constraint = get_pg_catalog_table("pg_constraint", engine, metadata=metadata)
     # conrelid is the table's OID.
     query = select(pg_constraint).where(pg_constraint.c.oid == oid)

--- a/mathesar/api/db/viewsets/records.py
+++ b/mathesar/api/db/viewsets/records.py
@@ -49,7 +49,6 @@ class RecordViewSet(viewsets.ViewSet):
         column_names_to_ids = table.get_column_name_id_bidirectional_map()
         column_ids_to_names = column_names_to_ids.inverse
         if filter_unprocessed:
-            table = get_table_or_404(table_pk)
             filter_processed = rewrite_db_function_spec_column_ids_to_names(
                 column_ids_to_names=column_ids_to_names,
                 spec=filter_unprocessed,

--- a/mathesar/api/pagination.py
+++ b/mathesar/api/pagination.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from db.records.operations.group import GroupBy
 from mathesar.api.utils import get_table_or_404, process_annotated_records
-from mathesar.models.base import Table
+from mathesar.models.base import Column, Table
 from mathesar.models.query import UIQuery
 from mathesar.utils.preview import get_preview_info
 
@@ -78,7 +78,7 @@ class TableLimitOffsetPagination(DefaultLimitOffsetPagination):
         preview_metadata = None
         # Only tables have columns on the Service layer that hold data necessary for preview template.
         if isinstance(table, Table):
-            columns_query = table.columns.all()
+            columns_query = Column.objects.filter(table_id=table.id).select_related('table__schema__database').prefetch('name')
             preview_metadata, preview_columns = get_preview_info(table.id)
             table_columns = [{'id': column.id, 'alias': column.name} for column in columns_query]
             columns_to_fetch = table_columns + preview_columns

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -244,8 +244,10 @@ class ColumnPrefetcher(Prefetcher):
         table_oids = [table.oid for table in tables]
 
         def _get_column_names_from_tables(table_oids):
-            # TODO why is the fallback engine an empty list? looks like a bug
-            engine = list(tables)[0]._sa_engine if len(tables) > 0 else []
+            if len(tables) > 0:
+                engine = list(tables)[0]._sa_engine
+            else:
+                return []
             return get_map_of_attnum_and_table_oid_to_column_name(
                 table_oids,
                 engine=engine,
@@ -527,8 +529,7 @@ class Table(DatabaseObject, Relation):
         return result
 
     def get_column_name_id_bidirectional_map(self):
-        # TODO: Prefetch column names to avoid N+1 queries
-        columns = Column.objects.filter(table_id=self.id)
+        columns = Column.objects.filter(table_id=self.id).select_related('table__schema__database').prefetch('name')
         columns_map = bidict({column.name: column.id for column in columns})
         return columns_map
 
@@ -763,7 +764,7 @@ class Constraint(DatabaseObject):
     @property
     def _constraint_record(self):
         engine = self.table.schema.database._sa_engine
-        return get_constraint_record_from_oid(self.oid, engine)
+        return get_constraint_record_from_oid(self.oid, engine, get_cached_metadata())
 
     @property
     def name(self):
@@ -773,18 +774,17 @@ class Constraint(DatabaseObject):
     def type(self):
         return constraint_utils.get_constraint_type_from_char(self._constraint_record['contype'])
 
-    @property
+    @cached_property
     def columns(self):
         column_attnum_list = self._constraint_record['conkey']
         return Column.objects.filter(table=self.table, attnum__in=column_attnum_list).order_by("attnum")
 
-    @property
+    @cached_property
     def referent_columns(self):
         column_attnum_list = self._constraint_record['confkey']
         if column_attnum_list:
             foreign_relation_oid = self._constraint_record['confrelid']
-            table = Table.objects.get(oid=foreign_relation_oid, schema=self.table.schema)
-            columns = Column.objects.filter(table=table, attnum__in=column_attnum_list).order_by("attnum")
+            columns = Column.objects.filter(table__oid=foreign_relation_oid, table__schema=self.table.schema, attnum__in=column_attnum_list).order_by("attnum")
             return columns
 
     @property

--- a/mathesar/utils/preview.py
+++ b/mathesar/utils/preview.py
@@ -1,7 +1,7 @@
 import re
 
 from db.constraints.utils import ConstraintType
-from mathesar.models.base import Column, Constraint
+from mathesar.models.base import Column, Constraint, Table
 
 
 def _preview_info_by_column_id(fk_constraints, previous_path=[], exising_columns=[]):
@@ -11,7 +11,7 @@ def _preview_info_by_column_id(fk_constraints, previous_path=[], exising_columns
         constrained_column = fk_constraint.columns[0]
         # For now only single column foreign key is used.
         referent_column = fk_constraint.referent_columns[0]
-        referent_table = referent_column.table
+        referent_table = Table.objects.select_related('settings__preview_settings').get(id=referent_column.table_id)
         referent_table_settings = referent_table.settings
         preview_template = referent_table_settings.preview_settings.template
         preview_data_column_ids = column_ids_from_preview_template(preview_template)
@@ -66,7 +66,7 @@ def column_alias_from_preview_template(preview_template):
 
 
 def get_preview_info(referrer_table_pk, restrict_columns=None, path=[], existing_columns=[]):
-    table_constraints = Constraint.objects.filter(table_id=referrer_table_pk)
+    table_constraints = Constraint.objects.filter(table_id=referrer_table_pk).select_related('table__schema__database')
     fk_constraints = [
         table_constraint
         for table_constraint in table_constraints


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1763 

Uses cached metadata and some Django prefetches to improve the performance of the `/records/` API. 

**Technical Details**

The performance improvements made by the PR are as follows
- SqlAlchemy queries were reduced from 660 to 141 queries
- Django queries were reduced from 194 queries to 91

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
