### PR TITLE
Wait on server readiness after upgrade to reload page

### DIFF
--- a/mathesar_ui/src/api/databases.ts
+++ b/mathesar_ui/src/api/databases.ts
@@ -1,0 +1,10 @@
+import type { Database } from '@mathesar/AppTypes';
+import { getAPI, type PaginatedResponse } from './utils/requestUtils';
+
+function list() {
+  return getAPI<PaginatedResponse<Database>>('/api/db/v0/databases/?limit=500');
+}
+
+export default {
+  list,
+};

--- a/mathesar_ui/src/stores/databases.ts
+++ b/mathesar_ui/src/stores/databases.ts
@@ -1,6 +1,7 @@
 import { writable, derived } from 'svelte/store';
 import { preloadCommonData } from '@mathesar/utils/preloadData';
-import { getAPI, States } from '@mathesar/api/utils/requestUtils';
+import databaseApi from '@mathesar/api/databases';
+import { States } from '@mathesar/api/utils/requestUtils';
 
 import type { Writable, Readable } from 'svelte/store';
 import type { Database } from '@mathesar/AppTypes';
@@ -62,9 +63,7 @@ export async function reloadDatabases(): Promise<
 
   try {
     databaseRequest?.cancel();
-    databaseRequest = getAPI<PaginatedResponse<Database>>(
-      '/api/db/v0/databases/?limit=500',
-    );
+    databaseRequest = databaseApi.list();
     const response = await databaseRequest;
     const data = response.results || [];
     databases.set({


### PR DESCRIPTION
Fixes #2566 

**This PR has the following changes:**
* After the upgrade request succeeds,
  * The frontend sends a request to `GET /api/db/v0/databases/`.
  * If it succeeds, it means that the server is up and running, and the frontend reloads the page.
  * If the request does not succeed, it sends another request to the same endpoint after 2 seconds. This repeats until the request succeeds.
* Does not allow the upgrade modal to be closed when upgrade is in progress. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
