### PR TITLE
Remove lazydict dependency

### DIFF
--- a/mathesar/api/display_options.py
+++ b/mathesar/api/display_options.py
@@ -91,4 +91,3 @@ DISPLAY_OPTIONS_BY_UI_TYPE = {
     # NOTE: below callable will be evaluated only once
     UIType.MONEY: _money_display_options_schema(),
 }
-

--- a/mathesar/api/display_options.py
+++ b/mathesar/api/display_options.py
@@ -88,6 +88,5 @@ DISPLAY_OPTIONS_BY_UI_TYPE = {
             {"name": "show_units", "type": "boolean"},
         ]
     },
-    # NOTE: below callable will be evaluated only once
     UIType.MONEY: _money_display_options_schema(),
 }

--- a/mathesar/api/display_options.py
+++ b/mathesar/api/display_options.py
@@ -1,6 +1,5 @@
 import json
 from mathesar.database.types import UIType
-from lazydict import LazyDictionary
 
 
 def _money_display_options_schema():
@@ -24,73 +23,72 @@ def _money_display_options_schema():
     }
 
 
-DISPLAY_OPTIONS_BY_UI_TYPE = LazyDictionary(
+DISPLAY_OPTIONS_BY_UI_TYPE = {
+    UIType.BOOLEAN:
     {
-        UIType.BOOLEAN:
-        {
-            "options": [
-                {
-                    "name": "input", "type": "string",
-                    "enum": ['dropdown', 'checkbox']
-                },
-                {
-                    'name': "custom_labels", "type": "object",
-                    "items": [
-                        {"name": "TRUE", "type": "string"},
-                        {'name': "FALSE", "type": "string"}
-                    ]
-                }
-            ]
+        "options": [
+            {
+                "name": "input", "type": "string",
+                "enum": ['dropdown', 'checkbox']
+            },
+            {
+                'name': "custom_labels", "type": "object",
+                "items": [
+                    {"name": "TRUE", "type": "string"},
+                    {'name': "FALSE", "type": "string"}
+                ]
+            }
+        ]
 
-        },
-        UIType.NUMBER:
-        {
-            "options": [
-                {
-                    "name": "show_as_percentage",
-                    "type": "string",
-                    "enum": ['dropdown', 'checkbox']
-                },
-                {
-                    "name": "use_grouping",
-                    "type": "string",
-                    "enum": ['true', 'false', 'auto']
-                },
-                {
-                    "name": "minimum_fraction_digits",
-                    "type": "number",
-                },
-                {
-                    "name": "maximum_fraction_digits",
-                    "type": "number",
-                },
-                {
-                    "name": "locale",
-                    "type": "string"
-                }
-            ]
-        },
-        UIType.DATETIME:
-        {
-            "options": [{"name": "format", "type": "string"}]
-        },
-        UIType.TIME:
-        {
-            "options": [{"name": "format", "type": "string"}]
-        },
-        UIType.DATE:
-        {
-            "options": [{"name": "format", "type": "string"}]
-        },
-        UIType.DURATION:
-        {
-            "options": [
-                {"name": "min", "type": "string"},
-                {"name": "max", "type": "string"},
-                {"name": "show_units", "type": "boolean"},
-            ]
-        },
-        # NOTE: below callable will be evaluated lazily by LazyDictionary
-        UIType.MONEY: _money_display_options_schema,
-    }
-)
+    },
+    UIType.NUMBER:
+    {
+        "options": [
+            {
+                "name": "show_as_percentage",
+                "type": "string",
+                "enum": ['dropdown', 'checkbox']
+            },
+            {
+                "name": "use_grouping",
+                "type": "string",
+                "enum": ['true', 'false', 'auto']
+            },
+            {
+                "name": "minimum_fraction_digits",
+                "type": "number",
+            },
+            {
+                "name": "maximum_fraction_digits",
+                "type": "number",
+            },
+            {
+                "name": "locale",
+                "type": "string"
+            }
+        ]
+    },
+    UIType.DATETIME:
+    {
+        "options": [{"name": "format", "type": "string"}]
+    },
+    UIType.TIME:
+    {
+        "options": [{"name": "format", "type": "string"}]
+    },
+    UIType.DATE:
+    {
+        "options": [{"name": "format", "type": "string"}]
+    },
+    UIType.DURATION:
+    {
+        "options": [
+            {"name": "min", "type": "string"},
+            {"name": "max", "type": "string"},
+            {"name": "show_units", "type": "boolean"},
+        ]
+    },
+    # NOTE: below callable will be evaluated only once
+    UIType.MONEY: _money_display_options_schema(),
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 alembic==1.6.5
 bidict==0.21.4
 frozendict==2.1.3
-lazydict==1.0.0b2
 charset-normalizer==2.0.7
 clevercsv==0.6.8
 Django==3.1.14


### PR DESCRIPTION
Fixes #2960

This PR removes the lazydict dependency that is not compatible with python > 3.9

**Technical details**

Please notice that this PR will evaluate the function `_money_display_options_schema` only once when the application is starting, while with the previous version that was using the lazydict would evaluate it once when it was called. 

We could implement a *lazy* solution instead however it would need more changes to the source code and I really don't think it's worth it, I actually prefer evaluating the function when the project is starting.
`


## Checklist
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
