### PR TITLE
Reset primary key column sequence upon splitting table.

### DIFF
--- a/db/tables/operations/split.py
+++ b/db/tables/operations/split.py
@@ -89,7 +89,7 @@ def extract_columns_from_table(old_table_oid, extracted_column_attnums, extracte
             fk_column_name,
         )
         conn.execute(split_ins)
-        update_sequence_to_latest(conn, engine, extracted_table)
+        update_pk_sequence_to_latest(conn, engine, extracted_table)
 
         remainder_table_oid = get_oid_from_table(remainder_table_with_fk_column.name, schema, engine)
         deletion_column_data = [
@@ -100,7 +100,7 @@ def extract_columns_from_table(old_table_oid, extracted_column_attnums, extracte
     return extracted_table, remainder_table_with_fk_column, fk_column_name
 
 
-def update_sequence_to_latest(conn, engine, extracted_table):
+def update_pk_sequence_to_latest(conn, engine, extracted_table):
     _preparer = engine.dialect.identifier_preparer
     quoted_table_name = _preparer.quote(extracted_table.schema) + "." + _preparer.quote(extracted_table.name)
     update_pk_sequence_stmt = func.setval(

--- a/db/tests/tables/operations/test_split.py
+++ b/db/tests/tables/operations/test_split.py
@@ -3,6 +3,7 @@ from sqlalchemy import MetaData, select
 from db import constants
 from db.columns.defaults import DEFAULT_COLUMNS
 from db.columns.operations.select import get_columns_attnum_from_names
+from db.records.operations.insert import insert_record_or_records
 from db.tables.operations.select import get_oid_from_table, reflect_table
 from db.tables.operations.split import extract_columns_from_table
 from db.metadata import get_empty_metadata
@@ -141,3 +142,10 @@ def test_extract_columns_leaves_correct_data(engine_with_roster, roster_table_na
     with engine.begin() as conn:
         actual_tuples = conn.execute(actual_tuple_sel).fetchall()
     assert sorted(expect_tuples) == sorted(actual_tuples)
+
+
+def test_extract_columns_insert_new_record(engine_with_roster, extracted_remainder_roster, roster_extracted_cols, roster_fkey_col):
+    engine, schema = engine_with_roster
+    extracted, remainder, _, _ = extracted_remainder_roster
+    # Verify if we are able to add new records to the Table. Refer https://github.com/centerofci/mathesar/issues/2144
+    insert_record_or_records(extracted, engine, {"Teacher": "Miyagi", "Teacher Email": "miyagi@karatekid.com"})


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2144 

Updates the sequence value of the primary key column to the maximum value of the Column (since it is a sequence). This ensures that the sequence value will correctly start from the last record's primary key column value instead of starting from value `1`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
