### PR TITLE
Don't re-fetch records after deleting rows

### DIFF
--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -344,38 +344,30 @@ export class RecordsData {
       });
   }
 
-  async fetch(
-    retainExistingRows = false,
-  ): Promise<TableRecordsData | undefined> {
+  async fetch(): Promise<TableRecordsData | undefined> {
     this.promise?.cancel();
     const { offset } = get(this.meta.pagination);
 
     this.savedRecordRowsWithGroupHeaders.update((existingData) => {
       let data = [...existingData];
       data.length = Math.min(data.length, get(this.meta.pagination).size);
-
       let index = -1;
-      data = data.map((entry) => {
+      data = data.map(() => {
         index += 1;
-        if (!retainExistingRows || !entry) {
-          return {
-            state: 'loading',
-            identifier: generateRowIdentifier('dummy', offset, index),
-            rowIndex: index,
-            record: {},
-          };
-        }
-        return entry;
+        return {
+          state: 'loading',
+          identifier: generateRowIdentifier('dummy', offset, index),
+          rowIndex: index,
+          record: {},
+        };
       });
-
       return data;
     });
+
     this.error.set(undefined);
-    if (!retainExistingRows) {
-      this.state.set(States.Loading);
-      this.newRecords.set([]);
-      this.meta.clearAllStatusesAndErrors();
-    }
+    this.state.set(States.Loading);
+    this.newRecords.set([]);
+    this.meta.clearAllStatusesAndErrors();
 
     try {
       const params = get(this.meta.recordsRequestParamsData);

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -472,7 +472,6 @@ export class RecordsData {
           }),
       );
       await Promise.all(promises);
-      await this.fetch(true);
     }
 
     const savedRecords = get(this.savedRecords);


### PR DESCRIPTION
Fixes #2463

## Context

- We have a section at the bottom of the table page for newly-added records.
- When the user hits the "Refresh" button at the bottom of the sheet, we re-fetch all the records in the table, re-incorporating newly-added records into normal part of the table.

## Before this PR

- After deleting a record, we re-fetch all the records in the table.
- But we _don't_ delete records from the newly-added records section. In most cases this is fine.
- But if the newly-added records section contains any records (that weren't deleted), then the sheet ends up with **duplicate** records. The keyed for-each block that we're using causes Svelte to throw an error in this case. 

## Suggested fix by Pavish

@pavish [said](https://github.com/centerofci/mathesar/issues/2463#issuecomment-1460278505):

> The removal from newRecords needs to happen before fetching the latest data.

If I understand you correctly, it sounds like you're suggesting that we perform the same actions, but in a different sequence. I don't think that will work. I'd like to take this a different direction

## After this PR

- After deleting a record, **we don't re-fetch** the records in the table.

## Thoughts

- Skipping the re-fetch solves the problem in a different way, and I like this better because it's simpler.

- It also eliminates the need for the `retainExistingRows` param, which has always seemed fishy to me.

- If we really do want to re-fetch, it's worth considering where the newly-added records _should_ go. Should they stay in the newly-added section? If so, why? If we really want to keep them in the newly-added section, then we'll need to look through the newly _fetched_ records, removing the duplicates from _there_. It doesn't seem worth it to me.

- Consider this UX situation...

    1. I'm doing some data clean up. I want to look through a bunch of rows manually and make some adjustments, editing cell values as I go.
    1. To make my work resumable (so I can pause without losing my place), I sort the sheet by a sensible column.
    1. Along the way, I make some edits to cell values _within that column that I sorted on_.
    1. Then I delete a row.

    Let's step back and consider what most users would expect at this point. While I was making all those edits to the data within my sorting column, none of the rows were re-sorted. I could continue about my work incrementally. If I delete a row, I would not expect anything to re-sort. If we re-fetch, we re-sort. This is part of why I don't think we should re-fetch. I don't think users will expect us to re-fetch.

- If there is a valid reason for re-fetching after deleting, then I'm open to closing this PR and making this fix by either:

    - _Fully_ re-fetching (including wiping the newly-added section)

    - Or removing newly added rows from the set of re-fetched rows (but this would be my least favorite approach)


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

