### PR TITLE
Add warnings to activate python environment when restarting the shell

### DIFF
--- a/docs/docs/installation/build-from-source/index.md
+++ b/docs/docs/installation/build-from-source/index.md
@@ -147,6 +147,10 @@
     source ./mathesar-venv/bin/activate
     ```
 
+    !!! warning "Important"
+        You need to activate the environment each time you restart the shell as they don't persist across sessions.
+
+
 ### Install the Mathesar application
 
 1. Install Python dependencies
@@ -186,7 +190,7 @@
           export $(sudo cat .env)
           ```
        
-        !!! info ""
+        !!! warning "Important"
             You need to export the environment variables each time you restart the shell as they don't persist across sessions.
 
 


### PR DESCRIPTION
Fixes the issues raised by the tester when testing "Build from source" installation documentation

The docs didn't have any information on the mandatory step for re-activating the Python environment when the shell is restarted. This PR adds the necessary information.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
