### PR TITLE
use fresh metadata for enriching table columns

### DIFF
--- a/db/columns/utils.py
+++ b/db/columns/utils.py
@@ -31,7 +31,6 @@ def get_enriched_column_table(table, metadata, engine=None):
         metadata,
         *table_columns,
         schema=table.schema,
-        extend_existing=True,
     )
 
 

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -23,6 +23,7 @@ from db.constraints.operations.select import (
 )
 from db.constraints import utils as constraint_utils
 from db.dependents.dependents_utils import get_dependents_graph, has_dependents
+from db.metadata import get_empty_metadata
 from db.records.operations.delete import delete_record
 from db.records.operations.insert import insert_record_or_records
 from db.records.operations.select import get_column_cast_records, get_count, get_record
@@ -349,7 +350,7 @@ class Table(DatabaseObject, Relation):
         return column_utils.get_enriched_column_table(
             table=self._sa_table,
             engine=self._sa_engine,
-            metadata=get_cached_metadata(),
+            metadata=get_empty_metadata(),
         )
 
     @property


### PR DESCRIPTION
**DO NOT MERGE UNTIL AFTER #1864**

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1781  (as well as numerous tiny miscellaneous bugs)

<!-- Concisely describe what the pull request does. -->

We now use an empty metadata for adding tables with enriched columns.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

The problem was when other bits of the machine tried to use a `metadata` instance via `get_cached_metadata` where some tables had overridden columns with the enriched columns. By using a single, fresh `MetaData()` whenever getting an enriched column table, we avoid the problem, since we don't store the enriched-column table in the cache this way. This is cheap, since there's never a reflection needed on this metadata, so it's okay if it's discarded after use.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
