### PR TITLE
Fixes #2736: database page table and exploration count update without reloading 

### DIFF
--- a/mathesar_ui/src/pages/database/SchemaRow.svelte
+++ b/mathesar_ui/src/pages/database/SchemaRow.svelte
@@ -14,12 +14,9 @@
     iconNotEditable,
   } from '@mathesar/icons';
   import { getSchemaPageUrl } from '@mathesar/routes/urls';
-  import SchemaConstituentCounts from './SchemaConstituentCounts.svelte';
-
-  
   import { queries } from '@mathesar/stores/queries';
   import { tables } from '@mathesar/stores/tables';
-  
+  import SchemaConstituentCounts from './SchemaConstituentCounts.svelte';
 
   const dispatch = createEventDispatcher();
 
@@ -33,7 +30,6 @@
   $: isDefault = schema.name === 'public';
   $: isLocked = schema.name === 'public';
 
-  
   $: tablesMap = $tables.data;
   $: explorationsMap = $queries.data;
   $: schema.num_tables = tablesMap.size;

--- a/mathesar_ui/src/pages/database/SchemaRow.svelte
+++ b/mathesar_ui/src/pages/database/SchemaRow.svelte
@@ -16,6 +16,14 @@
   import { getSchemaPageUrl } from '@mathesar/routes/urls';
   import SchemaConstituentCounts from './SchemaConstituentCounts.svelte';
 
+  
+  import { queries } from '@mathesar/stores/queries';
+  import {
+    tables as tablesStore,
+    importVerifiedTables as importVerifiedTablesStore,
+  } from '@mathesar/stores/tables';
+  
+
   const dispatch = createEventDispatcher();
 
   export let database: Database;
@@ -27,6 +35,12 @@
   $: href = getSchemaPageUrl(database.name, schema.id);
   $: isDefault = schema.name === 'public';
   $: isLocked = schema.name === 'public';
+
+  
+  $: tablesMap = $tablesStore.data;
+  $: explorationsMap = $queries.data;
+  $: schema.num_tables = tablesMap.size;
+  $: schema.num_queries = explorationsMap.size;
 </script>
 
 <div class="schema-row" class:hover={isHovered} class:is-locked={isLocked}>

--- a/mathesar_ui/src/pages/database/SchemaRow.svelte
+++ b/mathesar_ui/src/pages/database/SchemaRow.svelte
@@ -18,10 +18,7 @@
 
   
   import { queries } from '@mathesar/stores/queries';
-  import {
-    tables as tablesStore,
-    importVerifiedTables as importVerifiedTablesStore,
-  } from '@mathesar/stores/tables';
+  import { tables } from '@mathesar/stores/tables';
   
 
   const dispatch = createEventDispatcher();
@@ -37,7 +34,7 @@
   $: isLocked = schema.name === 'public';
 
   
-  $: tablesMap = $tablesStore.data;
+  $: tablesMap = $tables.data;
   $: explorationsMap = $queries.data;
   $: schema.num_tables = tablesMap.size;
   $: schema.num_queries = explorationsMap.size;


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->

Fixes #2736

<!-- Concisely describe what the pull request does. -->

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
To make the database page reflect changes, it is necessary to access the database to obtain the count of tables and queries. Then we need to make the two variables reactive. This will enable the UI to dynamically update as the underlying database changes.


**screencast**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

![mathesar_tables _ public _ Mathesar - Google Chrome 2023-03-30 22-52-20](https://user-images.githubusercontent.com/40593938/228967733-e91b7108-17d3-4fcf-92af-957b0f7119ce.gif)




## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>