### PR TITLE
Customised the operationids by implementing a post hook function 

### DIFF
--- a/config/settings/common_settings.py
+++ b/config/settings/common_settings.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from decouple import Csv, config as decouple_config
 from dj_database_url import parse as db_url
+from .openapi import custom_postprocessing_hook
 
 
 # We use a 'tuple' with pipes as delimiters as decople naively splits the global
@@ -192,6 +193,9 @@ SPECTACULAR_SETTINGS = {
     'DESCRIPTION': '',
     'VERSION': '1.0.0',
     'SERVE_INCLUDE_SCHEMA': False,
+    'POSTPROCESSING_HOOKS': [
+        'config.settings.openapi.custom_postprocessing_hook',
+    ],
     # OTHER SETTINGS
 }
 FRIENDLY_ERRORS = {

--- a/config/settings/openapi.py
+++ b/config/settings/openapi.py
@@ -1,0 +1,12 @@
+def custom_postprocessing_hook(generator, result, request, public):
+    # Modify the operation IDs in the result schema
+    for path, path_info in result['paths'].items():
+        for method, operation in path_info.items():
+            operation_id = operation.get('operationId')
+            if operation_id:
+                if path.startswith('/api/db/v0/'):
+                    operation['operationId'] = operation_id.replace('db_v0_', '')
+                elif path.startswith('/api/ui/v0/'):
+                    operation['operationId'] = operation_id.replace('ui_v0_', '')
+
+    return result


### PR DESCRIPTION
Fixes #3000 
This PR removes the prefixes `api_db_v0_` and `api_ui_v0_` that were present in the operationIds generated by the drf sppectacular library. This was done by implementing a **Post Processing hook function**.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
