### PR TITLE
Allow serializing unicode into URL

### DIFF
--- a/mathesar_ui/src/utils/Url64.ts
+++ b/mathesar_ui/src/utils/Url64.ts
@@ -1,17 +1,26 @@
 /**
  * Encode a string as a URL-safe base64 string.
  *
- * The resulting string won't have any characters which require URL encoding.
- * We change `+` to `-` and `/` to `_`. We remove the padding characters `=`
+ * The resulting string won't have any characters which require URL encoding. We
+ * change `+` to `-` and `/` to `_`. We remove the padding characters `=`
  * altogether because atob only needs them when inputs are concatenated.
+ *
+ * TODO:
+ *
+ * - Refactor this code to remove use of deprecated function `escape` and
+ *   `unescape`.
+ * - See: https://developer.mozilla.org/en-US/docs/Glossary/Base64
+ * - Consider using a 3rd party library. Maybe `base64-js`, `base64url` or
+ *   `utf8`.
  */
 export default class Url64 {
   static encode(s: string): string {
-    const base64 = btoa(s);
+    const base64 = btoa(unescape(encodeURIComponent(s)));
     return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   }
 
   static decode(s: string): string {
-    return atob(s.replace(/-/g, '+').replace(/_/g, '/'));
+    const base64 = s.replace(/-/g, '+').replace(/_/g, '/');
+    return decodeURIComponent(escape(atob(base64)));
   }
 }


### PR DESCRIPTION
Fixes #2666

@pavish [said](https://github.com/centerofci/mathesar/issues/2666#issuecomment-1465098983)

> For 0.1.1, I'd like to remove base64 encoding of the URL entirely. I don't see a good enough reason to have it, the change in url length isn't a major concern compared to the issues we need to handle to perform base64 encoding/decoding in JS.

@pavish what do you think about the approach in this PR?

One benefit of this approach is that it won't break people's workflows who are already bookmarking these URLs outside of Mathesar. Granted, there may not be that many cases like that, given our early stage. But I do think the base64 encoding is nice, and with this approach we wouldn't need to change it _again_ when/if we want to add base64 encoding back. The URL looks a lot nicer with it and it's easier to copy/paste

I think the main argument against the code in this PR is that it uses `escape` and `unescape` which are deprecated. But realistically, I can't imagine any browsers removing those functions any time soon. They're still supported everywhere.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

