### PR TITLE
Stale demo db reset

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -17,10 +17,13 @@ from django.contrib import admin
 from django.urls import include, path
 
 from mathesar import urls as mathesar_urls
+from mathesar import wildcard_urls as mathesar_wildcard_urls
 
-
-urlpatterns = [
+urls = [
     path('admin/', admin.site.urls),
     path('', include(mathesar_urls)),
     path('api-docs/', include('rest_framework.urls')),
+]
+urlpatterns = urls + [
+    path('', include(mathesar_wildcard_urls)),
 ]

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -1,17 +1,21 @@
-from django.urls import include, path, re_path
+from django.urls import path, re_path
 
-from config import urls as root_urls
+from config.urls import urls
 from demo import views
 
-
-urlpatterns = [
-    path('api/demo/v0/load_data/', views.load_data, name='load_data'),
-    path('api/demo/v0/datasets_exist/', views.data_exists, name='datasets_exist'),
+demo_wildcard_urls = [
     path('<db_name>/', views.SchemasView.as_view(), name='schemas'),
     re_path(
         r'^(?P<db_name>\w+)/(?P<schema_id>\w+)/',
         views.SchemasView.as_view(),
         name='schema_home'
-    ),
-    path('', include(root_urls)),
+    )
 ]
+
+# Ignore mathesar wildcard urls as we override it with the demo wildcard urls
+urlpatterns = urls + [
+    path('api/demo/v0/load_data/', views.load_data, name='load_data'),
+    path('api/demo/v0/datasets_exist/', views.data_exists, name='datasets_exist'),
+    path('api/demo/v0/delete_stale_db/', views.remove_stale_db, name='remove_stale_db'),
+
+] + demo_wildcard_urls

--- a/demo/views.py
+++ b/demo/views.py
@@ -40,19 +40,20 @@ def data_exists(request):
 
 @login_required
 @staff_member_required
-@api_view(['GET'])
+@api_view(['POST'])
 def remove_stale_db(request):
     """Remove databases older than MAX_DAYS"""
-    serializer = StaleDbRequestSerializer(data=request.data)
-    if serializer.is_valid(True):
-        deleted_databases = drop_all_stale_databases(
-            force=serializer.validated_data['force'],
-            max_days=serializer.validated_data['max_days']
-        )
-        return Response(
-            {'deleted_databases': deleted_databases},
-            status=status.HTTP_200_OK
-        )
+    if request.method == 'POST':
+        serializer = StaleDbRequestSerializer(data=request.data)
+        if serializer.is_valid(True):
+            deleted_databases = drop_all_stale_databases(
+                force=serializer.validated_data['force'],
+                max_days=serializer.validated_data['max_days']
+            )
+            return Response(
+                {'deleted_databases': deleted_databases},
+                status=status.HTTP_200_OK
+            )
 
 
 class SchemasView(RootSchemasView):

--- a/demo/views.py
+++ b/demo/views.py
@@ -1,9 +1,10 @@
+from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from demo.install import load_datasets, customize_settings, check_datasets
+from demo.install import drop_all_stale_databases, load_datasets, customize_settings, check_datasets
 from mathesar.database.base import create_mathesar_engine
 from mathesar.state import reset_reflection
 from mathesar.views import SchemasView as RootSchemasView
@@ -29,6 +30,15 @@ def data_exists(request):
     engine = create_mathesar_engine(db_name)
     datasets_exist = check_datasets(engine)
     return Response({'datasets_exist': datasets_exist})
+
+
+@login_required
+@staff_member_required
+@api_view(['GET'])
+def remove_stale_db(request):
+    """Remove databases older than MAX_DAYS"""
+    drop_all_stale_databases()
+    return Response(status=status.HTTP_200_OK)
 
 
 class SchemasView(RootSchemasView):

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path, re_path
+from django.urls import include, path
 from rest_framework_nested import routers
 
 from mathesar import views
@@ -34,10 +34,4 @@ urlpatterns = [
     path('auth/password_reset_confirm', MathesarPasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path('auth/', include('django.contrib.auth.urls')),
     path('', views.home, name='home'),
-    path('<db_name>/', views.SchemasView.as_view(), name='schemas'),
-    re_path(
-        r'^(?P<db_name>\w+)/(?P<schema_id>\w+)/',
-        views.SchemasView.as_view(),
-        name='schema_home'
-    ),
 ]

--- a/mathesar/wildcard_urls.py
+++ b/mathesar/wildcard_urls.py
@@ -1,0 +1,12 @@
+from django.urls import path, re_path
+
+from mathesar import views
+
+urlpatterns = [
+    path('<db_name>/', views.SchemasView.as_view(), name='schemas'),
+    re_path(
+        r'^(?P<db_name>\w+)/(?P<schema_id>\w+)/',
+        views.SchemasView.as_view(),
+        name='schema_home'
+    )
+]


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2225  and also fixes #2223

Adds an API endpoint to the demo view which would delete databases created during the live demo.

The API can also be called using the DRF API UI
```
POST /api/demo/v0/delete_stale_db/

It takes in optional parameter:
{
   "force": false, //force database deletion even if it is in use
   "max_days": 3 //delete database older than 3  days by default, changed based on requirements
 }
 ```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
