### PR TITLE
Capture `DeletedColumnAccess` exception when processing transformation

### DIFF
--- a/mathesar/api/db/viewsets/queries.py
+++ b/mathesar/api/db/viewsets/queries.py
@@ -94,11 +94,12 @@ class QueryViewSet(
         input_serializer = BaseQuerySerializer(data=request.data)
         input_serializer.is_valid(raise_exception=True)
         query = UIQuery(**input_serializer.validated_data)
-        query.replace_transformations_with_processed_transformations()
-        record_serializer = RecordListParameterSerializer(data=request.GET)
-        record_serializer.is_valid(raise_exception=True)
-        output_serializer = BaseQuerySerializer(query)
         try:
+            # TODO Consider treating the transformation as immutable
+            query.replace_transformations_with_processed_transformations()
+            record_serializer = RecordListParameterSerializer(data=request.GET)
+            record_serializer.is_valid(raise_exception=True)
+            output_serializer = BaseQuerySerializer(query)
             records = paginator.paginate_queryset(
                 queryset=self.get_queryset(),
                 request=request,
@@ -111,6 +112,7 @@ class QueryViewSet(
             )
             paginated_records = paginator.get_paginated_response(records)
         except DeletedColumnAccess as e:
+            output_serializer = BaseQuerySerializer(query)
             raise DeletedColumnAccessAPIException(e, query=output_serializer.data)
         columns = query.output_columns_simple
         column_metadata = query.all_columns_description_map


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes the failing test in https://github.com/centerofci/mathesar/actions/runs/3516417880/jobs/5892951882 

Exceptions were not correctly captured because the code block causing the exception was not within the `try` block which should be fixed by this PR

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
