### PR TITLE
Fix bug in query parameter loading

### DIFF
--- a/mathesar/api/db/viewsets/queries.py
+++ b/mathesar/api/db/viewsets/queries.py
@@ -109,12 +109,19 @@ class QueryViewSet(
         columns = query.output_columns_simple
         column_metadata = query.all_columns_description_map
         output_serializer = BaseQuerySerializer(query)
+
+        def _get_param_val(val):
+            try:
+                ret_val = json.loads(val)
+            except json.JSONDecodeError:
+                ret_val = val
+            return ret_val
         return Response(
             {
                 "query": output_serializer.data,
                 "records": paginated_records.data,
                 "output_columns": columns,
                 "column_metadata": column_metadata,
-                "parameters": {k: json.loads(request.GET[k]) for k in request.GET},
+                "parameters": {k: _get_param_val(request.GET[k]) for k in request.GET},
             }
         )


### PR DESCRIPTION
<!-- Concisely describe what the pull request does. -->

The recent live demo work exposed a latent bug wherein the `/queries/run/` endpoint would try to load a raw string (i.e., not wrapped in double-quotes) as JSON, and fail.

This PR tries to load as JSON, then falls back to primitive types when that doesn't work.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
