### PR TITLE
Make users change their password on their first login

### DIFF
--- a/mathesar/api/ui/serializers/users.py
+++ b/mathesar/api/ui/serializers/users.py
@@ -51,6 +51,7 @@ class UserSerializer(MathesarErrorMessageMixin, FieldAccessMixin, serializers.Mo
     def create(self, validated_data):
         password = validated_data.pop('password')
         user = User(**validated_data)
+        user.password_change_needed = True
         user.set_password(password)
         user.save()
         return user

--- a/mathesar/tests/api/test_user_api.py
+++ b/mathesar/tests/api/test_user_api.py
@@ -136,9 +136,10 @@ def test_user_create(client):
     assert 'password' not in response_data
     assert response_data['short_name'] == data['short_name']
     assert response_data['full_name'] == data['full_name']
-
+    created_user = User.objects.get(id=response_data['id'])
+    assert created_user.password_change_needed is True
     # clean up
-    User.objects.get(id=response_data['id']).delete()
+    created_user.delete()
 
 
 def test_user_create_no_superuser(client_bob):


### PR DESCRIPTION
Related to #1673 

Refer to https://github.com/centerofci/mathesar/pull/2000#issuecomment-1343504847 for the preface of this issue. 

This PR flags the user created by a superuser for a password change on his first login.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
