### PR TITLE
Allow user to navigate to linked table via cell context menu

### DIFF
--- a/mathesar_ui/src/components/LinkedRecord.svelte
+++ b/mathesar_ui/src/components/LinkedRecord.svelte
@@ -93,7 +93,7 @@
 <style>
   .linked-record {
     max-width: max-content;
-    display: grid;
+    display: inline;
     grid-template: auto / 1fr auto;
     position: relative;
     isolation: isolate;

--- a/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
+++ b/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
@@ -5,6 +5,7 @@
     type SortDirection,
   } from '@mathesar/components/sort-entry/utils';
   import {
+    iconTable,
     iconGrouping,
     iconSortAscending,
     iconSortDescending,
@@ -13,6 +14,7 @@
     getTabularDataStoreFromContext,
     type ProcessedColumn,
   } from '@mathesar/stores/table-data';
+  import { storeToGetTablePageUrl } from '@mathesar/stores/storeBasedUrls';
 
   export let processedColumn: ProcessedColumn;
 
@@ -30,7 +32,11 @@
   );
 
   $: hasGrouping = $grouping.hasColumn(columnId);
-
+  $: linkFk = processedColumn.linkFk;
+  $: getTablePageUrl = $storeToGetTablePageUrl;
+  $: fk_table_link = linkFk
+    ? getTablePageUrl({ tableId: linkFk.referent_table })
+    : undefined;
   function removeSorting() {
     sorting.update((s) => s.without(columnId));
   }
@@ -50,6 +56,10 @@
 
   function removeGrouping() {
     grouping.update((g) => g.withoutColumns([columnId]));
+  }
+
+  function goToTable() {
+    window.location.href = fk_table_link;
   }
 </script>
 
@@ -86,5 +96,11 @@
 {:else}
   <ButtonMenuItem icon={iconGrouping} on:click={addGrouping}>
     Group by Column
+  </ButtonMenuItem>
+{/if}
+
+{#if fk_table_link !== undefined}
+  <ButtonMenuItem icon={iconTable} on:click={goToTable}>
+    Open {processedColumn.column.name} Table
   </ButtonMenuItem>
 {/if}

--- a/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
+++ b/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
@@ -59,7 +59,9 @@
   }
 
   function goToTable() {
-    window.location.href = fk_table_link;
+    if (fk_table_link) {
+      window.location.href = fk_table_link;
+    }
   }
 </script>
 
@@ -99,7 +101,7 @@
   </ButtonMenuItem>
 {/if}
 
-{#if fk_table_link !== undefined}
+{#if fk_table_link}
   <ButtonMenuItem icon={iconTable} on:click={goToTable}>
     Open {processedColumn.column.name} Table
   </ButtonMenuItem>

--- a/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
+++ b/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
@@ -17,7 +17,7 @@
   import { storeToGetTablePageUrl } from '@mathesar/stores/storeBasedUrls';
   import LinkMenuItem from '@mathesar/component-library/menu/LinkMenuItem.svelte';
   import { getTableName } from '@mathesar/stores/tables';
-    import Identifier from '@mathesar/components/Identifier.svelte';
+  import Identifier from '@mathesar/components/Identifier.svelte';
 
   export let processedColumn: ProcessedColumn;
 
@@ -40,7 +40,9 @@
   $: fkTableLink = linkFk
     ? getTablePageUrl({ tableId: linkFk.referent_table })
     : undefined;
-  $: tableName = linkFk?.referent_table ? getTableName(linkFk?.referent_table) : undefined;
+  $: tableName = linkFk?.referent_table
+    ? getTableName(linkFk?.referent_table)
+    : undefined;
 
   function removeSorting() {
     sorting.update((s) => s.without(columnId));
@@ -103,5 +105,5 @@
 {#if fkTableLink !== undefined}
   <LinkMenuItem icon={iconTable} href={fkTableLink}>
     Open <Identifier>{tableName}</Identifier> Table
- </LinkMenuItem>
+  </LinkMenuItem>
 {/if}

--- a/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
+++ b/mathesar_ui/src/systems/table-view/header/header-cell/ColumnHeaderContextMenu.svelte
@@ -15,6 +15,9 @@
     type ProcessedColumn,
   } from '@mathesar/stores/table-data';
   import { storeToGetTablePageUrl } from '@mathesar/stores/storeBasedUrls';
+  import LinkMenuItem from '@mathesar/component-library/menu/LinkMenuItem.svelte';
+  import { getTableName } from '@mathesar/stores/tables';
+    import Identifier from '@mathesar/components/Identifier.svelte';
 
   export let processedColumn: ProcessedColumn;
 
@@ -34,9 +37,11 @@
   $: hasGrouping = $grouping.hasColumn(columnId);
   $: linkFk = processedColumn.linkFk;
   $: getTablePageUrl = $storeToGetTablePageUrl;
-  $: fk_table_link = linkFk
+  $: fkTableLink = linkFk
     ? getTablePageUrl({ tableId: linkFk.referent_table })
     : undefined;
+  $: tableName = linkFk?.referent_table ? getTableName(linkFk?.referent_table) : undefined;
+
   function removeSorting() {
     sorting.update((s) => s.without(columnId));
   }
@@ -56,12 +61,6 @@
 
   function removeGrouping() {
     grouping.update((g) => g.withoutColumns([columnId]));
-  }
-
-  function goToTable() {
-    if (fk_table_link) {
-      window.location.href = fk_table_link;
-    }
   }
 </script>
 
@@ -101,8 +100,8 @@
   </ButtonMenuItem>
 {/if}
 
-{#if fk_table_link}
-  <ButtonMenuItem icon={iconTable} on:click={goToTable}>
-    Open {processedColumn.column.name} Table
-  </ButtonMenuItem>
+{#if fkTableLink !== undefined}
+  <LinkMenuItem icon={iconTable} href={fkTableLink}>
+    Open <Identifier>{tableName}</Identifier> Table
+ </LinkMenuItem>
 {/if}

--- a/mathesar_ui/src/systems/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowCell.svelte
@@ -29,10 +29,10 @@
   import CellBackground from '@mathesar/components/CellBackground.svelte';
   import RowCellBackgrounds from '@mathesar/components/RowCellBackgrounds.svelte';
   import { storeToGetTablePageUrl } from '@mathesar/stores/storeBasedUrls';
-  import CellErrors from './CellErrors.svelte';
   import Identifier from '@mathesar/components/Identifier.svelte';
   import { getTableName } from '@mathesar/stores/tables';
-    import LinkedRecord from '@mathesar/components/LinkedRecord.svelte';
+  import LinkedRecord from '@mathesar/components/LinkedRecord.svelte';
+  import CellErrors from './CellErrors.svelte';
 
   export let recordsData: RecordsData;
   export let selection: TabularDataSelection;
@@ -87,7 +87,9 @@
   $: fkTableLink = linkFk
     ? getTablePageUrl({ tableId: linkFk.referent_table })
     : undefined;
-  $: tableName = linkFk?.referent_table ? getTableName(linkFk?.referent_table) : undefined;
+  $: tableName = linkFk?.referent_table
+    ? getTableName(linkFk?.referent_table)
+    : undefined;
   async function checkTypeAndScroll(type?: string) {
     if (type === 'moved') {
       await tick();
@@ -187,9 +189,13 @@
         Set to <Null />
       </ButtonMenuItem>
       {#if linkedRecordHref}
-       <LinkMenuItem icon={iconRecord} href={linkedRecordHref}>
-        Open <LinkedRecord recordSummary={$recordSummaries.get(String(column.id))?.get(String(value))}></LinkedRecord>
-      </LinkMenuItem>
+        <LinkMenuItem icon={iconRecord} href={linkedRecordHref}>
+          Open <LinkedRecord
+            recordSummary={$recordSummaries
+              .get(String(column.id))
+              ?.get(String(value))}
+          />
+        </LinkMenuItem>
       {/if}
       {#if fkTableLink}
         <LinkMenuItem icon={iconTable} href={fkTableLink}>

--- a/mathesar_ui/src/systems/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowCell.svelte
@@ -24,10 +24,11 @@
   import type { RequestStatus } from '@mathesar/api/utils/requestUtils';
   import { States } from '@mathesar/api/utils/requestUtils';
   import { SheetCell } from '@mathesar/components/sheet';
-  import { iconLinkToRecordPage, iconSetToNull } from '@mathesar/icons';
+  import { iconSetToNull, iconRecord, iconTable } from '@mathesar/icons';
   import { storeToGetRecordPageUrl } from '@mathesar/stores/storeBasedUrls';
   import CellBackground from '@mathesar/components/CellBackground.svelte';
   import RowCellBackgrounds from '@mathesar/components/RowCellBackgrounds.svelte';
+  import { storeToGetTablePageUrl } from '@mathesar/stores/storeBasedUrls';
   import CellErrors from './CellErrors.svelte';
 
   export let recordsData: RecordsData;
@@ -76,10 +77,13 @@
   $: isProcessing = modificationStatus?.state === 'processing';
   $: isEditable = !column.primary_key;
   $: getRecordPageUrl = $storeToGetRecordPageUrl;
+  $: getTablePageUrl = $storeToGetTablePageUrl;
   $: linkedRecordHref = linkFk
     ? getRecordPageUrl({ tableId: linkFk.referent_table, recordId: value })
     : undefined;
-
+  $: fk_table_link = linkFk
+    ? getTablePageUrl({ tableId: linkFk.referent_table })
+    : undefined;
   async function checkTypeAndScroll(type?: string) {
     if (type === 'moved') {
       await tick();
@@ -179,8 +183,11 @@
         Set to <Null />
       </ButtonMenuItem>
       {#if linkedRecordHref}
-        <LinkMenuItem icon={iconLinkToRecordPage} href={linkedRecordHref}>
-          Go To Linked Record
+        <LinkMenuItem icon={iconRecord} href={linkedRecordHref}>
+          Open {$recordSummaries.get(String(column.id))?.get(String(value))}
+        </LinkMenuItem>
+        <LinkMenuItem icon={iconTable} href={fk_table_link}>
+          Open {column.name}
         </LinkMenuItem>
       {/if}
     </ContextMenu>

--- a/mathesar_ui/src/systems/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowCell.svelte
@@ -30,6 +30,9 @@
   import RowCellBackgrounds from '@mathesar/components/RowCellBackgrounds.svelte';
   import { storeToGetTablePageUrl } from '@mathesar/stores/storeBasedUrls';
   import CellErrors from './CellErrors.svelte';
+  import Identifier from '@mathesar/components/Identifier.svelte';
+  import { getTableName } from '@mathesar/stores/tables';
+    import LinkedRecord from '@mathesar/components/LinkedRecord.svelte';
 
   export let recordsData: RecordsData;
   export let selection: TabularDataSelection;
@@ -81,9 +84,10 @@
   $: linkedRecordHref = linkFk
     ? getRecordPageUrl({ tableId: linkFk.referent_table, recordId: value })
     : undefined;
-  $: fk_table_link = linkFk
+  $: fkTableLink = linkFk
     ? getTablePageUrl({ tableId: linkFk.referent_table })
     : undefined;
+  $: tableName = linkFk?.referent_table ? getTableName(linkFk?.referent_table) : undefined;
   async function checkTypeAndScroll(type?: string) {
     if (type === 'moved') {
       await tick();
@@ -183,13 +187,13 @@
         Set to <Null />
       </ButtonMenuItem>
       {#if linkedRecordHref}
-        <LinkMenuItem icon={iconRecord} href={linkedRecordHref}>
-          Open {$recordSummaries.get(String(column.id))?.get(String(value))}
-        </LinkMenuItem>
+       <LinkMenuItem icon={iconRecord} href={linkedRecordHref}>
+        Open <LinkedRecord recordSummary={$recordSummaries.get(String(column.id))?.get(String(value))}></LinkedRecord>
+      </LinkMenuItem>
       {/if}
-      {#if fk_table_link}
-        <LinkMenuItem icon={iconTable} href={fk_table_link}>
-          Open {column.name}
+      {#if fkTableLink}
+        <LinkMenuItem icon={iconTable} href={fkTableLink}>
+          Open <Identifier>{tableName}</Identifier> Table
         </LinkMenuItem>
       {/if}
     </ContextMenu>

--- a/mathesar_ui/src/systems/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowCell.svelte
@@ -186,6 +186,8 @@
         <LinkMenuItem icon={iconRecord} href={linkedRecordHref}>
           Open {$recordSummaries.get(String(column.id))?.get(String(value))}
         </LinkMenuItem>
+      {/if}
+      {#if fk_table_link}
         <LinkMenuItem icon={iconTable} href={fk_table_link}>
           Open {column.name}
         </LinkMenuItem>


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2350 

<!-- Concisely describe what the pull request does. -->
**Preface**
I understand that the core maintainers are working hard to finish the release, so there is no rush to review this. I apologize if this adds more to your plates than it takes away, but I saw this issue and wanted to try. Thanks for all the help!

**Technical details**
The desired behavior described in the issue had three main components. 

1. Change the text on the "Go to Linked Record" button to "Open _" where _ represents the name of the linked value. Additionally, change the icon to the `iconRecord`. 


    - I attempted to achieve this behavior by setting the text to open, plus the name of the linked record. I then also changed the icon.
2. Add another entry to the Cell's context menu. This entry should be labeled "Open _ Table" where _ represents the name of the linked table. The icon for this new entry should be `iconTable`.


    - This was slightly more complicated than part 1 but there was previous code that I could work off of. I found the URL to the linked table similar to how the link to the record page is found for the "Go to Linked Record" option. I then set the text to the name of the column and changed the icon.


3. Add the same "Open _ Table" button to the context menu of an FK columns header. Set the icon for this option to `iconTable`.
    - I am the most unsure about my changes in this area. I create a new menu item for the context menu that only renders if the column is an FK column. I then set the text for this button in a similar fashion to the process outlined in step 2. I acquired the link in a similar fashion to step 2 as well. However, this is where I ran into a problem. The `<ButtonMenuItem>` components that comprise the context menu for the header doesn't allow an `href` field. So instead I wrote a function that sets the page URL to the linked table page URL. I am not sure if this is the correct way to implement it. 

**Screenshots**
<img width="1096" alt="Screenshot 2023-01-25 at 11 26 47 PM" src="https://user-images.githubusercontent.com/63031670/214758735-1d0e9dc3-8fa4-4217-af42-eda56b4e1db8.png">

_Image of the context menu for an FK row cell_

<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
<img width="1111" alt="Screenshot 2023-01-25 at 11 26 59 PM" src="https://user-images.githubusercontent.com/63031670/214758712-dd654666-aa40-4853-9e16-6db39f146a4f.png">

_Image of the context menu of an FK column header_


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X ] My pull request targets the `master` branch of the repository
- [ X] My commit messages follow [best practices][best_practices].
- [ X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
