### PR TITLE
Avoid text selection when selecting cells in safari

### DIFF
--- a/mathesar_ui/src/component-library/tabs/TabContainer.scss
+++ b/mathesar_ui/src/component-library/tabs/TabContainer.scss
@@ -19,6 +19,7 @@
       outline: none;
       position: relative;
       user-select: none;
+      -webkit-user-select: none; /* Safari */
       list-style: none;
       overflow: hidden;
       border-radius: 2px 2px 0px 0px;

--- a/mathesar_ui/src/components/sheet/SheetHeader.svelte
+++ b/mathesar_ui/src/components/sheet/SheetHeader.svelte
@@ -57,6 +57,7 @@
     flex-shrink: 0;
     border-bottom: 1px solid var(--slate-200);
     user-select: none;
+    -webkit-user-select: none; /* Safari */
     overflow: hidden;
 
     > div {

--- a/mathesar_ui/src/systems/data-explorer/result-pane/ResultRowCell.svelte
+++ b/mathesar_ui/src/systems/data-explorer/result-pane/ResultRowCell.svelte
@@ -105,6 +105,7 @@
 <style lang="scss">
   .cell {
     user-select: none;
+    -webkit-user-select: none; /* Safari */
     background: var(--cell-bg-color-base);
 
     &.is-active {

--- a/mathesar_ui/src/systems/table-view/row/Row.svelte
+++ b/mathesar_ui/src/systems/table-view/row/Row.svelte
@@ -145,6 +145,9 @@
 
 <style lang="scss">
   .row {
+    user-select: none;
+    -webkit-user-select: none;
+
     &.processing {
       pointer-events: none;
     }

--- a/mathesar_ui/src/systems/table-view/row/RowCell.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowCell.svelte
@@ -217,6 +217,7 @@
 <style lang="scss">
   .editable-cell.cell {
     user-select: none;
+    -webkit-user-select: none; /* Safari */
     background: var(--cell-bg-color-base);
     &.is-active {
       z-index: var(--z-index__sheet__active-cell);

--- a/mathesar_ui/src/systems/table-view/row/RowControl.svelte
+++ b/mathesar_ui/src/systems/table-view/row/RowControl.svelte
@@ -64,5 +64,6 @@
     * multi-row selection
     */
     user-select: none;
+    -webkit-user-select: none; /* Safari */
   }
 </style>


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2806 
<!-- Concisely describe what the pull request does. -->

**Technical details**
1. `user-select: none` does not work in Safari, it needs `-webkit-user-select: none`. [caniuse](https://caniuse.com/mdn-css_properties_user-select)
2. Safari has a different way to highlight blue color for the selected elements. It also highlights the parent element when selecting the texts. Hence the `.row` also needed to disable the selection. 

**Screenshots**

https://user-images.githubusercontent.com/11032856/234066842-ca6ec7ed-adc5-4a0b-bbb8-7c968c59b5ac.mov



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
