### PR TITLE
Fixes Record page form when PK is not an integer

### DIFF
--- a/mathesar_ui/src/components/breadcrumb/BreadcrumbItem.svelte
+++ b/mathesar_ui/src/components/breadcrumb/BreadcrumbItem.svelte
@@ -56,7 +56,7 @@
         item.database.name,
         item.schema.id,
         item.table.id,
-        item.record.id,
+        item.record.pk,
       )}
     >
       <NameWithIcon icon={iconRecord}>

--- a/mathesar_ui/src/components/breadcrumb/breadcrumbTypes.ts
+++ b/mathesar_ui/src/components/breadcrumb/breadcrumbTypes.ts
@@ -37,7 +37,7 @@ export interface BreadcrumbItemRecord {
   schema: SchemaEntry;
   table: TableEntry;
   record: {
-    id: number;
+    pk: string;
     summary: string;
   };
 }

--- a/mathesar_ui/src/pages/record/RecordPageContent.svelte
+++ b/mathesar_ui/src/pages/record/RecordPageContent.svelte
@@ -26,7 +26,7 @@
 
   $: table = $currentTable as TableEntry;
   $: ({ processedColumns } = tableStructure);
-  $: ({ recordId, summary, fieldValues } = record);
+  $: ({ recordPk, summary, fieldValues } = record);
   $: fieldPropsObjects = [...$processedColumns.values()].map((c) => ({
     processedColumn: c,
     field: optionalField($fieldValues.get(c.id)),
@@ -83,7 +83,7 @@
   {#await getJoinableTablesResult(table.id)}
     <RecordPageLoadingSpinner />
   {:then joinableTablesResult}
-    <Widgets {joinableTablesResult} {recordId} recordSummary={$summary} />
+    <Widgets {joinableTablesResult} {recordPk} recordSummary={$summary} />
   {/await}
 </div>
 

--- a/mathesar_ui/src/pages/record/RecordStore.ts
+++ b/mathesar_ui/src/pages/record/RecordStore.ts
@@ -28,14 +28,14 @@ export default class RecordStore {
 
   table: TableEntry;
 
-  recordId: number;
+  recordPk: string;
 
   private url: string;
 
-  constructor({ table, recordId }: { table: TableEntry; recordId: number }) {
+  constructor({ table, recordPk }: { table: TableEntry; recordPk: string }) {
     this.table = table;
-    this.recordId = recordId;
-    this.url = `/api/db/v0/tables/${this.table.id}/records/${this.recordId}/`;
+    this.recordPk = recordPk;
+    this.url = `/api/db/v0/tables/${this.table.id}/records/${this.recordPk}/`;
     const { template } = this.table.settings.preview_settings;
     this.summary = derived(
       [this.fieldValues, this.recordSummaries],

--- a/mathesar_ui/src/pages/record/TableWidget.svelte
+++ b/mathesar_ui/src/pages/record/TableWidget.svelte
@@ -21,7 +21,7 @@
     pagination: new Pagination({ size: 10 }),
   });
 
-  export let recordId: number;
+  export let recordPk: string;
   export let table: TableEntry;
   export let fkColumn: Pick<Column, 'id' | 'name'>;
 
@@ -30,7 +30,7 @@
     id: table.id,
     abstractTypesMap,
     meta,
-    contextualFilters: new Map([[fkColumn.id, recordId]]),
+    contextualFilters: new Map([[fkColumn.id, recordPk]]),
     table,
   });
   $: tabularDataStore.set(tabularData);

--- a/mathesar_ui/src/pages/record/Widgets.svelte
+++ b/mathesar_ui/src/pages/record/Widgets.svelte
@@ -7,7 +7,7 @@
   import { currentTable } from '@mathesar/stores/tables';
   import TableWidget from './TableWidget.svelte';
 
-  export let recordId: number;
+  export let recordPk: string;
   export let recordSummary: string;
   export let joinableTablesResult: JoinableTablesResult;
 
@@ -56,7 +56,7 @@
     <div class="widgets">
       {#each tableWidgetInputs as { table, fkColumn } (`${table.id}-${fkColumn.id}`)}
         <section class="table-widget-positioner">
-          <TableWidget {recordId} table={currTable} {fkColumn} />
+          <TableWidget {recordPk} table={currTable} {fkColumn} />
         </section>
       {/each}
     </div>

--- a/mathesar_ui/src/routes/RecordPageRoute.svelte
+++ b/mathesar_ui/src/routes/RecordPageRoute.svelte
@@ -8,9 +8,9 @@
   export let database: Database;
   export let schema: SchemaEntry;
   export let table: TableEntry;
-  export let recordId: number;
+  export let recordPk: string;
 
-  $: record = new RecordStore({ table, recordId });
+  $: record = new RecordStore({ table, recordPk });
   $: ({ summary, fetchRequest } = record);
 </script>
 
@@ -22,7 +22,7 @@
       schema,
       table,
       record: {
-        id: recordId,
+        pk: recordPk,
         summary: $summary,
       },
     }}

--- a/mathesar_ui/src/routes/TableRoute.svelte
+++ b/mathesar_ui/src/routes/TableRoute.svelte
@@ -30,12 +30,12 @@
     <TablePage {table} />
   </Route>
 
-  <Route path="/:recordId" let:meta>
+  <Route path="/:recordPk" let:meta>
     <RecordPageRoute
       {database}
       {schema}
       {table}
-      recordId={parseInt(meta.params.recordId, 10)}
+      recordPk={String(meta.params.recordPk)}
     />
   </Route>
 {:else}


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2715 

**Technical details**
* The Record page assumes the primary key would always be a `number`, which will break the form when the PK is a non-integer value.
* This PR updates the code to consider the PK to be a string.
* This is inline with our TableData store which considers the PK to be a string while making requests, and the API also only accepts it as a string, as it is part of the url path.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
