### PR TITLE
Fixes #2764: Add filter to disallow changing column data type 

### DIFF
--- a/mathesar_ui/src/components/abstract-type-control/AbstractTypeSelector.svelte
+++ b/mathesar_ui/src/components/abstract-type-control/AbstractTypeSelector.svelte
@@ -21,11 +21,12 @@
   export let selectedAbstractType: AbstractType;
   export let disabled = false;
 
+  // // Exclude 'jsonlist' and 'map' types, as existing columns cannot be changed to these types.
   $: allowedTypeConversions = getAllowedAbstractTypesForDbTypeAndItsTargetTypes(
     column.type,
     column.valid_target_types ?? [],
     $currentDbAbstractTypes.data,
-  );
+  ).filter((item) => !['jsonlist', 'map'].includes(item.identifier));
 
   function selectAbstractType(
     newAbstractType: ColumnWithAbstractType['abstractType'] | undefined,


### PR DESCRIPTION
Previously, users were able to change the data type of existing columns to a JSON list or map, which caused issues with the database schema. This commit adds a filter to disallow these changes, ensuring that the schema remains consistent and preventing data corruption. The filter is applied when retrieving allowed abstract types for a database type and its target types, and excludes the 'jsonlist' and 'map' types from the list of valid options.

Fixes #2764

It prevents the user to change the data type of the column to JSONList and Map as they do not have any proper UI at the moment.
**Technical details**
- I added a filter so that user would not be able to change the type of the column if it is JSONList or Map.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
