### PR TITLE
Added confirmation when deleting records via table inspector , Fix #2236

### DIFF
--- a/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
@@ -23,8 +23,6 @@
   export let selection: TabularDataSelection;
   export let columnsDataStore: ColumnsDataStore;
 
-  const isDeleting = false;
-
   async function handleDeleteRecords() {
     void confirmDelete({
       identifierType: 'Row',
@@ -76,7 +74,7 @@
     </AnchorButton>
   {/if}
   <Button appearance="outline-primary" on:click={handleDeleteRecords}>
-    <Icon {...isDeleting ? iconLoading : iconDeleteMajor} />
+    <Icon {...iconDeleteMajor} />
     <span>
       Delete {labeledCount(selectedRowIndices, 'records', {
         casing: 'title',

--- a/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
@@ -7,7 +7,7 @@
     iconLoading,
   } from '@mathesar/component-library';
   import { iconDeleteMajor, iconRecord } from '@mathesar/icons';
-    import { confirmDelete } from '@mathesar/stores/confirmation';
+  import { confirmDelete } from '@mathesar/stores/confirmation';
   import { storeToGetRecordPageUrl } from '@mathesar/stores/storeBasedUrls';
   import type {
     ColumnsDataStore,
@@ -23,7 +23,7 @@
   export let selection: TabularDataSelection;
   export let columnsDataStore: ColumnsDataStore;
 
-  let isDeleting = false;
+  const isDeleting = false;
 
   async function handleDeleteRecords() {
     void confirmDelete({
@@ -33,9 +33,9 @@
       onSuccess: () => {
         toast.success({
           title: 'Row deleted successfully!',
-        })
+        });
         selection.resetSelection();
-      }
+      },
     });
   }
 

--- a/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
@@ -7,6 +7,7 @@
     iconLoading,
   } from '@mathesar/component-library';
   import { iconDeleteMajor, iconRecord } from '@mathesar/icons';
+    import { confirmDelete } from '@mathesar/stores/confirmation';
   import { storeToGetRecordPageUrl } from '@mathesar/stores/storeBasedUrls';
   import type {
     ColumnsDataStore,
@@ -26,17 +27,29 @@
 
   async function handleDeleteRecords() {
     if (!isDeleting) {
-      try {
-        isDeleting = true;
-        selection.freezeSelection = true;
-        await recordsData.deleteSelected(selectedRowIndices);
-        selection.resetSelection();
-      } catch (e) {
-        toast.fromError(e);
-      } finally {
-        selection.freezeSelection = false;
-        isDeleting = true;
-      }
+      isDeleting = true;
+      selection.freezeSelection = true;
+      void confirmDelete({
+        identifierType: 'Row',
+        onProceed: () => recordsData.deleteSelected(selectedRowIndices),
+        onError: (e) => toast.fromError(e),
+        onSuccess: () =>
+          toast.success({
+            title: 'Row deleted successfully!',
+          }),
+      });
+      selection.freezeSelection = false;
+      isDeleting = true;
+      // try {
+      //   isDeleting = true;
+      //   selection.freezeSelection = true;
+      //   await recordsData.deleteSelected(selectedRowIndices);
+      //   selection.resetSelection();
+      // } catch (e) {
+      //   toast.fromError(e);
+      // } finally {
+        
+      // }
     }
   }
 

--- a/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
@@ -40,16 +40,6 @@
       });
       selection.freezeSelection = false;
       isDeleting = true;
-      // try {
-      //   isDeleting = true;
-      //   selection.freezeSelection = true;
-      //   await recordsData.deleteSelected(selectedRowIndices);
-      //   selection.resetSelection();
-      // } catch (e) {
-      //   toast.fromError(e);
-      // } finally {
-        
-      // }
     }
   }
 

--- a/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/record/RowActions.svelte
@@ -26,21 +26,17 @@
   let isDeleting = false;
 
   async function handleDeleteRecords() {
-    if (!isDeleting) {
-      isDeleting = true;
-      selection.freezeSelection = true;
-      void confirmDelete({
-        identifierType: 'Row',
-        onProceed: () => recordsData.deleteSelected(selectedRowIndices),
-        onError: (e) => toast.fromError(e),
-        onSuccess: () =>
-          toast.success({
-            title: 'Row deleted successfully!',
-          }),
-      });
-      selection.freezeSelection = false;
-      isDeleting = true;
-    }
+    void confirmDelete({
+      identifierType: 'Row',
+      onProceed: () => recordsData.deleteSelected(selectedRowIndices),
+      onError: (e) => toast.fromError(e),
+      onSuccess: () => {
+        toast.success({
+          title: 'Row deleted successfully!',
+        })
+        selection.resetSelection();
+      }
+    });
   }
 
   $: ({ columns } = columnsDataStore);


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
## Overview
1. This PR fixes issue #2236 
2. This PR adds a dialogue confirmation after pressing the `Delete Records` button in the table inspector

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
1. Dialogue Confirmation.
![image](https://user-images.githubusercontent.com/29446639/215351690-8447fca6-1e31-414b-aa61-d73411558fab.png)

2. Deleted Record after pressing
 
![image](https://user-images.githubusercontent.com/29446639/215351835-61036b42-91bf-4e36-876d-1e3bdb397b67.png)



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
