### PR TITLE
Atleast one cell always selected when user is on the table page

### DIFF
--- a/mathesar_ui/src/components/sheet/SheetSelection.ts
+++ b/mathesar_ui/src/components/sheet/SheetSelection.ts
@@ -303,6 +303,15 @@ export default class SheetSelection<
     }
   }
 
+  selectAndActivateFirstCellIfExists(): void {
+    const firstRow = this.getRows()[0];
+    const firstColumn = this.getColumns()[0];
+    if (firstRow && firstColumn) {
+      this.selectMultipleCells([[firstRow, firstColumn]]);
+      this.activateCell(firstRow, firstColumn);
+    }
+  }
+
   getIncludedCells(selectionBounds: SelectionBounds): Cell<Row, Column>[] {
     const { startRowIndex, endRowIndex, startColumnIndex, endColumnIndex } =
       selectionBounds;
@@ -428,6 +437,14 @@ export default class SheetSelection<
       rowIndex: row.rowIndex,
       columnId: column.id,
     });
+  }
+
+  focusCell(row: Pick<Row, 'rowIndex'>, column: Pick<Column, 'id'>): void {
+    const cellsInTheColumn = document.querySelectorAll(
+      `[data-column-identifier="${column.id}"]`,
+    );
+    const targetCell = cellsInTheColumn.item(row.rowIndex);
+    (targetCell?.querySelector('.cell-wrapper') as HTMLElement)?.focus();
   }
 
   private getAdjacentCell(

--- a/mathesar_ui/src/systems/table-view/Body.svelte
+++ b/mathesar_ui/src/systems/table-view/Body.svelte
@@ -45,39 +45,9 @@
     const record = allRecords?.[index];
     return record ? getItemSizeFromRow(record) : rowHeightPx;
   }
-
-  function checkAndResetActiveCell(e: Event) {
-    const target = e.target as HTMLElement;
-    const targetMissing = !document.body.contains(target);
-    let clearActiveCell = false;
-
-    if (targetMissing) {
-      const focusedElementNotWithinEditableCell =
-        !document.activeElement ||
-        (!document.activeElement.closest('.editable-cell') &&
-          !document.activeElement.closest('.retain-active-cell'));
-      clearActiveCell = focusedElementNotWithinEditableCell;
-    } else {
-      const targetNotWithinEditableCell =
-        !target.closest('.editable-cell') &&
-        !target.closest('.retain-active-cell');
-      const targetNotWithinTableInspector = !target.closest(
-        '.table-inspector-container',
-      );
-      clearActiveCell =
-        targetNotWithinEditableCell && targetNotWithinTableInspector;
-    }
-
-    if (clearActiveCell) {
-      selection.resetActiveCell();
-    }
-  }
 </script>
 
-<svelte:window
-  on:keydown={checkAndResetActiveCell}
-  on:mousedown={checkAndResetActiveCell}
-/>
+<svelte:window />
 
 {#key id}
   {#if usesVirtualList}


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->

Fixes #1717 
Fixes #1750 
Fixes #1873 

<!-- Concisely describe what the pull request does. -->

**Technical details**
This PR does 3 things
1. As soon as the table page is loaded, the top left cell is auto-selected and activated
2. When the user is on the table page, no matter where he clicks the selection/activated cell state is persisted.
3. Whenever the user clicks on the white area of the `TableView` component, the active cells re-instated focus.

**Screenshots**
https://www.loom.com/share/ff23cab0f5504fe9bd762bec53c8c2ae

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
