### PR TITLE
Validate identifier length for models that are reflections of Postgres objects

### DIFF
--- a/db/identifiers.py
+++ b/db/identifiers.py
@@ -1,5 +1,6 @@
 import hashlib
 
+
 def truncate_if_necessary(identifier):
     """
     Takes an identifier and returns it, truncating it, if it is too long. The truncated version

--- a/db/identifiers.py
+++ b/db/identifiers.py
@@ -1,0 +1,63 @@
+import hashlib
+
+def truncate_if_necessary(identifier):
+    """
+    Takes an identifier and returns it, truncating it, if it is too long. The truncated version
+    will end with a hash of the passed identifier, therefore column name collision should be very
+    rare.
+
+    Iteratively removes characters from the end of the identifier, until the resulting string, with
+    the suffix hash of the identifier appended, is short enough that it doesn't need to be truncated
+    anymore. Whitespace is trimmed from the truncated identifier before appending the suffix.
+    """
+    assert type(identifier) is str
+    if not is_identifier_too_long(identifier):
+        return identifier
+    right_side = "-" + _get_truncation_hash(identifier)
+    identifier_length = len(identifier)
+    assert len(right_side) < identifier_length  # Sanity check
+    range_of_num_of_chars_to_remove = range(1, identifier_length)
+    for num_of_chars_to_remove in range_of_num_of_chars_to_remove:
+        left_side = identifier[:num_of_chars_to_remove * -1]
+        left_side = left_side.rstrip()
+        truncated_identifier = left_side + right_side
+        if not is_identifier_too_long(truncated_identifier):
+            return truncated_identifier
+    raise Exception(
+        "Acceptable truncation not found; should never happen."
+    )
+
+
+def is_identifier_too_long(identifier):
+    postgres_identifier_size_limit = 63
+    size = _get_size_of_identifier_in_bytes(identifier)
+    return size > postgres_identifier_size_limit
+
+
+def _get_truncation_hash(identifier):
+    """
+    Produces an 8-character string hash of the passed identifier.
+
+    Using hash function blake2s, because it seems fairly recommended and it seems to be better
+    suited for shorter digests than blake2b. We want short digests to not take up too much of the
+    truncated identifier in whose construction this will be used.
+    """
+    h = hashlib.blake2s(digest_size=4)
+    bytes = _get_identifier_in_bytes(identifier)
+    h.update(bytes)
+    return h.hexdigest()
+
+
+def _get_size_of_identifier_in_bytes(s):
+    bytes = _get_identifier_in_bytes(s)
+    return len(bytes)
+
+
+def _get_identifier_in_bytes(s):
+    """
+    Afaict, following Postgres doc [0] says that UTF-8 supports all languages; therefore, different
+    server locale configurations should not break this.
+
+    [0] https://www.postgresql.org/docs/13/multibyte.html
+    """
+    return s.encode('utf-8')

--- a/mathesar/api/exceptions/database_exceptions/exceptions.py
+++ b/mathesar/api/exceptions/database_exceptions/exceptions.py
@@ -425,3 +425,19 @@ class ColumnMappingsNotFound(MathesarAPIException):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
     ):
         super().__init__(exception, self.error_code, message, field, details, status_code)
+
+
+class IdentifierTooLong(MathesarAPIException):
+    error_code = ErrorCodes.IdentifierTooLong.value
+
+    def __init__(
+            self,
+            exception=None,
+            message="Identifier is longer than Postgres' limit of 63 bytes.",
+            field=None,
+            details=None,
+            status_code=status.HTTP_400_BAD_REQUEST
+    ):
+        if exception is None:
+            exception = Exception(message)
+        super().__init__(exception, self.error_code, message, field, details, status_code)

--- a/mathesar/api/exceptions/error_codes.py
+++ b/mathesar/api/exceptions/error_codes.py
@@ -61,3 +61,4 @@ class ErrorCodes(Enum):
     IncorrectOldPassword = 4419
     EditingPublicSchema = 4421
     DuplicateUIQueryInSchema = 4422
+    IdentifierTooLong = 4423

--- a/mathesar/api/serializers/columns.py
+++ b/mathesar/api/serializers/columns.py
@@ -3,6 +3,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.fields import empty, SerializerMethodField
 from rest_framework.settings import api_settings
 
+from db.identifiers import is_identifier_too_long
 from db.columns.exceptions import InvalidTypeError
 from db.columns.exceptions import InvalidTypeOptionError
 from db.types.base import PostgresType, MathesarCustomType
@@ -109,6 +110,11 @@ class SimpleColumnSerializer(MathesarErrorMessageMixin, serializers.ModelSeriali
             db_type = get_db_type_enum_from_id(db_type_id) if db_type_id else None
         self.context[DISPLAY_OPTIONS_SERIALIZER_MAPPING_KEY] = db_type
         return super().to_internal_value(data)
+
+    def validate_name(self, name):
+        if is_identifier_too_long(name):
+            raise database_api_exceptions.IdentifierTooLong(field='name')
+        return name
 
 
 def _force_canonical_type(representation, db_type):

--- a/mathesar/api/serializers/constraints.py
+++ b/mathesar/api/serializers/constraints.py
@@ -1,7 +1,10 @@
 from psycopg2.errors import DuplicateTable, UniqueViolation
 from rest_framework import serializers, status
 from sqlalchemy.exc import IntegrityError, ProgrammingError
+
 from db.constraints import utils as constraint_utils
+from db.identifiers import is_identifier_too_long
+from db.constraints.base import ForeignKeyConstraint, UniqueConstraint
 
 import mathesar.api.exceptions.database_exceptions.exceptions as database_api_exceptions
 import mathesar.api.exceptions.generic_exceptions.base_exceptions as base_api_exceptions
@@ -9,7 +12,6 @@ from mathesar.api.exceptions.validation_exceptions.exceptions import (
     ConstraintColumnEmptyAPIException, UnsupportedConstraintAPIException,
     InvalidTableName
 )
-from db.constraints.base import ForeignKeyConstraint, UniqueConstraint
 from mathesar.api.serializers.shared_serializers import (
     MathesarPolymorphicErrorMixin,
     ReadWritePolymorphicSerializerMappingMixin,
@@ -69,6 +71,11 @@ class BaseConstraintSerializer(serializers.ModelSerializer):
             else:
                 raise base_api_exceptions.MathesarAPIException(e)
         return constraint
+
+    def validate_name(self, name):
+        if is_identifier_too_long(name):
+            raise database_api_exceptions.IdentifierTooLong(field='name')
+        return name
 
 
 class ForeignKeyConstraintSerializer(BaseConstraintSerializer):

--- a/mathesar/api/serializers/schemas.py
+++ b/mathesar/api/serializers/schemas.py
@@ -1,11 +1,15 @@
 from rest_access_policy import PermittedSlugRelatedField
 from rest_framework import serializers
 
-from mathesar.api.db.permissions.table import TableAccessPolicy
+from db.identifiers import is_identifier_too_long
 
+from mathesar.api.db.permissions.table import TableAccessPolicy
 from mathesar.api.db.permissions.database import DatabaseAccessPolicy
 from mathesar.api.exceptions.mixins import MathesarErrorMessageMixin
 from mathesar.models.base import Database, Schema, Table
+from mathesar.api.exceptions.database_exceptions import (
+    exceptions as database_api_exceptions
+)
 
 
 class SchemaSerializer(MathesarErrorMessageMixin, serializers.HyperlinkedModelSerializer):
@@ -38,3 +42,8 @@ class SchemaSerializer(MathesarErrorMessageMixin, serializers.HyperlinkedModelSe
 
     def get_num_queries(self, obj):
         return sum(t.queries.count() for t in obj.tables.all())
+
+    def validate_name(self, name):
+        if is_identifier_too_long(name):
+            raise database_api_exceptions.IdentifierTooLong(field='name')
+        return name

--- a/mathesar/api/serializers/tables.py
+++ b/mathesar/api/serializers/tables.py
@@ -9,6 +9,10 @@ from db.tables.operations.create import DuplicateTable
 from db.columns.exceptions import InvalidTypeError
 from mathesar.api.db.permissions.schema import SchemaAccessPolicy
 from mathesar.api.db.permissions.table import TableAccessPolicy
+from db.identifiers import is_identifier_too_long
+from mathesar.api.exceptions.database_exceptions import (
+    exceptions as database_api_exceptions
+)
 
 from mathesar.api.exceptions.validation_exceptions.exceptions import (
     ColumnSizeMismatchAPIException, DistinctColumnRequiredAPIException,
@@ -175,6 +179,11 @@ class TableSerializer(MathesarErrorMessageMixin, serializers.ModelSerializer):
             except ValueError as e:
                 raise base_api_exceptions.ValueAPIException(e, status_code=status.HTTP_400_BAD_REQUEST)
         return instance
+
+    def validate_name(self, name):
+        if is_identifier_too_long(name):
+            raise database_api_exceptions.IdentifierTooLong(field='name')
+        return name
 
     def validate(self, data):
         if self.partial:

--- a/mathesar/imports/csv.py
+++ b/mathesar/imports/csv.py
@@ -1,8 +1,8 @@
 from io import TextIOWrapper
-import hashlib
 
 import clevercsv as csv
 
+from db.identifiers import truncate_if_necessary
 from db.tables.operations.alter import update_pk_sequence_to_latest
 from mathesar.database.base import create_mathesar_engine
 from mathesar.models.base import Table
@@ -175,7 +175,7 @@ def _process_column_names(column_names):
         in column_names
     )
     column_names = (
-        _truncate_if_necessary(column_name)
+        truncate_if_necessary(column_name)
         for column_name
         in column_names
     )
@@ -185,69 +185,6 @@ def _process_column_names(column_names):
         in enumerate(column_names)
     )
     return list(column_names)
-
-
-def _truncate_if_necessary(identifier):
-    """
-    Takes an identifier and returns it, truncating it, if it is too long. The truncated version
-    will end with a hash of the passed identifier, therefore column name collision should be very
-    rare.
-
-    Iteratively removes characters from the end of the identifier, until the resulting string, with
-    the suffix hash of the identifier appended, is short enough that it doesn't need to be truncated
-    anymore. Whitespace is trimmed from the truncated identifier before appending the suffix.
-    """
-    assert type(identifier) is str
-    if not _is_truncation_necessary(identifier):
-        return identifier
-    right_side = "-" + _get_truncation_hash(identifier)
-    identifier_length = len(identifier)
-    assert len(right_side) < identifier_length  # Sanity check
-    range_of_num_of_chars_to_remove = range(1, identifier_length)
-    for num_of_chars_to_remove in range_of_num_of_chars_to_remove:
-        left_side = identifier[:num_of_chars_to_remove * -1]
-        left_side = left_side.rstrip()
-        truncated_identifier = left_side + right_side
-        if not _is_truncation_necessary(truncated_identifier):
-            return truncated_identifier
-    raise Exception(
-        "Acceptable truncation not found; should never happen."
-    )
-
-
-def _is_truncation_necessary(identifier):
-    postgres_identifier_size_limit = 63
-    size = _get_size_of_identifier_in_bytes(identifier)
-    return size > postgres_identifier_size_limit
-
-
-def _get_truncation_hash(identifier):
-    """
-    Produces an 8-character string hash of the passed identifier.
-
-    Using hash function blake2s, because it seems fairly recommended and it seems to be better
-    suited for shorter digests than blake2b. We want short digests to not take up too much of the
-    truncated identifier in whose construction this will be used.
-    """
-    h = hashlib.blake2s(digest_size=4)
-    bytes = _get_identifier_in_bytes(identifier)
-    h.update(bytes)
-    return h.hexdigest()
-
-
-def _get_size_of_identifier_in_bytes(s):
-    bytes = _get_identifier_in_bytes(s)
-    return len(bytes)
-
-
-def _get_identifier_in_bytes(s):
-    """
-    Afaict, following Postgres doc [0] says that UTF-8 supports all languages; therefore, different
-    server locale configurations should not break this.
-
-    [0] https://www.postgresql.org/docs/13/multibyte.html
-    """
-    return s.encode('utf-8')
 
 
 def create_table_from_csv(data_file, name, schema, comment=None):

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -9,6 +9,9 @@ from db.types.base import PostgresType, MathesarCustomType
 
 from mathesar.api.exceptions.error_codes import ErrorCodes
 from mathesar.tests.api.test_table_api import check_columns_response
+from mathesar.api.exceptions.database_exceptions import (
+    exceptions as database_api_exceptions
+)
 
 
 def test_column_list(column_test_table, client):
@@ -151,6 +154,22 @@ def test_column_create(column_test_table, client):
     assert actual_new_col["name"] == name
     assert actual_new_col["type"] == db_type.id
     assert actual_new_col["default"] is None
+
+
+def test_column_create_with_long_column_name(column_test_table, client):
+    very_long_string = ''.join(map(str, range(50)))
+    name = 'very_long_identifier_' + very_long_string
+    db_type = PostgresType.NUMERIC
+    data = {
+        "name": name,
+        "type": db_type.id,
+    }
+    response = client.post(
+        f"/api/db/v0/tables/{column_test_table.id}/columns/",
+        data=data,
+    )
+    assert response.status_code == 400
+    assert response.json()[0]['code'] == database_api_exceptions.IdentifierTooLong.error_code
 
 
 @pytest.mark.parametrize('client_name, expected_status_code', write_client_with_different_roles)

--- a/mathesar/tests/api/test_schema_api.py
+++ b/mathesar/tests/api/test_schema_api.py
@@ -293,6 +293,23 @@ def test_schema_create_by_superuser(client, FUN_create_dj_db, MOD_engine_cache):
     )
 
 
+def test_schema_create_by_superuser_too_long_name(client, FUN_create_dj_db):
+    db_name = "some_db1"
+    FUN_create_dj_db(db_name)
+    schema_count_before = Schema.objects.count()
+    very_long_string = ''.join(map(str, range(50)))
+    schema_name = 'very_long_identifier_' + very_long_string
+    data = {
+        'name': schema_name,
+        'database': db_name
+    }
+    response = client.post('/api/db/v0/schemas/', data=data)
+    assert response.status_code == 400
+    assert response.json()[0]['code'] == ErrorCodes.IdentifierTooLong.value
+    schema_count_after = Schema.objects.count()
+    assert schema_count_after == schema_count_before
+
+
 def test_schema_create_by_db_manager(client_bob, user_bob, FUN_create_dj_db, get_uid):
     db_name = get_uid()
     role = "manager"

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -714,6 +714,18 @@ def test_table_create_with_same_name(client, schema):
     assert response_error[0]['message'] == f'Relation {table_name} already exists in schema {schema.id}'
 
 
+def test_table_create_with_too_long_name(client, schema):
+    very_long_string = ''.join(map(str, range(50)))
+    table_name = 'very_long_identifier_' + very_long_string
+    body = {
+        'name': table_name,
+        'schema': schema.id,
+    }
+    response = client.post('/api/db/v0/tables/', body)
+    assert response.status_code == 400
+    assert response.json()[0]['code'] == ErrorCodes.IdentifierTooLong.value
+
+
 def test_table_create_with_existing_id_col(client, existing_id_col_table_datafile, schema, engine):
     table_name = "Table 1"
     response, response_table, table = _create_table(


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2634

Depends on #2659
<!-- Concisely describe what the pull request does. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
