### PR TITLE
Prevent default credentials being used for removed DBs

### DIFF
--- a/mathesar/database/base.py
+++ b/mathesar/database/base.py
@@ -13,7 +13,10 @@ def create_mathesar_engine(db_name):
     try:
         credentials = _get_credentials_for_db_name_in_settings(db_name)
     except KeyError:
-        credentials = _get_credentials_for_db_name_not_in_settings(db_name)
+        if hasattr(settings, 'MATHESAR_LIVE_DEMO') and settings.MATHESAR_LIVE_DEMO:
+            credentials = _get_credentials_for_db_name_not_in_settings(db_name)
+        else:
+            raise
     return engine.create_future_engine_with_custom_types(**credentials)
 
 

--- a/mathesar/views.py
+++ b/mathesar/views.py
@@ -33,11 +33,11 @@ def get_schema_list(request, database):
 
 
 def _get_permissible_db_queryset(request):
-    qs = Database.objects.all()
+    qs = Database.objects.filter(deleted=False)
     permission_restricted_qs = DatabaseAccessPolicy.scope_queryset(request, qs)
     schema_qs = Schema.objects.all()
     permitted_schemas = SchemaAccessPolicy.scope_queryset(request, schema_qs)
-    databases_from_permitted_schema = Database.objects.filter(schemas__in=permitted_schemas)
+    databases_from_permitted_schema = Database.objects.filter(schemas__in=permitted_schemas, deleted=False)
     permission_restricted_qs = permission_restricted_qs | databases_from_permitted_schema
     return permission_restricted_qs.distinct()
 


### PR DESCRIPTION
Fixes #2877 

The root cause behind the issue:
* If a user DB is configured once, the name of the DB is always stored in our `mathesar_database` table. We have a bool column `deleted` to mark if the DB is removed.
* In our case, the user adds a DB and then removes it. So, it's present in the `mathesar_database` table, but not in the `DATABASES` dict.
* When attempting to connect to a DB which isn't present in the `DATABASES` dict, the credentials of the `default` db was being used. This was implemented to support dynamically created DBs for the demo, however, this also affects non-demo environments.
* If the credentials for the `default` DB matches with the DB which is removed, the connection succeeds. This is the case when all of them run on the same server with the same user, which is the default setup of our docker-compose installation methods.
* Since the connection succeeds, the `deleted` flag isn't modified, and we are able to access DBs which the user expects to have been removed. These DBs also show up on the UI.

The changes in this PR:
* Only uses the credentials of the `default` DB if Mathesar is running in demo mode.
  * We have separated all our demo logic with a middleware and separate settings file. My commit checks the `MATHESAR_LIVE_DEMO` setting in our main application code. I don't see an easier alternative to move this check within the demo module. 
* Passes down only the DBs that have `deleted:false` to the frontend via `common_data`. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
