### PR TITLE
Avoid passing args to `_setup_demo_template_db` function

### DIFF
--- a/demo/management/commands/setup_demo_template_db.py
+++ b/demo/management/commands/setup_demo_template_db.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     help = 'Initialize the demo template database.'
 
     def handle(self, *args, **options):
-        _setup_demo_template_db(*args, **options)
+        _setup_demo_template_db()
 
 
 def _setup_demo_template_db():


### PR DESCRIPTION
Fixes #2526 

`demo.management.commands.setup_demo_template_db._setup_demo_template_db` does not accept any arguments but arguments are passed to the function when calling it on https://github.com/centerofci/mathesar/blob/5dd4104a5b54bbd61d98a1d9d44c74d9ef89bb75/demo/management/commands/setup_demo_template_db.py#L15

This causes an error when running the Django management command `setup_demo_template_db` because all [management commands](https://docs.djangoproject.com/en/4.1/ref/django-admin/) can accept some default options such as [--verbosity](https://docs.djangoproject.com/en/4.1/ref/django-admin/#cmdoption-verbosity) and [--traceback](https://docs.djangoproject.com/en/4.1/ref/django-admin/#cmdoption-traceback), so these arguments are always passed by default.