### PR TITLE
Fix filter validation logic when checked using filter id

### DIFF
--- a/mathesar_ui/src/stores/abstract-types/operations/filtering.ts
+++ b/mathesar_ui/src/stores/abstract-types/operations/filtering.ts
@@ -60,16 +60,19 @@ const equalityFiltersResponse: AbstractTypeFilterDefinitionResponse[] = [
     name: 'equals',
     aliases: constructAliasMapForTypes(allDateTimeTypes, 'is same as'),
     uiTypeParameterMap: constructParamMapForAllTypes((category) => [category]),
+    hasParams: true,
   },
   {
     id: 'null',
     name: 'is empty',
     uiTypeParameterMap: constructParamMapForAllTypes(() => []),
+    hasParams: false,
   },
   {
     id: 'not_null',
     name: 'is not empty',
     uiTypeParameterMap: constructParamMapForAllTypes(() => []),
+    hasParams: false,
   },
 ];
 
@@ -85,6 +88,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
       [abstractTypeCategory.Email]: [abstractTypeCategory.Text],
       [abstractTypeCategory.Uri]: [abstractTypeCategory.Text],
     },
+    hasParams: true,
   },
   {
     id: 'starts_with_case_insensitive',
@@ -94,6 +98,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
       [abstractTypeCategory.Email]: [abstractTypeCategory.Text],
       [abstractTypeCategory.Uri]: [abstractTypeCategory.Text],
     },
+    hasParams: true,
   },
   {
     id: 'uri_scheme_equals',
@@ -101,6 +106,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.Uri]: [abstractTypeCategory.Text],
     },
+    hasParams: true,
   },
   {
     id: 'uri_authority_contains',
@@ -108,6 +114,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.Uri]: [abstractTypeCategory.Text],
     },
+    hasParams: true,
   },
   {
     id: 'json_array_length_equals',
@@ -115,6 +122,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.JsonArray]: [abstractTypeCategory.Number],
     },
+    hasParams: true,
   },
   {
     id: 'json_array_length_greater_than',
@@ -122,6 +130,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.JsonArray]: [abstractTypeCategory.Number],
     },
+    hasParams: true,
   },
   {
     id: 'json_array_length_greater_or_equal',
@@ -129,6 +138,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.JsonArray]: [abstractTypeCategory.Number],
     },
+    hasParams: true,
   },
   {
     id: 'json_array_length_less_than',
@@ -136,6 +146,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.JsonArray]: [abstractTypeCategory.Number],
     },
+    hasParams: true,
   },
   {
     id: 'json_array_length_less_or_equal',
@@ -143,6 +154,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.JsonArray]: [abstractTypeCategory.Number],
     },
+    hasParams: true,
   },
   {
     id: 'json_array_not_empty',
@@ -150,6 +162,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.JsonArray]: [],
     },
+    hasParams: false,
   },
   {
     id: 'json_array_contains',
@@ -157,6 +170,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.JsonArray]: [abstractTypeCategory.Text],
     },
+    hasParams: true,
   },
   {
     id: 'email_domain_equals',
@@ -164,6 +178,7 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.Email]: [abstractTypeCategory.Text],
     },
+    hasParams: true,
   },
   {
     id: 'email_domain_contains',
@@ -171,18 +186,21 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
     uiTypeParameterMap: {
       [abstractTypeCategory.Email]: [abstractTypeCategory.Text],
     },
+    hasParams: true,
   },
   {
     id: 'lesser',
     name: 'is lesser than',
     aliases: constructAliasMapForTypes(allDateTimeTypes, 'is before'),
     uiTypeParameterMap: numericallyOperableTypesParams,
+    hasParams: true,
   },
   {
     id: 'greater',
     name: 'is greater than',
     aliases: constructAliasMapForTypes(allDateTimeTypes, 'is after'),
     uiTypeParameterMap: numericallyOperableTypesParams,
+    hasParams: true,
   },
   {
     id: 'lesser_or_equal',
@@ -192,12 +210,14 @@ const filterResponse: AbstractTypeFilterDefinitionResponse[] = [
       'is before or same as',
     ),
     uiTypeParameterMap: numericallyOperableTypesParams,
+    hasParams: true,
   },
   {
     id: 'greater_or_equal',
     name: 'is greater or equal to',
     aliases: constructAliasMapForTypes(allDateTimeTypes, 'is after or same as'),
     uiTypeParameterMap: numericallyOperableTypesParams,
+    hasParams: true,
   },
 ];
 
@@ -270,7 +290,7 @@ export function getLimitedFilterInformationById(
       id: filter.id,
       name: filter.name,
       hasAliases: !!filter.aliases,
-      hasParams: Object.keys(filter.uiTypeParameterMap).length > 0,
+      hasParams: filter.hasParams,
     };
   }
   return undefined;

--- a/mathesar_ui/src/stores/abstract-types/types.ts
+++ b/mathesar_ui/src/stores/abstract-types/types.ts
@@ -103,6 +103,7 @@ export interface AbstractTypeFilterDefinitionResponse {
   uiTypeParameterMap: Partial<
     Record<AbstractTypeCategoryIdentifier, AbstractTypeCategoryIdentifier[]>
   >;
+  hasParams: boolean;
 }
 
 export interface AbstractTypeLimitedFilterInformation {


### PR DESCRIPTION
Fixes #2318

This PR fixes a filter validation logic when checked using filter id.

The abstract-type based files probably require a refactoring since a number of use cases were added on to them which were not taken into consideration during the initial design, but that's a low priority and we haven't had any major concerns over them so far. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
