### PR TITLE
Add referent table ID to returned JSON for fkey deletion error

### DIFF
--- a/mathesar/api/exceptions/database_exceptions/exceptions.py
+++ b/mathesar/api/exceptions/database_exceptions/exceptions.py
@@ -323,6 +323,7 @@ class ForeignKeyViolationAPIException(MathesarAPIException):
                 "constraint": constraint.id,
                 "constraint_columns": [c.id for c in constraint.columns],
                 "constraint_referent_columns": [c.id for c in constraint.referent_columns],
+                "constraint_referent_table": constraint.referent_columns[0].table.id,
             })
         except Exception:
             warnings.warn("Could not enrich Exception")


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #1813 

<!-- Concisely describe what the pull request does. -->

This adds a `referent_table` field to the response as requested by @pavish in his review of #1849 

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

New response:

```json
[
  {
    "code": 4212,
    "message": "Key (id)=(6) is still referenced from table \"Checkouts\".",
    "field": null,
    "detail": {
      "constraint": 4,
      "constraint_columns": [
        6
      ],
      "constraint_referent_columns": [
        11
      ],
      "constraint_referent_table": 1
    }
  }
]
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
