### PR TITLE
Optionally accept column name when splitting table

### DIFF
--- a/db/tables/operations/split.py
+++ b/db/tables/operations/split.py
@@ -60,7 +60,7 @@ def _create_split_insert_stmt(old_table, extracted_table, extracted_columns, rem
     return split_ins
 
 
-def extract_columns_from_table(old_table_oid, extracted_column_attnums, extracted_table_name, schema, engine, relationship_fk_column_name):
+def extract_columns_from_table(old_table_oid, extracted_column_attnums, extracted_table_name, schema, engine, relationship_fk_column_name=None):
     # TODO reuse metadata
     old_table = reflect_table_from_oid(old_table_oid, engine, metadata=get_empty_metadata())
     old_table_name = old_table.name

--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -97,10 +97,12 @@ class TableViewSet(CreateModelMixin, RetrieveModelMixin, ListModelMixin, viewset
             # as they are the only reference to the new column after it is moved to a new table
             columns_to_extract = serializer.validated_data['extract_columns']
             extracted_table_name = serializer.validated_data['extracted_table_name']
+            relationship_fk_column_name = serializer.validated_data['relationship_fk_column_name']
             extracted_table, remainder_table, _ = table.split_table(
                 columns_to_extract=columns_to_extract,
                 extracted_table_name=extracted_table_name,
                 column_names_id_map=column_names_id_map,
+                relationship_fk_column_name=relationship_fk_column_name
             )
             split_table_response = {
                 'extracted_table': extracted_table.id,

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -198,6 +198,7 @@ class MoveTableRequestSerializer(MathesarErrorMessageMixin, serializers.Serializ
 class SplitTableRequestSerializer(MathesarErrorMessageMixin, serializers.Serializer):
     extract_columns = serializers.PrimaryKeyRelatedField(queryset=Column.current_objects.all(), many=True)
     extracted_table_name = serializers.CharField()
+    relationship_fk_column_name = serializers.CharField(allow_blank=False, allow_null=True, default=None)
 
 
 class SplitTableResponseSerializer(MathesarErrorMessageMixin, serializers.Serializer):

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -595,6 +595,7 @@ class Table(DatabaseObject, Relation):
             columns_to_extract,
             extracted_table_name,
             column_names_id_map,
+            relationship_fk_column_name
     ):
         # Collect various information about relevant columns before mutating
         columns_attnum_to_extract = [column.attnum for column in columns_to_extract]
@@ -607,7 +608,8 @@ class Table(DatabaseObject, Relation):
             columns_attnum_to_extract,
             extracted_table_name,
             self.schema.name,
-            self._sa_engine
+            self._sa_engine,
+            relationship_fk_column_name
         )
         engine = self._sa_engine
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1434 

Adds optional parameter `relationship_fk_column_name` which is used for setting the foreign key column created while splitting the table.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
