### PR TITLE
Add support for Unsetting Default Value of a column

### DIFF
--- a/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
@@ -22,9 +22,7 @@
   $: isDefaultNull = column.column.default === null;
   $: actionButtonsVisible = (() => {
     if (isDefaultNull) {
-      if (typeof value === 'object') {
-        JSON.stringify(initialValue) !== '';
-      } else return String(initialValue) !== '';
+      return column.column.default !== null;
     }
     if (typeof value === 'object') {
       return JSON.stringify(value) !== JSON.stringify(initialValue);
@@ -45,13 +43,12 @@
   async function save() {
     typeChangeState = { state: 'processing' };
     try {
-      let defaultRequest = null;
-      if (!isDefaultNull) {
-        defaultRequest = {
-          is_dynamic: !!column.column.default?.is_dynamic,
-          value,
-        };
-      }
+      const defaultRequest = isDefaultNull
+        ? null
+        : {
+            is_dynamic: !!column.column.default?.is_dynamic,
+            value,
+          };
       await columnsDataStore.patch(column.id, {
         default: defaultRequest,
       });

--- a/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
@@ -19,13 +19,12 @@
 
   $: initialValue = column.column.default?.value ?? column.initialInputValue;
   $: value = initialValue;
-  $: isDefaultNull = column.column.default == null;
+  $: isDefaultNull = column.column.default === null;
   $: actionButtonsVisible = (() => {
     if (isDefaultNull) {
       if (typeof value === 'object') {
         JSON.stringify(initialValue) !== '';
-      }
-      else return String(initialValue) !== '';
+      } else return String(initialValue) !== '';
     }
     if (typeof value === 'object') {
       return JSON.stringify(value) !== JSON.stringify(initialValue);
@@ -91,22 +90,12 @@
 
 <div class="default-value-container">
   <LabeledInput layout="inline-input-first">
-    <span slot="label">
-      No Default Value
-    </span>
-    <Radio
-      checked={isDefaultNull}
-      on:change={toggleNoDefault}
-    />
+    <span slot="label"> No Default Value </span>
+    <Radio checked={isDefaultNull} on:change={toggleNoDefault} />
   </LabeledInput>
   <LabeledInput layout="inline-input-first">
-    <span slot="label">
-      Custom default
-    </span>
-    <Radio    
-      checked={!isDefaultNull}  
-      on:change={toggleNoDefault}
-    />
+    <span slot="label"> Custom default </span>
+    <Radio checked={!isDefaultNull} on:change={toggleNoDefault} />
   </LabeledInput>
   {#if !isDefaultNull}
     <DynamicInput
@@ -116,7 +105,7 @@
       {recordSummary}
       {setRecordSummary}
     />
-  {/if}  
+  {/if}
   {#if actionButtonsVisible}
     <CancelOrProceedButtonPair
       onProceed={save}

--- a/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
@@ -42,13 +42,13 @@
 
   async function save() {
     typeChangeState = { state: 'processing' };
+    const defaultRequest = isDefaultNull
+      ? null
+      : {
+          is_dynamic: !!column.column.default?.is_dynamic,
+          value,
+        };
     try {
-      const defaultRequest = isDefaultNull
-        ? null
-        : {
-            is_dynamic: !!column.column.default?.is_dynamic,
-            value,
-          };
       await columnsDataStore.patch(column.id, {
         default: defaultRequest,
       });

--- a/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
+++ b/mathesar_ui/src/systems/table-view/table-inspector/column/SetDefaultValue.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { RequestStatus } from '@mathesar/api/utils/requestUtils';
   import { CancelOrProceedButtonPair } from '@mathesar/component-library';
+  import LabeledInput from '@mathesar/component-library/labeled-input/LabeledInput.svelte';
+  import Radio from '@mathesar/component-library/radio/Radio.svelte';
   import DynamicInput from '@mathesar/components/cell-fabric/DynamicInput.svelte';
   import {
     getTabularDataStoreFromContext,
@@ -17,7 +19,14 @@
 
   $: initialValue = column.column.default?.value ?? column.initialInputValue;
   $: value = initialValue;
+  $: isDefaultNull = column.column.default == null;
   $: actionButtonsVisible = (() => {
+    if (isDefaultNull) {
+      if (typeof value === 'object') {
+        JSON.stringify(initialValue) !== '';
+      }
+      else return String(initialValue) !== '';
+    }
     if (typeof value === 'object') {
       return JSON.stringify(value) !== JSON.stringify(initialValue);
     }
@@ -37,11 +46,15 @@
   async function save() {
     typeChangeState = { state: 'processing' };
     try {
-      await columnsDataStore.patch(column.id, {
-        default: {
+      let defaultRequest = null;
+      if (!isDefaultNull) {
+        defaultRequest = {
           is_dynamic: !!column.column.default?.is_dynamic,
           value,
-        },
+        };
+      }
+      await columnsDataStore.patch(column.id, {
+        default: defaultRequest,
       });
       typeChangeState = { state: 'success' };
     } catch (err) {
@@ -59,6 +72,10 @@
     typeChangeState = { state: 'success' };
   }
 
+  function toggleNoDefault() {
+    isDefaultNull = !isDefaultNull;
+  }
+
   function setRecordSummary(recordId: string, _recordSummary: string) {
     if (recordSummaries) {
       recordSummaries.addBespokeRecordSummary({
@@ -73,14 +90,33 @@
 </script>
 
 <div class="default-value-container">
-  <span class="label">Value</span>
-  <DynamicInput
-    componentAndProps={column.inputComponentAndProps}
-    bind:value
-    {disabled}
-    {recordSummary}
-    {setRecordSummary}
-  />
+  <LabeledInput layout="inline-input-first">
+    <span slot="label">
+      No Default Value
+    </span>
+    <Radio
+      checked={isDefaultNull}
+      on:change={toggleNoDefault}
+    />
+  </LabeledInput>
+  <LabeledInput layout="inline-input-first">
+    <span slot="label">
+      Custom default
+    </span>
+    <Radio    
+      checked={!isDefaultNull}  
+      on:change={toggleNoDefault}
+    />
+  </LabeledInput>
+  {#if !isDefaultNull}
+    <DynamicInput
+      componentAndProps={column.inputComponentAndProps}
+      bind:value
+      {disabled}
+      {recordSummary}
+      {setRecordSummary}
+    />
+  {/if}  
   {#if actionButtonsVisible}
     <CancelOrProceedButtonPair
       onProceed={save}


### PR DESCRIPTION
Fixes #2835.

This pull request adds support for unsetting default value of a column.
- Here is the **[figma design](https://www.figma.com/file/xHb5oIqye3fnXtb2heRH34/Styling?node-id=5641-31738)** by @ghislaineguerin for UI changes.

## Technical details
**No default value** radio button will allow users to remove default of a column (i.e set default to `null`).

When checking `null`, `===` is used to check if the column default is `null`, instead of using:
```
if (!default) {
}
``` 
**not to capture** `""`, `0`, `undefined`, `false` **as null.**
 


## Screenshots

https://github.com/centerofci/mathesar/assets/64671908/589ba894-1346-41f8-bf42-2b10cbcc6ddd



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
