### PR TITLE
Fix regression displaying record page table widget

### DIFF
--- a/mathesar_ui/src/systems/table-view/TableView.svelte
+++ b/mathesar_ui/src/systems/table-view/TableView.svelte
@@ -105,7 +105,7 @@
 </script>
 
 <div class="table-view">
-  <WithTableInspector {showTableInspector}>
+  <WithTableInspector {context} {showTableInspector}>
     <div class="sheet-area" on:click={checkAndReinstateFocusOnActiveCell}>
       {#if $processedColumns.size}
         <Sheet

--- a/mathesar_ui/src/systems/table-view/table-inspector/WithTableInspector.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/WithTableInspector.svelte
@@ -3,15 +3,24 @@
   import { tableInspectorWidth } from '@mathesar/stores/localStorage';
   import TableInspector from './TableInspector.svelte';
 
+  export let context: 'page' | 'widget';
   export let showTableInspector: boolean;
 </script>
 
-<WithPanel
-  showPanel={showTableInspector}
-  bind:sizePx={$tableInspectorWidth}
-  minSizePx={200}
-  maxSizePx={600}
->
+{#if context === 'widget'}
+  <!--
+    Don't use `WithPanel` to display the table widget because `WithPanel` uses
+    `height:100%;` but the table widget needs to define its own height.
+  -->
   <slot />
-  <TableInspector slot="panel" />
-</WithPanel>
+{:else}
+  <WithPanel
+    showPanel={showTableInspector}
+    bind:sizePx={$tableInspectorWidth}
+    minSizePx={200}
+    maxSizePx={600}
+  >
+    <slot />
+    <TableInspector slot="panel" />
+  </WithPanel>
+{/if}


### PR DESCRIPTION
Fixes #2855

## Before

![image](https://user-images.githubusercontent.com/42411/235533900-6aab6298-3c42-439b-89c1-62730893cda8.png)

## After

![image](https://user-images.githubusercontent.com/42411/235533763-aee57aff-a007-4c3a-945b-34ec9ef93f67.png)


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


