### PR TITLE
Return the created foreign key column when splitting the Table

### DIFF
--- a/db/tables/operations/split.py
+++ b/db/tables/operations/split.py
@@ -108,7 +108,7 @@ def extract_columns_from_table(old_table_oid, extracted_column_attnums, extracte
         fk_column_attnum = get_column_attnum_from_name(remainder_table_oid, fk_column_name, engine, get_empty_metadata())
         if relationship_fk_column_name != fk_column_name:
             rename_column(remainder_table_oid, fk_column_attnum, engine, conn, relationship_fk_column_name)
-    return extracted_table, remainder_table_with_fk_column, fk_column_name
+    return extracted_table, remainder_table_with_fk_column, fk_column_attnum
 
 
 def update_pk_sequence_to_latest(conn, engine, extracted_table):

--- a/db/tests/columns/operations/test_alter.py
+++ b/db/tests/columns/operations/test_alter.py
@@ -8,7 +8,10 @@ from sqlalchemy.exc import IntegrityError
 from db import constants
 from db.columns.operations import alter as alter_operations
 from db.columns.operations.alter import alter_column, batch_update_columns, change_column_nullable, rename_column, retype_column, set_column_default
-from db.columns.operations.select import get_column_attnum_from_name, get_column_default, get_columns_attnum_from_names
+from db.columns.operations.select import (
+    get_column_attnum_from_name, get_column_default, get_column_name_from_attnum,
+    get_columns_attnum_from_names,
+)
 from db.columns.utils import to_mathesar_column_with_engine
 from db.tables.operations.create import create_mathesar_table
 from db.tables.operations.select import get_oid_from_table, reflect_table
@@ -120,9 +123,12 @@ def test_rename_column_foreign_keys(engine_with_schema):
     table_oid = get_oid_from_table(table_name, schema, engine)
     extracted_cols = ["Filler 1"]
     extracted_col_attnums = get_columns_attnum_from_names(table_oid, extracted_cols, engine, metadata=get_empty_metadata())
-    extracted, remainder, fk_name = extract_columns_from_table(
+    extracted, remainder, fk_attnum = extract_columns_from_table(
         table_oid, extracted_col_attnums, "Extracted", schema, engine
     )
+    remainder_table_oid = get_oid_from_table(remainder.name, schema, engine)
+
+    fk_name = get_column_name_from_attnum(remainder_table_oid, fk_attnum, engine, get_empty_metadata())
     new_fk_name = "new_" + fk_name
     remainder = _rename_column_and_assert(remainder, fk_name, new_fk_name, engine)
 

--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -107,7 +107,7 @@ class TableViewSet(AccessViewSetMixin, CreateModelMixin, RetrieveModelMixin, Lis
             columns_to_extract = serializer.validated_data['extract_columns']
             extracted_table_name = serializer.validated_data['extracted_table_name']
             relationship_fk_column_name = serializer.validated_data['relationship_fk_column_name']
-            extracted_table, remainder_table, _ = table.split_table(
+            extracted_table, remainder_table, remainder_fk_column = table.split_table(
                 columns_to_extract=columns_to_extract,
                 extracted_table_name=extracted_table_name,
                 column_names_id_map=column_names_id_map,
@@ -115,7 +115,8 @@ class TableViewSet(AccessViewSetMixin, CreateModelMixin, RetrieveModelMixin, Lis
             )
             split_table_response = {
                 'extracted_table': extracted_table.id,
-                'remainder_table': remainder_table.id
+                'remainder_table': remainder_table.id,
+                'fk_column': remainder_fk_column.id
             }
             response_serializer = SplitTableResponseSerializer(data=split_table_response)
             response_serializer.is_valid(True)

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -230,6 +230,7 @@ class SplitTableRequestSerializer(MathesarErrorMessageMixin, serializers.Seriali
 class SplitTableResponseSerializer(MathesarErrorMessageMixin, serializers.Serializer):
     extracted_table = serializers.PrimaryKeyRelatedField(queryset=Table.current_objects.all())
     remainder_table = serializers.PrimaryKeyRelatedField(queryset=Table.current_objects.all())
+    fk_column = serializers.PrimaryKeyRelatedField(queryset=Column.current_objects.all())
 
 
 class MappingSerializer(MathesarErrorMessageMixin, serializers.Serializer):

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -649,7 +649,7 @@ class Table(DatabaseObject, Relation):
         remainder_fk_column_attnum = get_column_attnum_from_name(
             remainder_table.oid,
             remainder_fk_name,
-            remainder_table._sa,
+            remainder_table._sa_engine,
             metadata=get_empty_metadata()
         )
         remainder_fk_column = Column.objects.get(table=remainder_table, attnum=remainder_fk_column_attnum)

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -14,7 +14,7 @@ from db.columns.operations.create import create_column, duplicate_column
 from db.columns.operations.alter import alter_column
 from db.columns.operations.drop import drop_column
 from db.columns.operations.select import (
-    get_column_attnum_from_name, get_column_attnum_from_names_as_map, get_column_name_from_attnum,
+    get_column_attnum_from_names_as_map, get_column_name_from_attnum,
     get_map_of_attnum_to_column_name, get_map_of_attnum_and_table_oid_to_column_name,
 )
 from db.constraints.operations.create import create_constraint
@@ -625,7 +625,7 @@ class Table(DatabaseObject, Relation):
         remainder_column_names = column_names_id_map.keys() - extracted_column_names
 
         # Mutate on Postgres
-        extracted_sa_table, remainder_sa_table, remainder_fk_name = extract_columns_from_table(
+        extracted_sa_table, remainder_sa_table, linking_fk_column_attnum = extract_columns_from_table(
             self.oid,
             columns_attnum_to_extract,
             extracted_table_name,
@@ -646,13 +646,7 @@ class Table(DatabaseObject, Relation):
         remainder_table = Table.current_objects.get(oid=remainder_table_oid)
         remainder_table.update_column_reference(remainder_column_names, column_names_id_map)
         reset_reflection()
-        remainder_fk_column_attnum = get_column_attnum_from_name(
-            remainder_table.oid,
-            remainder_fk_name,
-            remainder_table._sa_engine,
-            metadata=get_empty_metadata()
-        )
-        remainder_fk_column = Column.objects.get(table=remainder_table, attnum=remainder_fk_column_attnum)
+        remainder_fk_column = Column.objects.get(table=remainder_table, attnum=linking_fk_column_attnum)
 
         return extracted_table, remainder_table, remainder_fk_column
 

--- a/mathesar/models/base.py
+++ b/mathesar/models/base.py
@@ -14,7 +14,7 @@ from db.columns.operations.create import create_column, duplicate_column
 from db.columns.operations.alter import alter_column
 from db.columns.operations.drop import drop_column
 from db.columns.operations.select import (
-    get_column_attnum_from_names_as_map, get_column_name_from_attnum,
+    get_column_attnum_from_name, get_column_attnum_from_names_as_map, get_column_name_from_attnum,
     get_map_of_attnum_to_column_name, get_map_of_attnum_and_table_oid_to_column_name,
 )
 from db.constraints.operations.create import create_constraint
@@ -625,7 +625,7 @@ class Table(DatabaseObject, Relation):
         remainder_column_names = column_names_id_map.keys() - extracted_column_names
 
         # Mutate on Postgres
-        extracted_sa_table, remainder_sa_table, remainder_fk = extract_columns_from_table(
+        extracted_sa_table, remainder_sa_table, remainder_fk_name = extract_columns_from_table(
             self.oid,
             columns_attnum_to_extract,
             extracted_table_name,
@@ -646,7 +646,15 @@ class Table(DatabaseObject, Relation):
         remainder_table = Table.current_objects.get(oid=remainder_table_oid)
         remainder_table.update_column_reference(remainder_column_names, column_names_id_map)
         reset_reflection()
-        return extracted_table, remainder_table, remainder_fk
+        remainder_fk_column_attnum = get_column_attnum_from_name(
+            remainder_table.oid,
+            remainder_fk_name,
+            remainder_table._sa,
+            metadata=get_empty_metadata()
+        )
+        remainder_fk_column = Column.objects.get(table=remainder_table, attnum=remainder_fk_column_attnum)
+
+        return extracted_table, remainder_table, remainder_fk_column
 
     def update_column_reference(self, column_names, column_name_id_map):
         """

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -1575,11 +1575,12 @@ def test_table_extract_columns_specify_fk_column_name(create_patents_table, clie
     assert current_table_response.status_code == 201
     response_data = current_table_response.json()
     remainder_table_id = response_data['remainder_table']
+    fk_column = response_data['fk_column']
     remainder_table = Table.objects.get(id=remainder_table_id)
     metadata = get_empty_metadata()
     relationship_fk_column_attnum = get_column_attnum_from_name(remainder_table.oid, relationship_fk_column_name, remainder_table._sa_engine, metadata=metadata)
     assert relationship_fk_column_attnum is not None
-    Column.objects.get(table_id=remainder_table_id, attnum=relationship_fk_column_attnum)
+    assert fk_column == Column.objects.get(table_id=remainder_table_id, attnum=relationship_fk_column_attnum).id
 
 
 def test_table_extract_columns_with_display_options(create_patents_table, client):


### PR DESCRIPTION
`/api/db/v0/tables/{table.id}/split_table/` API returns the foreign key column field that is created when splitting the table in addition to the existing fields.

The response for the Split table API is

```
{
                'extracted_table': extracted_table_id,
                'remainder_table': remainder_table_id,
                'fk_column': remainder_fk_column_id
}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
