### PR TITLE
added permissionform file for issue Show readonly permissions in user edit…

### DIFF
--- a/mathesar_ui/src/pages/admin-users/EditUserPage.svelte
+++ b/mathesar_ui/src/pages/admin-users/EditUserPage.svelte
@@ -10,6 +10,7 @@
   import {
     PasswordChangeForm,
     UserDetailsForm,
+    UserPermissionForm,
   } from '@mathesar/systems/users-and-permissions';
   import type { UserModel } from '@mathesar/stores/users';
   import FormBox from './FormBox.svelte';
@@ -60,6 +61,9 @@
     </FormBox>
     <FormBox>
       <PasswordChangeForm {userId} />
+    </FormBox> 
+    <FormBox>
+      <UserPermissionForm {userId}/>
     </FormBox>
     {#if !userIsLoggedInUser}
       <FormBox>

--- a/mathesar_ui/src/systems/users-and-permissions/UserPermissionForm.svelte
+++ b/mathesar_ui/src/systems/users-and-permissions/UserPermissionForm.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { Help } from '@mathesar-component-library';
+  import WarningBox from '@mathesar/components/message-boxes/WarningBox.svelte';
+  import type { UserModel } from '@mathesar/stores/users';
+  import { getSchemasStoreForDB } from '@mathesar/stores/schemas';
+  import { getUsersStoreFromContext } from '@mathesar/stores/users'; 
+  import type { Database, SchemaEntry } from '@mathesar/AppTypes';
+
+  export let database : Database;
+  export let schema : SchemaEntry;
+  export let userId: UserModel['id']
+  const usersStore = getUsersStoreFromContext();
+  $: user = usersStore?.getUserDetails(userId);
+  export let userWithRole : UserModel['schemaRoles'];
+  $: schemaStore = getSchemasStoreForDB(user?.databaseId);
+</script>
+
+<div class="user-permission-form">
+  <div>
+    <span>Permissions</span>
+    <Help>User Permissions</Help>
+  </div>
+  {#if !userWithRole }
+    <div class="user-without-permission">
+      <WarningBox fullWidth>
+        Please navigate to the appropriate database or schema in order to grant
+        access to the user.
+      </WarningBox>
+    </div>
+  {:else}
+  <div>
+    {database.name} / {schmema.name}
+  </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .user-permission-form {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: var(--size-large);
+  }
+  .user-without-permission {
+    margin-left: var(--size-large);
+  }
+</style>

--- a/mathesar_ui/src/systems/users-and-permissions/index.ts
+++ b/mathesar_ui/src/systems/users-and-permissions/index.ts
@@ -1,4 +1,5 @@
 export { default as UserDetailsForm } from './UserDetailsForm.svelte';
 export { default as PasswordChangeForm } from './PasswordChangeForm.svelte';
+export { default as UserPermissionForm } from './UserPermissionForm.svelte';
 export { default as AccessControlView } from './AccessControlView.svelte';
 export { getUserTypeInfoFromUserModel } from './utils';


### PR DESCRIPTION
… page

<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2556

<!-- Concisely describe what the pull request does. -->
This Pull Request has partially solved the issue. So, making a draft PR.
**My workflow**
1] I have created a `UserPermissionForm.svelte` file in @mathesar/systems/users-and-permissions and used it as a component in the `EditUserPage.svelte`  file.
2] In UserPermissionForm, I have made a condition in which if the user having role will show the schema name with their role, and if not any permission, then a warning message will show up with `Please navigate to the appropriate database or schema in order to grant access to the user.`
3] For this, First, I import `Database` and `SchemaEntry` from @mathesar/AppTypes and make props with this, and for the user role I have import `UserModel` from @mathesar/stores/users, but when I try to access, then it shows me undefined. Like I have tried to access schema name as {schema.name} but an error arises as "cannot read properties of undefined (reading 'name')"
4] For warning messages, I use the `WarningBox` component that import it from @mathesar/components/message-boxes/WarningBox.svelte. This is working fine. 



**Screenshots**
Current work done 

![image](https://user-images.githubusercontent.com/95216822/224801475-16c87c35-4d9c-4090-be08-cd751d592c69.png)

Error-

![image](https://user-images.githubusercontent.com/95216822/224801893-d215fbd8-9e82-441f-842c-1912034dc2b7.png)

<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
