### PR TITLE
Fix editor viewer access for unconfirmed tables

### DIFF
--- a/mathesar/api/db/viewsets/schemas.py
+++ b/mathesar/api/db/viewsets/schemas.py
@@ -35,7 +35,7 @@ class SchemaViewSet(AccessViewSetMixin, viewsets.GenericViewSet, ListModelMixin,
             database_name,
             comment=serializer.validated_data.get('description')
         )
-        serializer = SchemaSerializer(schema)
+        serializer = SchemaSerializer(schema, context={'request': request})
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def partial_update(self, request, pk=None):

--- a/mathesar/api/serializers/schemas.py
+++ b/mathesar/api/serializers/schemas.py
@@ -1,5 +1,8 @@
+import django.db.models
+from django.db.models import Case, When, Value, F, Q, Count
 from rest_access_policy import PermittedSlugRelatedField
 from rest_framework import serializers
+from mathesar.models.users import Role
 
 from mathesar.api.db.permissions.database import DatabaseAccessPolicy
 from mathesar.api.exceptions.mixins import MathesarErrorMessageMixin
@@ -30,7 +33,30 @@ class SchemaSerializer(MathesarErrorMessageMixin, serializers.HyperlinkedModelSe
         ]
 
     def get_num_tables(self, obj):
-        return obj.tables.count()
+        confirmed_table_roles = (Role.EDITOR.value, Role.VIEWER.value)
+        user = self.context['request'].user
+
+        confirmed_table = "CONFIRMED"
+        unconfirmed_table = "UNCONFIRMED"
+        not_allowed = "NOT_ALLOWED"
+
+        if not user.is_superuser:
+            permissible_schema_role_filter = Q(schema__schema_role__role__in=confirmed_table_roles)
+            permissible_table_view_filter = Q(import_verified=True) | Q(import_verified__isnull=True)
+
+            qs = obj.tables.filter(schema__schema_role__user=user).annotate(
+                to_count=Case(
+                    When(permissible_schema_role_filter, then=Case(
+                        When(permissible_table_view_filter, then=Value(confirmed_table)),
+                        default=Value(unconfirmed_table)
+                    )),
+                    default=Value(not_allowed), output_field=django.db.models.CharField()
+                )
+            )
+            count = qs.filter(Q(to_count=not_allowed) | Q(to_count=confirmed_table)).count()
+        else:
+            count = obj.tables.count()
+        return count
 
     def get_num_queries(self, obj):
         return sum(t.queries.count() for t in obj.tables.all())


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2469 

<!-- Concisely describe what the pull request does. -->
This PR makes some changes in the SchemaSerializer and TableAccessPolicy to allow users with Editor and Viewer to view only confirmed tables. Managers and Admin Users are still able to view unconfirmed tables.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
I use a confirmed_table_roles tuple much like the allowed_roles tuple to specify which roles are allowed to not view the unconfirmed tables.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
