### PR TITLE
Improve TSV serialization when copying cells

### DIFF
--- a/mathesar_ui/package-lock.json
+++ b/mathesar_ui/package-lock.json
@@ -11045,6 +11045,15 @@
       "integrity": "sha512-1TcL7YDYCtnHmLhTWbum+IIwLlvpaHoEKS2KNIngEwLzwgDeHaebaEHHbQp8IqzNQ9IYiboLKUjAf7MZqG63+w==",
       "dev": true
     },
+    "@types/papaparse": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.7.tgz",
+      "integrity": "sha512-f2HKmlnPdCvS0WI33WtCs5GD7X1cxzzS/aduaxSu3I7TbhWlENjSPs6z5TaB9K0J+BH1jbmqTaM+ja5puis4wg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -20242,6 +20251,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
+    },
+    "papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "parallel-transform": {
       "version": "1.2.0",

--- a/mathesar_ui/package.json
+++ b/mathesar_ui/package.json
@@ -27,6 +27,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@tsconfig/svelte": "^3.0.0",
     "@types/js-cookie": "^3.0.2",
+    "@types/papaparse": "^5.3.7",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
     "@vitejs/plugin-legacy": "^2.2.0",
@@ -64,6 +65,7 @@
     "flatpickr": "^4.6.13",
     "iter-tools": "^7.4.0",
     "js-cookie": "^3.0.1",
+    "papaparse": "^5.4.1",
     "perfect-scrollbar": "^1.5.5"
   }
 }


### PR DESCRIPTION
Fixes #2811

## Notes

This PR adds the [PapaParse](https://github.com/mholt/PapaParse) library and uses it to serialize cell data to a TSV string when copying cells to the clipboard.


## Before/after

- Set up four cells with the following content. Then copy them and [inspect](https://evercoder.github.io/clipboard-inspector/) your clipboard

    | a | b |
    | -- | -- |
    | apple<br>banana, orange | cherry⏩tomato |
    | "asparagus<br>potato" | "broccoli"<br>carrot |

    (with the ⏩ emoji representing a tab character)

- **Before**

    The clipboard contents are:

    ```
    apple
    banana, orange⏩cherry⏩tomato
    "asparagus
    potato"⏩"broccoli"
    carrot
    ```

    Pasting into LibreOffice Calc or Google Sheets leads to mangled data.

- **After**

    The clipboard contents are:

    ```
    "apple
    banana, orange"⏩"cherry⏩tomato"
    """asparagus
    potato"""⏩"""broccoli""
    carrot"
    ```

    Pasting into LibreOffice Calc and Google Sheets works as expected.

## Bundle size increase

|                | Before      | After       | Change |
| --             | --          | --          | -- |
| main.js        | 1355.70 KiB | 1375.42 KiB | + 19.72 KiB |
| main.js + gzip | 374.19 KiB  | 381.86 KiB  | **+ 7.67 KiB** |


## Choice of library

Key

- ⭐ = GitHub stars
- 💾 = NPM downloads per week
- 🗓️ = time since most recent NPM update
- 📎 = NPM dependencies
- 🧩 = NPM dependents
- 📦 = NPM reported package size


### The one I chose

- `papaparse`
    - [npm](https://www.npmjs.com/package/papaparse) | [GH](https://github.com/mholt/PapaParse)
    - 11.3k ⭐ | 1.8M 💾 | 2 mo 🗓️ | 0 📎 | 1376 🧩 | 260 kB 📦

### Alternatives worth considering

- `csv`
    - [npm](https://www.npmjs.com/package/csv) | [GH](https://github.com/adaltas/node-csv)
    - 3.5k ⭐ | 3M 💾 | 0 mo 🗓️ | 0 📎 | 1879 🧩 | 2000 kB 📦
    - Concerned about bundle size, though it's hard to tell how much our bundle size would actually increase after tree-shaking. This project is split into separate packages, [csv-parse](https://www.npmjs.com/package/csv-parse), [csv-stringify](https://www.npmjs.com/package/csv-stringify) etc.

- `json-2-csv`
    - [npm](https://www.npmjs.com/package/json-2-csv) | [GH](https://github.com/mrodrig/json-2-csv)
    - 0.3k ⭐ | 0.1M 💾 | 2mo 🗓️ | 2 📎 | 170 🧩 | 100 kB 📦
    - Looks to be newer

### Tried and didn't like

- `csv-string`
    - [npm](https://www.npmjs.com/package/csv-string) | [GH](https://github.com/Inist-CNRS/node-csv-string)
    - 0.1k ⭐ | 0.1M 💾 | 7 mo 🗓️ | 0 📎 | 127 🧩 | 30 kB 📦
    - More recent, API looks nice
    - I tried this and ran into this [open issue](https://github.com/Inist-CNRS/node-csv-string/issues/57) because a polyfill is required.

### Others I looked at

- `csv-parser`
    - [npm](https://www.npmjs.com/package/csv-parser) | [GH](https://github.com/mafintosh/csv-parser)
    - 1.3k ⭐ | 1.3M 💾 | 2 yr 🗓️ | 1 📎 | 707 🧩 | 30 kB 📦
    - Doesn't handle serialization

- `comma-separated-values`
    - [npm](https://www.npmjs.com/package/comma-separated-values) | [GH](https://github.com/CyrusOfEden/CSV.js)
    - 1.5k ⭐ | 0.04M 💾 | 8 yr 🗓️ | ? 📎 | ? 🧩 | ? 📦
    - Concerned about lack of maintenance

- `d3-dsv` | [GH](https://github.com/d3/d3-dsv)
    - 0.4k ⭐ | 2.1M 💾 | ? 🗓️ | 3 📎 | 316 🧩 | 51 kB 📦
    - Seems to be mostly geared towards integration with D3

- `csvtojson`
    - [npm](https://www.npmjs.com/package/csvtojson) | [GH](https://github.com/Keyang/node-csvtojson)
    - 1.9k ⭐ | 0.7M 💾 | 4 yr 🗓️ | ? 📎 | ? 🧩 | ? 📦
    - Might be overkill, doesn't handle serialization

- `neat-csv`
    - [npm](https://www.npmjs.com/package/neat-csv)
    - Just a wrapper around `csv-parser`

- `tsv`
    - [npm](https://www.npmjs.com/package/tsv)
    - Unmaintained

- `zsv-lib`
    - [GitHub](https://www.npmjs.com/package/zsv-lib)
    - wasm-based
    - still in alpha



## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

