### PR TITLE
Fix UUID pkeys bug

### DIFF
--- a/db/columns/base.py
+++ b/db/columns/base.py
@@ -138,6 +138,10 @@ class MathesarColumn(Column):
     @property
     def is_default(self):
         default_def = DEFAULT_COLUMNS.get(self.name, False)
+        try:
+            self.type.python_type
+        except NotImplementedError:
+            return False
         return (
             default_def
             and self.type.python_type == default_def[TYPE]().python_type

--- a/db/tests/columns/test_base.py
+++ b/db/tests/columns/test_base.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy import (
     INTEGER, ForeignKey, VARCHAR, CHAR, NUMERIC, ARRAY, JSON
 )
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql.sqltypes import NullType
 
 from db.columns.base import MathesarColumn
@@ -112,6 +113,11 @@ def test_MC_inits_with_engine_empty(column_builder):
 def test_MC_is_default_when_true():
     for default_col in get_default_mathesar_column_list():
         assert default_col.is_default
+
+
+def test_MC_is_default_with_uuid_col():
+    col = MathesarColumn('id', UUID, primary_key=True, nullable=False)
+    assert not col.is_default
 
 
 def test_MC_is_default_when_false_for_name():


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2635 

<!-- Concisely describe what the pull request does. -->

This PR allows Mathesar to render tables with a UUID primary key.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

The issue was that the `UUID` type doesn't map to a known python type in SQLAlchemy's infrastructure, and this was causing our logic that determines whether a column is a mathesar default column to raise an exception.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
