### PR TITLE
add truncate component in Record Selector table cells

### DIFF
--- a/mathesar_ui/src/components/cell-fabric/data-types/components/SteppedInputCell.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/SteppedInputCell.svelte
@@ -5,6 +5,7 @@
     compareWholeValues,
     getValueComparisonOutcome,
     splitMatchParts,
+    Truncate,
   } from '@mathesar-component-library';
   import CellValue from '@mathesar/components/CellValue.svelte';
   import CellWrapper from './CellWrapper.svelte';
@@ -170,12 +171,15 @@
   {:else}
     <div
       class="content"
-      class:nowrap={!isActive && !isIndependentOfSheet}
-      class:truncate={isActive && multiLineTruncate && !isIndependentOfSheet}
     >
+    <Truncate 
+      lines = {isActive && multiLineTruncate ? 2 : 1}
+      passthrough = {isIndependentOfSheet}
+      >
       <slot name="content" {value} {formatValue} {matchParts}>
         <CellValue value={formattedValue} {matchParts} />
       </slot>
+    </Truncate>
     </div>
   {/if}
 </CellWrapper>

--- a/mathesar_ui/src/components/cell-fabric/data-types/components/SteppedInputCell.svelte
+++ b/mathesar_ui/src/components/cell-fabric/data-types/components/SteppedInputCell.svelte
@@ -169,17 +169,15 @@
   {#if isEditMode}
     <slot {handleInputBlur} {handleInputKeydown} />
   {:else}
-    <div
-      class="content"
-    >
-    <Truncate 
-      lines = {isActive && multiLineTruncate ? 2 : 1}
-      passthrough = {isIndependentOfSheet}
+    <div class="content">
+      <Truncate
+        lines={isActive && multiLineTruncate ? 2 : 1}
+        passthrough={isIndependentOfSheet}
       >
-      <slot name="content" {value} {formatValue} {matchParts}>
-        <CellValue value={formattedValue} {matchParts} />
-      </slot>
-    </Truncate>
+        <slot name="content" {value} {formatValue} {matchParts}>
+          <CellValue value={formattedValue} {matchParts} />
+        </slot>
+      </Truncate>
     </div>
   {/if}
 </CellWrapper>


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2345

<!-- Concisely describe what the pull request does. -->
This pull request will add the feature of truncate components in table cells.
Like this way-

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
Hovering over a cell (column 3 and row 28), it displays the popover full cell contents-
![image](https://user-images.githubusercontent.com/95216822/229763470-8e7152d7-4e9b-4257-b6c0-b243910aa8ee.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
