### PR TITLE
Optimize stale constraint lookup

### DIFF
--- a/mathesar/state/django.py
+++ b/mathesar/state/django.py
@@ -198,15 +198,25 @@ def reflect_constraints_from_database(database):
             constraint_obj = models.Constraint(oid=constraint_oid, table=table)
             constraint_objs_to_create.append(constraint_obj)
     models.Constraint.current_objects.bulk_create(constraint_objs_to_create, ignore_conflicts=True)
-
-    stale_constraint_ids = []
-    for constraint in models.Constraint.current_objects.all():
-        if constraint.oid not in [db_constraint['oid'] for db_constraint in db_constraints]:
-            stale_constraint_ids.append(constraint.id)
-    models.Constraint.current_objects.filter(
-        table__schema__database=database, id__in=stale_constraint_ids
-    ).delete()
+    _delete_stale_dj_constraints(db_constraints, database)
     engine.dispose()
+
+
+def _delete_stale_dj_constraints(known_db_constraints, database):
+    """
+    Deletes stale Constraint Django model instances in this database. A constraint is stale when it
+    is not in the provided `known_db_constraints` structure.
+    """
+    known_db_constraint_oids = set(
+        known_db_constraint['oid']
+        for known_db_constraint
+        in known_db_constraints
+    )
+    stale_dj_constraints = models.Constraint.current_objects.filter(
+        ~Q(oid__in=known_db_constraint_oids),
+        table__schema__database=database,
+    )
+    stale_dj_constraints.delete()
 
 
 # TODO pass in a cached engine instead of creating a new one


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related #2544

Fixes a [source of demo-mode slowness](https://github.com/centerofci/mathesar/issues/2544#issuecomment-1450291112). Specifically, makes constraint cleanup limited to the database being reflected and more CPU efficient.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
