### PR TITLE
Change helpText from prop to slot in NameAndDescInputModalForm

### DIFF
--- a/mathesar_ui/src/component-library/alert/Alert.svelte
+++ b/mathesar_ui/src/component-library/alert/Alert.svelte
@@ -16,7 +16,7 @@
 
 <div class={classes}>
   <Icon {...icon} />
-  <span class="content">
-    <slot name="content" />
-  </span>
+  <div class="content">
+    <slot />
+  </div>
 </div>

--- a/mathesar_ui/src/components/NameAndDescInputModalForm.svelte
+++ b/mathesar_ui/src/components/NameAndDescInputModalForm.svelte
@@ -10,7 +10,6 @@
    */
   import { tick } from 'svelte';
   import {
-    Alert,
     LabeledInput,
     type ModalController,
   } from '@mathesar-component-library';

--- a/mathesar_ui/src/components/NameAndDescInputModalForm.svelte
+++ b/mathesar_ui/src/components/NameAndDescInputModalForm.svelte
@@ -21,7 +21,6 @@
   import { toast } from '@mathesar/stores/toast';
   import TextArea from '@mathesar/component-library/text-area/TextArea.svelte';
 
-  export let helpText = '';
   export let saveButtonLabel = 'Save';
   export let controller: ModalController;
   export let getNameValidationErrors: (name: string) => string[];

--- a/mathesar_ui/src/components/NameAndDescInputModalForm.svelte
+++ b/mathesar_ui/src/components/NameAndDescInputModalForm.svelte
@@ -75,11 +75,8 @@
   <slot slot="title" name="title" {initialName} />
 
   <div class="form-container">
-    {#if helpText}
-      <Alert appearance="info">
-        <slot slot="content">{helpText}</slot>
-      </Alert>
-    {/if}
+    <slot name="helpText" />
+
     <div class="input-container">
       <LabeledInput label="Name" layout="stacked">
         <TextInput

--- a/mathesar_ui/src/pages/database/AddEditSchemaModal.svelte
+++ b/mathesar_ui/src/pages/database/AddEditSchemaModal.svelte
@@ -14,7 +14,6 @@
   export let controller: ModalController;
   export let schema: SchemaEntry | undefined = undefined;
 
-
   function nameIsDuplicate(name: string) {
     // Handling the condition when the new name is equal to the current name
     // But the user has made sone key down events
@@ -59,13 +58,11 @@
 >
   <svelte:fragment slot="helpText">
     {#if !schema}
-      <Alert appearance="info">
-        <slot slot="content">
-          Name your schema to reflect its purpose. For example, your personal
-          financial schema may be called "Personal Finances" and your movie
-          collection "Movies." Add a description to your schema to remember what
-          it's for.
-        </slot>
+      <Alert>
+        Name your schema to reflect its purpose. For example, your personal
+        financial schema may be called "Personal Finances" and your movie
+        collection "Movies." Add a description to your schema to remember what
+        it's for.
       </Alert>
     {/if}
   </svelte:fragment>

--- a/mathesar_ui/src/pages/database/AddEditSchemaModal.svelte
+++ b/mathesar_ui/src/pages/database/AddEditSchemaModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ModalController } from '@mathesar-component-library';
+  import { Alert, ModalController } from '@mathesar-component-library';
   import type { Database, SchemaEntry } from '@mathesar/AppTypes';
   import {
     schemas,
@@ -14,8 +14,6 @@
   export let controller: ModalController;
   export let schema: SchemaEntry | undefined = undefined;
 
-  const createSchemaHelpText =
-    'Name your schema to reflect its purpose. For example, your personal financial schema may be called "Personal Finances" and your movie collection "Movies." Add a description to your schema to remember what it\'s for.';
 
   function nameIsDuplicate(name: string) {
     // Handling the condition when the new name is equal to the current name
@@ -58,8 +56,20 @@
   getInitialName={() => schema?.name ?? ''}
   getInitialDescription={() => schema?.description ?? ''}
   saveButtonLabel={schema ? 'Save' : 'Create New Schema'}
-  helpText={schema ? '' : createSchemaHelpText}
 >
+  <svelte:fragment slot="helpText">
+    {#if !schema}
+      <Alert appearance="info">
+        <slot slot="content">
+          Name your schema to reflect its purpose. For example, your personal
+          financial schema may be called "Personal Finances" and your movie
+          collection "Movies." Add a description to your schema to remember what
+          it's for.
+        </slot>
+      </Alert>
+    {/if}
+  </svelte:fragment>
+
   <span slot="title" let:initialName>
     {#if schema}
       Rename <Identifier>{initialName}</Identifier> Schema

--- a/mathesar_ui/src/pages/database/SchemaRow.svelte
+++ b/mathesar_ui/src/pages/database/SchemaRow.svelte
@@ -60,11 +60,9 @@
     <SchemaConstituentCounts {schema} />
 
     {#if isDefault}
-      <Alert appearance="info">
-        <slot slot="content">
-          Every PostgreSQL database includes the "public" schema. This protected
-          schema can be read by anybody who accesses the database.
-        </slot>
+      <Alert>
+        Every PostgreSQL database includes the "public" schema. This protected
+        schema can be read by anybody who accesses the database.
       </Alert>
     {/if}
   </div>


### PR DESCRIPTION
Fixes #1858 

This PR chnages helpText from prop to named slot in NameAndDescInputModalForm. It also modifies AddEditSchemaModal to pass the helpText as a named slot to NameAndDescInputModalForm instead of a prop.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
