### PR TITLE
Fix typo in clean_stale_db command by changing timedelta function parameter from 'minutes' to 'days'

### DIFF
--- a/demo/management/commands/clean_stale_db.py
+++ b/demo/management/commands/clean_stale_db.py
@@ -43,7 +43,7 @@ def drop_all_stale_databases(force=False, max_days=3, *args, **kwargs):
         'template0',
         'template1'
     ]
-    stale_databases = Database.objects.filter(created_at__lt=now() - timedelta(minutes=max_days))
+    stale_databases = Database.objects.filter(created_at__lt=now() - timedelta(days=max_days))
     deleted_databases = []
     for database in stale_databases:
         if database.name not in excluded_databases and database.deleted is False:


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2467 

<!-- Concisely describe what the pull request does. -->
This PR fixes the issue of demo databases younger than 3 days getting deleted by default.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
The cause of this issue was the filter query using 'minutes' instead of 'days' as the parameter for timedelta function.
https://github.com/centerofci/mathesar/blob/7226575fcebcc014bc70bb024446698736df5af6/demo/management/commands/clean_stale_db.py#L46
This has been fixed by changing the parameter from 'minutes' to 'days'.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
