### PR TITLE
Add `remove` transform for hiding columns

### DIFF
--- a/db/tests/records/operations/test_select.py
+++ b/db/tests/records/operations/test_select.py
@@ -1,13 +1,9 @@
-import pytest
-
 from decimal import Decimal
 from collections import Counter
 
 from sqlalchemy import Column, VARCHAR
 
 from db.records.operations.select import get_records, get_column_cast_records
-from db.transforms.operations.apply import apply_transformations
-from db.transforms import base as transforms_base
 from db.tables.operations.create import create_mathesar_table
 from db.types.base import PostgresType
 
@@ -108,75 +104,3 @@ def test_get_records_duplicate_only(roster_table_obj):
     all_counter = {k: v for k, v in all_counter.items() if v > 1}
     got_counter = Counter(tuple(r[c] for c in duplicate_only) for r in dupe_record_list)
     assert all_counter == got_counter
-
-
-# TODO might want to move this to transforms test namespace
-@pytest.mark.parametrize(
-    "transformations,expected_records",
-    [
-        [
-            [
-                transforms_base.Filter(
-                    spec=dict(
-                        contains=[
-                            dict(column_name=["Student Name"]),
-                            dict(literal=["son"]),
-                        ]
-                    ),
-                ),
-                transforms_base.Order(
-                    spec=[{"field": "Teacher Email", "direction": "asc"}],
-                ),
-                transforms_base.Limit(
-                    spec=5,
-                ),
-                transforms_base.SelectSubsetOfColumns(
-                    spec=["id"],
-                ),
-            ],
-            [
-                (978,),
-                (194,),
-                (99,),
-                (155,),
-                (192,),
-            ]
-        ],
-        [
-            [
-                transforms_base.Limit(
-                    spec=50,
-                ),
-                transforms_base.Filter(
-                    spec=dict(
-                        contains=[
-                            dict(column_name=["Student Name"]),
-                            dict(literal=["son"]),
-                        ]
-                    ),
-                ),
-                transforms_base.Order(
-                    spec=[{"field": "Teacher Email", "direction": "asc"}],
-                ),
-                transforms_base.Limit(
-                    spec=5,
-                ),
-                transforms_base.SelectSubsetOfColumns(
-                    spec=["id"],
-                ),
-            ],
-            [
-                (31,),
-                (16,),
-                (18,),
-                (24,),
-                (33,),
-            ]
-        ],
-    ]
-)
-def test_transformations(roster_table_obj, transformations, expected_records):
-    roster, engine = roster_table_obj
-    relation = apply_transformations(roster, transformations)
-    records = get_records(relation, engine)
-    assert records == expected_records

--- a/db/tests/transforms/test_basic.py
+++ b/db/tests/transforms/test_basic.py
@@ -75,7 +75,7 @@ from db.records.operations.select import get_records
                 transforms_base.SelectSubsetOfColumns(
                     spec=["id", "Grade"],
                 ),
-                transforms_base.RemoveColumns(
+                transforms_base.HideColumns(
                     spec=["Grade"],
                 ),
             ],

--- a/db/tests/transforms/test_basic.py
+++ b/db/tests/transforms/test_basic.py
@@ -1,0 +1,92 @@
+import pytest
+
+from db.transforms.operations.apply import apply_transformations
+from db.transforms import base as transforms_base
+from db.records.operations.select import get_records
+
+
+@pytest.mark.parametrize(
+    "transformations,expected_records",
+    [
+        [
+            [
+                transforms_base.Filter(
+                    spec=dict(
+                        contains=[
+                            dict(column_name=["Student Name"]),
+                            dict(literal=["son"]),
+                        ]
+                    ),
+                ),
+                transforms_base.Order(
+                    spec=[{"field": "Teacher Email", "direction": "asc"}],
+                ),
+                transforms_base.Limit(
+                    spec=5,
+                ),
+                transforms_base.SelectSubsetOfColumns(
+                    spec=["id"],
+                ),
+            ],
+            [
+                (978,),
+                (194,),
+                (99,),
+                (155,),
+                (192,),
+            ]
+        ],
+        [
+            [
+                transforms_base.Limit(
+                    spec=50,
+                ),
+                transforms_base.Filter(
+                    spec=dict(
+                        contains=[
+                            dict(column_name=["Student Name"]),
+                            dict(literal=["son"]),
+                        ]
+                    ),
+                ),
+                transforms_base.Order(
+                    spec=[{"field": "Teacher Email", "direction": "asc"}],
+                ),
+                transforms_base.Limit(
+                    spec=5,
+                ),
+                transforms_base.SelectSubsetOfColumns(
+                    spec=["id"],
+                ),
+            ],
+            [
+                (31,),
+                (16,),
+                (18,),
+                (24,),
+                (33,),
+            ]
+        ],
+        [
+            [
+                transforms_base.Limit(
+                    spec=1,
+                ),
+                transforms_base.SelectSubsetOfColumns(
+                    spec=["id", "Grade"],
+                ),
+                transforms_base.RemoveColumns(
+                    spec=["Grade"],
+                ),
+            ],
+            [
+                (1,),
+            ]
+        ],
+    ]
+)
+def test_transformations(roster_table_obj, transformations, expected_records):
+    roster, engine = roster_table_obj
+    relation = apply_transformations(roster, transformations)
+    records = get_records(relation, engine)
+    assert records == expected_records

--- a/db/transforms/base.py
+++ b/db/transforms/base.py
@@ -390,6 +390,49 @@ def _add_aliases_to_summarization_expr_field(
     return summarization
 
 
+class RemoveColumns(Transform):
+    """
+    We're implementing this transform in terms of selecting columns (since Postgres doesn't really
+    support "selecting everything except").
+    """
+    type = "remove"
+
+    def apply_to_relation(self, relation):
+        input_aliases = [
+            col.name
+            for col
+            in relation.c
+        ]
+        columns_to_select = self.get_columns_to_select(input_aliases)
+        select_transform = SelectSubsetOfColumns(columns_to_select)
+        relation = select_transform.apply_to_relation(relation)
+        breakpoint()
+        return relation
+
+    def get_unique_constraint_mappings(self, input_aliases):
+        columns_to_select = self.get_columns_to_select(input_aliases)
+        return [
+            UniqueConstraintMapping(
+                column_to_select,
+                column_to_select,
+            )
+            for column_to_select
+            in columns_to_select
+        ]
+
+    def get_columns_to_select(self, input_aliases):
+        return [
+            column
+            for column
+            in input_aliases
+            if column not in self._columns_to_remove
+        ]
+
+    @property
+    def _columns_to_remove(self):
+        return self.spec
+
+
 class SelectSubsetOfColumns(Transform):
     type = "select"
 

--- a/db/transforms/base.py
+++ b/db/transforms/base.py
@@ -406,7 +406,6 @@ class RemoveColumns(Transform):
         columns_to_select = self.get_columns_to_select(input_aliases)
         select_transform = SelectSubsetOfColumns(columns_to_select)
         relation = select_transform.apply_to_relation(relation)
-        breakpoint()
         return relation
 
     def get_unique_constraint_mappings(self, input_aliases):

--- a/db/transforms/base.py
+++ b/db/transforms/base.py
@@ -390,12 +390,14 @@ def _add_aliases_to_summarization_expr_field(
     return summarization
 
 
-class RemoveColumns(Transform):
+class HideColumns(Transform):
     """
+    Selects every column in the transform, except for the columns specified in the spec.
+
     We're implementing this transform in terms of selecting columns (since Postgres doesn't really
     support "selecting everything except").
     """
-    type = "remove"
+    type = "hide"
 
     def apply_to_relation(self, relation):
         input_aliases = [
@@ -424,11 +426,11 @@ class RemoveColumns(Transform):
             column
             for column
             in input_aliases
-            if column not in self._columns_to_remove
+            if column not in self._columns_to_hide
         ]
 
     @property
-    def _columns_to_remove(self):
+    def _columns_to_hide(self):
         return self.spec
 
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #1867

The new transform's id is `remove` and it takes a list of aliases, in the same vein as the existing `select` transform.

Note, I moved a test function to a different file, and then added a test case to it. Sorry for the diff noise.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
