### PR TITLE
Fix bug #2701

### DIFF
--- a/mathesar_ui/src/api/utils/requestUtils.ts
+++ b/mathesar_ui/src/api/utils/requestUtils.ts
@@ -166,6 +166,10 @@ export function deleteAPI<T>(url: string): CancellablePromise<T> {
   return sendXHRRequest('DELETE', url);
 }
 
+export function deletebulkAPI<T>(url: string, data: unknown): CancellablePromise<T> {
+  return sendXHRRequest('DELETE', url, data);
+}
+
 export function uploadFile<T>(
   url: string,
   formData: FormData,

--- a/mathesar_ui/src/stores/table-data/records.ts
+++ b/mathesar_ui/src/stores/table-data/records.ts
@@ -12,6 +12,7 @@ import {
   deleteAPI,
   patchAPI,
   postAPI,
+  deletebulkAPI,
 } from '@mathesar/api/utils/requestUtils';
 import {
   isDefinedNonNullable,
@@ -460,20 +461,25 @@ export class RecordsData {
     }
 
     let shouldReFetchRecords = successRowKeys.size > 0;
+    
     if (primaryKeysOfSavedRows.length > 0) {
-      // TODO: Convert this to single request
-      const promises = primaryKeysOfSavedRows.map((pk) =>
-        deleteAPI<RowKey>(`${this.url}${pk}/`)
-          .then(() => {
-            successRowKeys.add(pk);
-            return successRowKeys;
-          })
-          .catch((error: unknown) => {
-            failures.set(pk, getErrorMessage(error));
-            return failures;
-          }),
-      );
-      await Promise.all(promises);
+      // Converted delete to single bulk delete request as per https://github.com/centerofci/mathesar/issues/2701
+      const pks:Number[]=[];
+      primaryKeysOfSavedRows.map(n=>{
+        pks.push(Number(n));
+      })
+      //unable to use this.url since other urls use api/db/ over api/ui/
+      const bulkDeleteURL=`/api/ui/v0/tables/${this.parentId}/records/delete/`;
+      const bulkDeletePromise=deletebulkAPI<RowKey>(`${bulkDeleteURL}`,
+        {'pks':pks})
+        .then(() => {
+          return primaryKeysOfSavedRows
+        })
+        .catch((error: unknown) => {
+          failures.set(primaryKeysOfSavedRows.join(','), getErrorMessage(error));
+          return failures;
+        })
+      await bulkDeletePromise;
       shouldReFetchRecords = true;
     }
 


### PR DESCRIPTION
Call new endpoint for bulk delete

Fixes #2701 
 

**Technical details**
I had to intentionally created new variable to store delete url. 
Line num: 472  const bulkDeleteURL=`/api/ui/v0/tables/${this.parentId}/records/delete/`;
Since changing this.url may have side effects on other requests

**Screenshots**
![image](https://user-images.githubusercontent.com/16798480/227756041-7d10c718-d6d3-42bb-9441-7fe019696f24.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ x] My pull request targets the `develop` branch of the repository
- [ x] My commit messages follow [best practices][best_practices].
- [ x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
