### PR TITLE
Add `Mode` aggregation function

### DIFF
--- a/db/functions/base.py
+++ b/db/functions/base.py
@@ -18,7 +18,7 @@ import warnings
 from sqlalchemy import column, not_, and_, or_, func, literal, cast, distinct
 from sqlalchemy.dialects.postgresql import array_agg, TEXT, array
 from sqlalchemy.sql import quoted_name
-from sqlalchemy.sql.functions import GenericFunction, concat, percentile_disc
+from sqlalchemy.sql.functions import GenericFunction, concat, percentile_disc, mode
 
 from db.engine import get_dummy_engine
 from db.functions import hints
@@ -381,6 +381,18 @@ class Count(DBFunction):
     @staticmethod
     def to_sa_expression(column_expr):
         return sa_call_sql_function('count', column_expr, return_type=PostgresType.INTEGER)
+
+
+class Mode(DBFunction):
+    id = 'mode'
+    name = 'mode'
+    hints = tuple([
+        hints.aggregation
+    ])
+
+    @staticmethod
+    def to_sa_expression(column_expr):
+        return mode().within_group(column_expr)
 
 
 class ArrayAgg(DBFunction):

--- a/mathesar/models/query.py
+++ b/mathesar/models/query.py
@@ -6,7 +6,7 @@ from db.queries.operations.process import get_transforms_with_summarizes_speced
 from db.transforms.operations.deserialize import deserialize_transformation
 from db.transforms.operations.serialize import serialize_transformation
 from db.transforms.base import Summarize
-from db.functions.base import Count, ArrayAgg, Sum, Median
+from db.functions.base import Count, ArrayAgg, Sum, Median, Mode
 from db.functions.packed import DistinctArrayAgg
 
 from mathesar.api.exceptions.query_exceptions.exceptions import DeletedColumnAccess
@@ -421,6 +421,7 @@ def _get_default_display_name_for_agg_output_alias(
             Count.id: " count",
             Sum.id: " sum",
             Median.id: "median",
+            Mode.id: " mode",
         }
         suffix_to_add = map_of_agg_function_to_suffix.get(agg_function)
         if suffix_to_add:

--- a/mathesar/tests/api/query/test_aggregation_functions.py
+++ b/mathesar/tests/api/query/test_aggregation_functions.py
@@ -295,6 +295,68 @@ def test_median_aggregation(library_ma_tables, get_uid, client):
     assert sorted(actual_records, key=lambda x: x['Checkout Month']) == expect_records
 
 
+def test_mode_aggregation(library_ma_tables, get_uid, client):
+    _ = library_ma_tables
+    checkouts = {
+        t["name"]: t for t in client.get("/api/db/v0/tables/").json()["results"]
+    }["Checkouts"]
+    columns = {
+        c["name"]: c for c in checkouts["columns"]
+    }
+    request_data = {
+        "name": get_uid(),
+        "base_table": checkouts["id"],
+        "initial_columns": [
+            {"id": columns["Checkout Time"]["id"], "alias": "Checkout Time"},
+            {"id": columns["Patron"]["id"], "alias": "Patron"},
+        ],
+        "display_names": {
+            "Checkout Month": "Month",
+            "Mode": "Mode of patron",
+        },
+        "display_options": {
+            "Checkout Time": {
+                display_option_origin: "Checkout Time",
+            },
+            "Patron": {
+                display_option_origin: "Patron",
+            },
+        },
+        "transformations": [
+            {
+                "spec": {
+                    "grouping_expressions": [
+                        {
+                            "input_alias": "Checkout Time",
+                            "output_alias": "Checkout Month",
+                            "preproc": "truncate_to_month",
+                        }
+                    ],
+                    "aggregation_expressions": [
+                        {
+                            "input_alias": "Patron",
+                            "output_alias": "Mode",
+                            "function": "mode",
+                        }
+                    ]
+                },
+                "type": "summarize",
+            }
+        ]
+    }
+    response = client.post('/api/db/v0/queries/', data=request_data)
+    assert response.status_code == 201
+    query_id = response.json()['id']
+    expect_records = [
+        {'Checkout Month': '2022-05', 'Mode': 11},
+        {'Checkout Month': '2022-06', 'Mode': 2},
+        {'Checkout Month': '2022-07', 'Mode': 22},
+        {'Checkout Month': '2022-08', 'Mode': 3},
+    ]
+    actual_records = client.get(f'/api/db/v0/queries/{query_id}/records/').json()['results']
+    assert sorted(actual_records, key=lambda x: x['Checkout Month']) == expect_records
+
+
 def test_Mathesar_money_distinct_list_aggregation(library_ma_tables, get_uid, client):
     _ = library_ma_tables
     items = {

--- a/mathesar_ui/src/api/types/queries.ts
+++ b/mathesar_ui/src/api/types/queries.ts
@@ -143,11 +143,11 @@ export type QueryColumnSource =
 
 export interface QueryInitialColumnMetaData
   extends QueryResultColumn,
-    QueryInitialColumnSource {}
+  QueryInitialColumnSource { }
 
 export interface QueryVirtualColumnMetaData
   extends QueryResultColumn,
-    QueryGeneratedColumnSource {}
+  QueryGeneratedColumnSource { }
 
 export type QueryColumnMetaData =
   | QueryInitialColumnMetaData

--- a/mathesar_ui/src/api/types/queries.ts
+++ b/mathesar_ui/src/api/types/queries.ts
@@ -35,6 +35,7 @@ export const querySummarizationFunctionIds = [
   'count',
   'sum',
   'median',
+  'mode',
 ] as const;
 
 export type QuerySummarizationFunctionId =
@@ -143,11 +144,11 @@ export type QueryColumnSource =
 
 export interface QueryInitialColumnMetaData
   extends QueryResultColumn,
-  QueryInitialColumnSource { }
+    QueryInitialColumnSource {}
 
 export interface QueryVirtualColumnMetaData
   extends QueryResultColumn,
-  QueryGeneratedColumnSource { }
+    QueryGeneratedColumnSource {}
 
 export type QueryColumnMetaData =
   | QueryInitialColumnMetaData

--- a/mathesar_ui/src/stores/abstract-types/operations/summarization.ts
+++ b/mathesar_ui/src/stores/abstract-types/operations/summarization.ts
@@ -48,7 +48,7 @@ const functionsResponse: AbstractTypeSummarizationFunctionsResponse = {
   },
   mode: {
     label: 'Mode',
-    inputOutputTypeMap: mapInpuTypesToCorrespondingOutputTypes(),
+    inputOutputTypeMap: mapInputTypesToTheSameOutputType(),
   },
 };
 

--- a/mathesar_ui/src/stores/abstract-types/operations/summarization.ts
+++ b/mathesar_ui/src/stores/abstract-types/operations/summarization.ts
@@ -15,6 +15,12 @@ function mapAllInputTypesToOneOutputType(
   );
 }
 
+function mapInpuTypesToCorrespondingOutputTypes(): AbstractTypeSummarizationFunctionsResponseValue['inputOutputTypeMap'] {
+  return Object.fromEntries(
+    Object.values(abstractTypeCategory).map((t) => [t, t]),
+  );
+}
+
 const functionsResponse: AbstractTypeSummarizationFunctionsResponse = {
   distinct_aggregate_to_array: {
     label: 'List',
@@ -41,6 +47,10 @@ const functionsResponse: AbstractTypeSummarizationFunctionsResponse = {
     inputOutputTypeMap: mapAllInputTypesToOneOutputType(
       abstractTypeCategory.Number,
     ),
+  },
+  mode: {
+    label: 'Mode',
+    inputOutputTypeMap: mapInpuTypesToCorrespondingOutputTypes(),
   },
 };
 

--- a/mathesar_ui/src/systems/data-explorer/QuerySummarizationTransformationModel.ts
+++ b/mathesar_ui/src/systems/data-explorer/QuerySummarizationTransformationModel.ts
@@ -24,7 +24,8 @@ export interface QuerySummarizationTransformationEntry {
 }
 
 export default class QuerySummarizationTransformationModel
-  implements QuerySummarizationTransformationEntry {
+  implements QuerySummarizationTransformationEntry
+{
   type = 'summarize' as const;
 
   name = 'Summarization' as const;

--- a/mathesar_ui/src/systems/data-explorer/QuerySummarizationTransformationModel.ts
+++ b/mathesar_ui/src/systems/data-explorer/QuerySummarizationTransformationModel.ts
@@ -24,8 +24,7 @@ export interface QuerySummarizationTransformationEntry {
 }
 
 export default class QuerySummarizationTransformationModel
-  implements QuerySummarizationTransformationEntry
-{
+  implements QuerySummarizationTransformationEntry {
   type = 'summarize' as const;
 
   name = 'Summarization' as const;


### PR DESCRIPTION
Fixes #2918

**This pull request adds support for `Mode` aggregation as a transformation step in the data explorer.** 

User will be able to:
- Get the `mode` of any column based on `Group By` clause.
---
**Technical details**

I have made the following changes:
- Add `Mode(DBFunction)` class to support mode aggregation
- Add `mode` suffix to the output alias of the aggregated column.
- Add `Mode` to the list of transformation steps in the data explorer.
- Add test for the same.
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
