### PR TITLE
Fix DE bug while calculating links for tables with multiple columns linking to the same target table

### DIFF
--- a/mathesar_ui/src/api/tables.ts
+++ b/mathesar_ui/src/api/tables.ts
@@ -24,7 +24,7 @@ export interface TableEntry {
   id: number;
   name: string;
   schema: number;
-  import_verified: boolean;
+  import_verified: boolean | null;
   data_files?: number[];
   columns: MinimalColumnDetails[];
   settings: TableSettings;

--- a/mathesar_ui/src/systems/data-explorer/QueryManager.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryManager.ts
@@ -72,7 +72,7 @@ export default class QueryManager extends QueryRunner<{ save: QueryInstance }> {
 
   inputColumns: Writable<InputColumnsStoreSubstance> = writable({
     baseTableColumns: new Map(),
-    tablesThatReferenceBaseTable: new Map(),
+    tablesThatReferenceBaseTable: [],
     inputColumnInformationMap: new Map(),
   });
 
@@ -109,7 +109,7 @@ export default class QueryManager extends QueryRunner<{ save: QueryInstance }> {
     if (!baseTableId) {
       this.inputColumns.set({
         baseTableColumns: new Map(),
-        tablesThatReferenceBaseTable: new Map(),
+        tablesThatReferenceBaseTable: [],
         inputColumnInformationMap: new Map(),
       });
       this.state.update((state) => ({

--- a/mathesar_ui/src/systems/data-explorer/__tests__/mockData.ts
+++ b/mathesar_ui/src/systems/data-explorer/__tests__/mockData.ts
@@ -1,0 +1,510 @@
+import type { JoinableTablesResult } from '@mathesar/api/tables/joinable_tables';
+
+export const ItemsTableId = 75;
+export const CheckoutsPkColumnId = 216;
+export const ItemsPkColumnId = 221;
+
+export const checkoutsJoinableTables: JoinableTablesResult = {
+  joinable_tables: [
+    {
+      target: ItemsTableId,
+      jp_path: [[CheckoutsPkColumnId, ItemsPkColumnId]],
+      fk_path: [[188, false]],
+      depth: 1,
+      multiple_results: false,
+    },
+    {
+      target: 72,
+      jp_path: [[217, 228]],
+      fk_path: [[189, false]],
+      depth: 1,
+      multiple_results: false,
+    },
+    {
+      target: 78,
+      jp_path: [
+        [CheckoutsPkColumnId, ItemsPkColumnId],
+        [222, 229],
+      ],
+      fk_path: [
+        [188, false],
+        [192, false],
+      ],
+      depth: 2,
+      multiple_results: false,
+    },
+    {
+      target: 74,
+      jp_path: [
+        [CheckoutsPkColumnId, ItemsPkColumnId],
+        [222, 229],
+        [231, 235],
+      ],
+      fk_path: [
+        [188, false],
+        [192, false],
+        [196, false],
+      ],
+      depth: 3,
+      multiple_results: false,
+    },
+    {
+      target: 77,
+      jp_path: [
+        [CheckoutsPkColumnId, ItemsPkColumnId],
+        [222, 229],
+        [232, 211],
+      ],
+      fk_path: [
+        [188, false],
+        [192, false],
+        [195, false],
+      ],
+      depth: 3,
+      multiple_results: false,
+    },
+  ],
+  tables: {
+    [ItemsTableId]: {
+      name: 'Items',
+      columns: [ItemsPkColumnId, 222],
+    },
+    72: { name: 'Patrons', columns: [228] },
+    78: { name: 'Publications', columns: [229, 231, 232] },
+    74: { name: 'Publishers', columns: [235] },
+    77: { name: 'Authors', columns: [211] },
+  },
+  columns: {
+    [ItemsPkColumnId]: { name: 'id', type: 'integer' },
+    222: { name: 'Publication', type: 'integer' },
+    228: { name: 'id', type: 'integer' },
+    229: { name: 'id', type: 'integer' },
+    231: { name: 'Publisher', type: 'integer' },
+    232: { name: 'Author', type: 'integer' },
+    235: { name: 'id', type: 'integer' },
+    211: { name: 'id', type: 'integer' },
+  },
+};
+
+export const checkoutsLinkTreeFromItems = {
+  id: ItemsTableId,
+  linkedToColumn: {
+    id: ItemsPkColumnId,
+    name: 'id',
+  },
+  name: 'Items',
+  columns: new Map([
+    [
+      ItemsPkColumnId,
+      expect.objectContaining({
+        id: ItemsPkColumnId,
+        jpPath: [[216, 221]],
+        linksTo: undefined,
+        name: 'id',
+      }),
+    ],
+    [
+      222,
+      expect.objectContaining({
+        id: 222,
+        jpPath: [[216, 221]],
+        linksTo: {
+          id: 78,
+          name: 'Publications',
+          linkedToColumn: { id: 229, name: 'id' },
+          columns: new Map([
+            [
+              229,
+              expect.objectContaining({
+                id: 228,
+                name: 'id',
+                jpPath: [
+                  [216, 221],
+                  [222, 229],
+                ],
+              }),
+            ],
+            [
+              231,
+              expect.objectContaining({
+                id: 231,
+                name: 'Publisher',
+                jpPath: [
+                  [216, 221],
+                  [222, 229],
+                ],
+                linksTo: {
+                  id: 74,
+                  name: 'Publishers',
+                  linkedToColumn: {
+                    id: 235,
+                    name: 'id',
+                  },
+                  columns: new Map([
+                    [
+                      235,
+                      expect.objectContaining({
+                        id: 235,
+                        name: 'id',
+                        jpPath: [
+                          [216, 221],
+                          [222, 229],
+                          [231, 235],
+                        ],
+                        linksTo: undefined,
+                      }),
+                    ],
+                  ]),
+                },
+              }),
+            ],
+            [
+              232,
+              expect.objectContaining({
+                id: 232,
+                name: 'Author',
+                jpPath: [
+                  [216, 221],
+                  [222, 229],
+                ],
+                linksTo: new Map([
+                  [
+                    77,
+                    expect.objectContaining({
+                      id: 77,
+                      name: 'Authors',
+                      linkedToColumn: { id: 211, name: 'id' },
+                      columns: new Map([[211, { id: 221, name: 'id' }]]),
+                    }),
+                  ],
+                ]),
+              }),
+            ],
+          ]),
+        },
+        name: 'Publication',
+      }),
+    ],
+  ]),
+};
+
+export const SelfRefTableId = 1158;
+export const SelfRefTablePkColumnId = 4898;
+export const SelfRefTableFkColumnId = 5355;
+
+export const selfRefTableJoinableTables: JoinableTablesResult = {
+  joinable_tables: [
+    {
+      target: SelfRefTableId,
+      jp_path: [[SelfRefTableFkColumnId, SelfRefTablePkColumnId]],
+      fk_path: [[2529, false]],
+      depth: 1,
+      multiple_results: false,
+    },
+    {
+      target: SelfRefTableId,
+      jp_path: [[SelfRefTablePkColumnId, SelfRefTableFkColumnId]],
+      fk_path: [[2529, true]],
+      depth: 1,
+      multiple_results: true,
+    },
+    {
+      target: SelfRefTableId,
+      jp_path: [
+        [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+        [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+      ],
+      fk_path: [
+        [2529, false],
+        [2529, false],
+      ],
+      depth: 2,
+      multiple_results: false,
+    },
+    {
+      target: SelfRefTableId,
+      jp_path: [
+        [SelfRefTablePkColumnId, SelfRefTableFkColumnId],
+        [SelfRefTablePkColumnId, SelfRefTableFkColumnId],
+      ],
+      fk_path: [
+        [2529, true],
+        [2529, true],
+      ],
+      depth: 2,
+      multiple_results: true,
+    },
+    {
+      target: SelfRefTableId,
+      jp_path: [
+        [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+        [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+        [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+      ],
+      fk_path: [
+        [2529, false],
+        [2529, false],
+        [2529, false],
+      ],
+      depth: 3,
+      multiple_results: false,
+    },
+    {
+      target: SelfRefTableId,
+      jp_path: [
+        [SelfRefTablePkColumnId, SelfRefTableFkColumnId],
+        [SelfRefTablePkColumnId, SelfRefTableFkColumnId],
+        [SelfRefTablePkColumnId, SelfRefTableFkColumnId],
+      ],
+      fk_path: [
+        [2529, true],
+        [2529, true],
+        [2529, true],
+      ],
+      depth: 3,
+      multiple_results: true,
+    },
+  ],
+  tables: {
+    [SelfRefTableId]: {
+      name: 'Self Referential Table',
+      columns: [SelfRefTablePkColumnId, SelfRefTableFkColumnId],
+    },
+  },
+  columns: {
+    [SelfRefTablePkColumnId]: { name: 'id', type: 'integer' },
+    [SelfRefTableFkColumnId]: { name: 'Self Referential Row', type: 'integer' },
+  },
+};
+
+export const selfRefTableLinkTree = {
+  id: SelfRefTableId,
+  name: 'Self Referential Table',
+  linkedToColumn: {
+    id: SelfRefTablePkColumnId,
+    name: 'id',
+  },
+  columns: new Map([
+    [
+      SelfRefTablePkColumnId,
+      expect.objectContaining({
+        id: SelfRefTablePkColumnId,
+        jpPath: [[SelfRefTableFkColumnId, SelfRefTablePkColumnId]],
+        linksTo: undefined,
+        name: 'id',
+      }),
+    ],
+    [
+      SelfRefTableFkColumnId,
+      expect.objectContaining({
+        id: SelfRefTableFkColumnId,
+        jpPath: [[SelfRefTableFkColumnId, SelfRefTablePkColumnId]],
+        linksTo: {
+          id: SelfRefTableId,
+          name: 'Self Referential Table',
+          linkedToColumn: { id: SelfRefTablePkColumnId, name: 'id' },
+          columns: new Map([
+            [
+              SelfRefTablePkColumnId,
+              expect.objectContaining({
+                id: SelfRefTablePkColumnId,
+                jpPath: [
+                  [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                  [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                ],
+                linksTo: undefined,
+              }),
+            ],
+            [
+              SelfRefTableFkColumnId,
+              expect.objectContaining({
+                id: SelfRefTableFkColumnId,
+                jpPath: [
+                  [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                  [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                ],
+                linksTo: {
+                  id: SelfRefTableId,
+                  linkedToColumn: {
+                    id: SelfRefTablePkColumnId,
+                    name: 'id',
+                  },
+                  columns: new Map([
+                    [
+                      SelfRefTablePkColumnId,
+                      expect.objectContaining({
+                        id: SelfRefTablePkColumnId,
+                        jpPath: [
+                          [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                          [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                          [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                        ],
+                        linksTo: undefined,
+                        name: 'id',
+                      }),
+                    ],
+                    [
+                      SelfRefTableFkColumnId,
+                      expect.objectContaining({
+                        id: SelfRefTableFkColumnId,
+                        jpPath: [
+                          [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                          [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                          [SelfRefTableFkColumnId, SelfRefTablePkColumnId],
+                        ],
+                        linksTo: undefined,
+                        name: 'Self Referential Row',
+                      }),
+                    ],
+                  ]),
+                },
+              }),
+            ],
+          ]),
+        },
+        name: 'Self Referential Row',
+      }),
+    ],
+  ]),
+};
+
+export const personTableId = 1332;
+export const groupTablePerson1ColumnId = 5831;
+export const groupTablePerson2ColumnId = 5914;
+export const personTablePkColumnId = 5570;
+export const groupTable: JoinableTablesResult = {
+  joinable_tables: [
+    {
+      target: personTableId,
+      jp_path: [[groupTablePerson1ColumnId, personTablePkColumnId]],
+      fk_path: [[2765, false]],
+      depth: 1,
+      multiple_results: false,
+    },
+    {
+      target: personTableId,
+      jp_path: [[groupTablePerson2ColumnId, personTablePkColumnId]],
+      fk_path: [[2801, false]],
+      depth: 1,
+      multiple_results: false,
+    },
+    {
+      target: 1295,
+      jp_path: [
+        [groupTablePerson1ColumnId, personTablePkColumnId],
+        [personTablePkColumnId, groupTablePerson2ColumnId],
+      ],
+      fk_path: [
+        [2765, false],
+        [2801, true],
+      ],
+      depth: 2,
+      multiple_results: true,
+    },
+    {
+      target: 1295,
+      jp_path: [
+        [groupTablePerson2ColumnId, personTablePkColumnId],
+        [personTablePkColumnId, groupTablePerson1ColumnId],
+      ],
+      fk_path: [
+        [2801, false],
+        [2765, true],
+      ],
+      depth: 2,
+      multiple_results: true,
+    },
+    {
+      target: personTableId,
+      jp_path: [
+        [groupTablePerson1ColumnId, personTablePkColumnId],
+        [personTablePkColumnId, groupTablePerson2ColumnId],
+        [groupTablePerson1ColumnId, personTablePkColumnId],
+      ],
+      fk_path: [
+        [2765, false],
+        [2801, true],
+        [2765, false],
+      ],
+      depth: 3,
+      multiple_results: true,
+    },
+    {
+      target: personTableId,
+      jp_path: [
+        [groupTablePerson2ColumnId, personTablePkColumnId],
+        [personTablePkColumnId, groupTablePerson1ColumnId],
+        [groupTablePerson2ColumnId, personTablePkColumnId],
+      ],
+      fk_path: [
+        [2801, false],
+        [2765, true],
+        [2801, false],
+      ],
+      depth: 3,
+      multiple_results: true,
+    },
+  ],
+  tables: {
+    [personTableId]: { name: 'Person', columns: [personTablePkColumnId, 5781] },
+    1295: {
+      name: 'Group',
+      columns: [5431, groupTablePerson1ColumnId, groupTablePerson2ColumnId],
+    },
+  },
+  columns: {
+    [personTablePkColumnId]: { name: 'id', type: 'integer' },
+    5781: { name: 'name', type: 'text' },
+    5431: { name: 'id', type: 'integer' },
+    [groupTablePerson1ColumnId]: { name: 'Person1', type: 'integer' },
+    [groupTablePerson2ColumnId]: { name: 'Person2', type: 'integer' },
+  },
+};
+
+export const groupTableLinkTreeFromPerson1 = {
+  id: personTableId,
+  name: 'Person',
+  linkedToColumn: {
+    id: personTablePkColumnId,
+    name: 'id',
+  },
+  columns: new Map([
+    [
+      personTablePkColumnId,
+      expect.objectContaining({
+        id: personTablePkColumnId,
+        jpPath: [[groupTablePerson1ColumnId, personTablePkColumnId]],
+      }),
+    ],
+    [
+      5781,
+      expect.objectContaining({
+        id: 5781,
+      }),
+    ],
+  ]),
+};
+
+export const groupTableLinkTreeFromPerson2 = {
+  id: personTableId,
+  name: 'Person',
+  linkedToColumn: {
+    id: personTablePkColumnId,
+    name: 'id',
+  },
+  columns: new Map([
+    [
+      personTablePkColumnId,
+      expect.objectContaining({
+        id: personTablePkColumnId,
+        jpPath: [[groupTablePerson2ColumnId, personTablePkColumnId]],
+      }),
+    ],
+    [
+      5781,
+      expect.objectContaining({
+        id: 5781,
+      }),
+    ],
+  ]),
+};

--- a/mathesar_ui/src/systems/data-explorer/__tests__/utils.test.ts
+++ b/mathesar_ui/src/systems/data-explorer/__tests__/utils.test.ts
@@ -1,0 +1,50 @@
+import {
+  checkoutsJoinableTables,
+  CheckoutsPkColumnId,
+  checkoutsLinkTreeFromItems,
+  selfRefTableJoinableTables,
+  SelfRefTableFkColumnId,
+  selfRefTableLinkTree,
+  groupTable,
+  groupTablePerson1ColumnId,
+  groupTablePerson2ColumnId,
+  groupTableLinkTreeFromPerson1,
+  groupTableLinkTreeFromPerson2,
+} from './mockData';
+import { getLinkFromColumn } from '../utils';
+
+describe('Test getLinkFromColumn', () => {
+  test('should generate tree with forward links', () => {
+    const forwardLinksFromItem = getLinkFromColumn(
+      checkoutsJoinableTables,
+      CheckoutsPkColumnId,
+      1,
+    );
+    expect(forwardLinksFromItem).toEqual(checkoutsLinkTreeFromItems);
+  });
+
+  test('should include self referential links', () => {
+    const forwardLinks = getLinkFromColumn(
+      selfRefTableJoinableTables,
+      SelfRefTableFkColumnId,
+      1,
+    );
+    expect(forwardLinks).toEqual(selfRefTableLinkTree);
+  });
+
+  test('should generate tree when there are multiple columns linking to the same table', () => {
+    const forwardLinksFromFk1 = getLinkFromColumn(
+      groupTable,
+      groupTablePerson1ColumnId,
+      1,
+    );
+    const forwardLinksFromFk2 = getLinkFromColumn(
+      groupTable,
+      groupTablePerson2ColumnId,
+      1,
+    );
+    expect(forwardLinksFromFk1).toEqual(groupTableLinkTreeFromPerson1);
+
+    expect(forwardLinksFromFk2).toEqual(groupTableLinkTreeFromPerson2);
+  });
+});

--- a/mathesar_ui/src/systems/data-explorer/input-sidebar/InputSidebar.svelte
+++ b/mathesar_ui/src/systems/data-explorer/input-sidebar/InputSidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TabContainer, Spinner } from '@mathesar-component-library';
+  import { TabContainer, Spinner, Alert } from '@mathesar-component-library';
   import { getAvailableName } from '@mathesar/utils/db';
   import ColumnSelectionPane from './column-selection-pane/ColumnSelectionPane.svelte';
   import TransformationsPane from './transformations-pane/TransformationsPane.svelte';
@@ -64,7 +64,11 @@
           <TransformationsPane {queryManager} />
         {/if}
       {:else if inputColumnsFetchState?.state === 'failure'}
-        Failed to fetch column information
+        <Alert appearance="error">
+          Failed to fetch column information: {inputColumnsFetchState?.errors.join(
+            ';',
+          )}
+        </Alert>
       {/if}
     </TabContainer>
   </section>

--- a/mathesar_ui/src/systems/data-explorer/input-sidebar/column-selection-pane/ColumnSelectionPane.svelte
+++ b/mathesar_ui/src/systems/data-explorer/input-sidebar/column-selection-pane/ColumnSelectionPane.svelte
@@ -15,7 +15,7 @@
   $: hasLinksFromBaseTable = [...baseTableColumns].some(
     ([, entry]) => entry.linksTo !== undefined,
   );
-  $: hasLinksToBaseTable = tablesThatReferenceBaseTable.size > 0;
+  $: hasLinksToBaseTable = tablesThatReferenceBaseTable.length > 0;
 </script>
 
 <div data-identifier="column-selection-list">
@@ -56,7 +56,8 @@
         <header>Linked to Base table</header>
         <div class="content" data-identifier="referenced-by-tables">
           {#if hasInitialColumns}
-            {#each [...tablesThatReferenceBaseTable] as [tableId, table] (tableId)}
+            <!--table.id is not unique here. Same table can be present multiple times-->
+            {#each tablesThatReferenceBaseTable as table (table)}
               <TableGroupCollapsible
                 tableName={table.name}
                 column={table.referencedViaColumn}

--- a/mathesar_ui/src/systems/data-explorer/utils.ts
+++ b/mathesar_ui/src/systems/data-explorer/utils.ts
@@ -93,7 +93,7 @@ export interface ReferencedByTable extends LinkedTable {
 
 export interface InputColumnsStoreSubstance {
   baseTableColumns: Map<ColumnWithLink['id'], ColumnWithLink>;
-  tablesThatReferenceBaseTable: Map<ReferencedByTable['id'], ReferencedByTable>;
+  tablesThatReferenceBaseTable: ReferencedByTable[];
   inputColumnInformationMap: Map<InputColumn['id'], InputColumn>;
 }
 
@@ -124,10 +124,6 @@ export function getLinkFromColumn(
   );
   if (validLinks.length === 0) {
     return undefined;
-  }
-  if (validLinks.length > 1) {
-    // This scenario should never occur
-    throw new Error(`Multiple links present for the same column: ${columnId}`);
   }
   const link = validLinks[0];
   const toTableInfo = result.tables[link.target];
@@ -215,11 +211,11 @@ export function getBaseTableColumnsWithLinks(
 export function getTablesThatReferenceBaseTable(
   result: JoinableTablesResult,
   baseTable: TableEntry,
-): Map<ReferencedByTable['id'], ReferencedByTable> {
+): ReferencedByTable[] {
   const referenceLinks = result.joinable_tables.filter(
     (entry) => entry.depth === 1 && entry.fk_path[0][1] === true,
   );
-  const references: Map<ReferencedByTable['id'], ReferencedByTable> = new Map();
+  const references: ReferencedByTable[] = [];
 
   referenceLinks.forEach((reference) => {
     const tableId = reference.target;
@@ -250,7 +246,7 @@ export function getTablesThatReferenceBaseTable(
           ];
         });
 
-    references.set(tableId, {
+    references.push({
       id: tableId,
       name: table.name,
       referencedViaColumn: {


### PR DESCRIPTION
Fixes #1981 

The link calculation logic previously did not consider the entire tree path and only took the depth into account. This PR fixes that.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
