### PR TITLE
Fix visual regression of table inspector section heading style

### DIFF
--- a/mathesar_ui/src/component-library/collapsible/Collapsible.scss
+++ b/mathesar_ui/src/component-library/collapsible/Collapsible.scss
@@ -11,7 +11,7 @@
       text-align: left;
       cursor: pointer;
       font-weight: inherit;
-      .collapsible-btn-title {
+      .collapsible-header-title {
         flex-grow: 1;
         overflow: hidden;
         font-weight: 600;

--- a/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationInspector.svelte
+++ b/mathesar_ui/src/systems/data-explorer/exploration-inspector/ExplorationInspector.svelte
@@ -62,7 +62,7 @@
     :global(.section-content .labeled-input .label) {
       font-weight: 590;
     }
-    :global(.collapsible > button.btn) {
+    :global(.collapsible > .collapsible-header > button.btn) {
       background-color: var(--sand-200);
 
       &:hover {
@@ -73,7 +73,10 @@
         background-color: var(--sand-400);
       }
     }
-    :global(.collapsible > button.btn .collapsible-header-title) {
+    :global(.collapsible
+        > .collapsible-header
+        > button.btn
+        .collapsible-header-title) {
       font-weight: 590;
     }
     :global(.collapsible .section-content.actions .delete-button) {

--- a/mathesar_ui/src/systems/table-view/table-inspector/TableInspector.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/TableInspector.svelte
@@ -73,7 +73,7 @@
     background-color: var(--sand-100);
     isolation: isolate;
 
-    :global(.collapsible > button.btn) {
+    :global(.collapsible > .collapsible-header > button.btn) {
       background-color: var(--sand-200);
 
       &:hover {


### PR DESCRIPTION
## Notes

This PR fixes a visual regression introduced by #2332

| Before this PR | After this PR |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/42411/219436499-9bac4a58-12a9-40aa-9acc-af77dc31d0e1.png) | ![image](https://user-images.githubusercontent.com/42411/219436392-7a666a73-98c6-47cd-aacf-13a99707c504.png) |

## Retrospective

- @pavish and @rajatvijay I want to call attention to the fact that this regression is related to our usage of global CSS. In #2332 a community contributor did some minor refactoring within the `Collapsible` component. That refactoring inadvertently broke some styling in the table inspector and data explorer because those code locations were using global CSS that relied on the DOM structure within `Collapsible` remaining stable. This is exactly the reason why I'm so adamant on avoiding global CSS. The bigger our project gets and the more community contributors we have, the more present this problem will become. And realistically, even if we had a much more robust automated testing strategy, this visual regressions like these would be really hard to spot with any automated tests that we'd ever want to write. In theory, we _could_ have automated visual regression tests, but I imagine those sort of tests would produce way too many false positives to be useful for a product that's changing as rapidly as ours. This is to say that, in my opinion, scoped CSS is the best tool we have at our disposal to avoid bugs like this. For components outside the component-library, I  want us to use global CSS only as a last resort.

- I gave some though to refactoring the global CSS into scoped CSS to fix this bug, but with our priorities focused on the release, I didn't want to change too much.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


