### PR TITLE
Clean up import docs

### DIFF
--- a/docs/docs/user-guide/importing-data.md
+++ b/docs/docs/user-guide/importing-data.md
@@ -10,8 +10,8 @@ Fields in the CSV data may be delimited by any of the following characters:
 
 | Name | Character | Notes |
 | -- | -- | -- |
-| Comma | `,` | This yields a traditional CSV file, aka "**C**omma **S**eparated **V**alue" |
-| Tab | _(not printable)_ | This is sometimes referred to as a _TSV_ file, for "**T**ab **S**eparated **V**alue"  |
+| Comma | `,` | A traditional CSV file (a "**C**omma **S**eparated **V**alue" document) |
+| Tab | _(not printable)_ | This is sometimes referred to as a _TSV_ file (a "**T**ab **S**eparated **V**alue" document) |
 | Semicolon | `;` |  |
 | Colon | `:` |  |
 | Pipe | `|` |  |

--- a/docs/docs/user-guide/importing-data.md
+++ b/docs/docs/user-guide/importing-data.md
@@ -24,7 +24,7 @@ If you un-check **"Use first row as header"**, then Mathesar will generate defau
 
 ## Importing JSON data {:#json}
 
-The JSON data must be structured in of the following ways:
+The JSON data must be structured in one of the following ways:
 
 - **An array of objects**
 

--- a/docs/docs/user-guide/importing-data.md
+++ b/docs/docs/user-guide/importing-data.md
@@ -1,39 +1,62 @@
 # Importing data into Mathesar
 
-Mathesar allows importing data directly into tables using a *SV file (including CSV and TSV files), or JSON file. It also attempts to automatically infer the data type of the columns.
+Mathesar allows importing data in CSV and JSON format. It also attempts to automatically infer the data type of the columns.
 
-### Importing CSV, TSV and other *SV files
-Currently supported delimiters are [commas, tabs, colons, pipes, semicolon](https://github.com/centerofci/mathesar/blob/3eae659ec5a9447fdc91780876edbe76ace68a06/mathesar/imports/csv.py#L17). You can use the first row as a header when the table preview is shown. If the header is absent, Mathesar allocates default names (For example, 'Column 0', 'Column 1', and so on) to columns that can be edited later.
+## Importing CSV data {:#csv}
 
-### Importing JSON files
-Mathesar accepts the JSON files if they are structured in one of these ways:
-1. A single object structured as key-value pairs. This will create a table with a single row. The keys of the object will be used as column names, and the values will be inserted into the row. Example:
+### Delimiters
 
-```
-{
-    "name": "John",
-    "age": 21,
-    "friends": ["Bob", "Mary"]
-}
-```
+Fields in the CSV data may be delimited by any of the following characters:
 
-2. List of objects. The will create a table with columns names the same as the keys of the JSON objects. The example below creates a table with column names **first_name**, **last_name**, **gender**, **friends**, and **email** and adds two rows of data corresponding to the number of JSON objects. Missing keys in each object get __*null*__ for corresponding columns.
+| Name | Character | Notes |
+| -- | -- | -- |
+| Comma | `,` | This yields a traditional CSV file, aka "**C**omma **S**eparated **V**alue" |
+| Tab | _(not printable)_ | This is sometimes referred to as a _TSV_ file, for "**T**ab **S**eparated **V**alue"  |
+| Semicolon | `;` |  |
+| Colon | `:` |  |
+| Pipe | `|` |  |
 
-```
-[
-    {
-        "first_name":"Matt",
-        "last_name":"Murdock",
-        "gender":"Male",
+### Header rows
+
+By default, Mathesar will use the first row of CSV data to name the columns.
+
+If you un-check **"Use first row as header"**, then Mathesar will generate default names for the columns which you can edit later.
+
+## Importing JSON data {:#json}
+
+The JSON data must be structured in of the following ways:
+
+- **An array of objects**
+
+    Each object produces one row in the table, and the object keys become column names. If a key is present is only one object, then the values for that column will be `NULL` in all other rows.
+
+    ```json
+    [
+      {
+        "first_name": "Matt",
+        "last_name": "Murdock",
+        "gender": "Male",
         "friends": ["Stick", "Foggy"]
-    },
+      },
+      {
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "jd@example.org",
+        "gender": "Male"
+      }
+    ]
+    ```
+
+- **A single object**
+
+    This is similar to above but produces a table with only one row.
+
+    ```json
     {
-        "first_name":"John",
-        "last_name":"Doe",
-        "email":"jd@example.org",
-        "gender":"Male",
-    },
-]
-```
+      "name": "John",
+      "age": 21,
+      "friends": ["Bob", "Mary"]
+    }
+    ```
 
 Our goal is to support whatever [`pandas.json_normalize`](https://pandas.pydata.org/docs/reference/api/pandas.json_normalize.html) supports.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,9 +23,9 @@ nav:
       - Uninstall Mathesar: administration/uninstall.md
   - Using Mathesar:
       - Introduction: user-guide/index.md
+      - Importing data: user-guide/importing-data.md
       - Syncing database changes: user-guide/syncing-db.md
       - Users & access levels: user-guide/users.md
-      - Importing data into Mathesar: user-guide/importing-data.md
 
 plugins:
   - search:

--- a/mathesar/imports/base.py
+++ b/mathesar/imports/base.py
@@ -5,7 +5,6 @@ from mathesar.imports.json import create_db_table_from_json_data_file
 from db.tables.operations.select import get_oid_from_table
 from mathesar.errors import InvalidTableError
 
-ALLOWED_DELIMITERS = ",\t:|;"
 SAMPLE_SIZE = 20000
 CHECK_ROWS = 10
 

--- a/mathesar/imports/csv.py
+++ b/mathesar/imports/csv.py
@@ -14,6 +14,8 @@ from psycopg2.errors import IntegrityError, DataError
 
 from mathesar.state import reset_reflection
 
+# The user-facing documentation replicates these delimiter characters. If you
+# change this variable, please update the documentation as well.
 ALLOWED_DELIMITERS = ",\t:|;"
 SAMPLE_SIZE = 20000
 CHECK_ROWS = 10


### PR DESCRIPTION

I noticed this new docs page and though it could use some cleanup. Here's what I did:

- Fix list that was not rendering due to missing empty line preceding.
- Add syntax highlighting to example JSON.
- Fix syntax errors in example JSON (trailing commas).
- Format the example JSON more idiomatically.
- Fix grammatical errors.
- Clean up language.
- Reorder JSON examples, placing "array of objects" first since it's likely to be more common.
- Give bold headings to each JSON example to make it easier for readers to skim.
- Remove `*SV` occurrences because that nomenclature may be confusing to some readers.
- Fix headings to follow proper structure.
- Write all CSV delimiters out instead of referencing python code. Some readers won't know what a "pipe" is, and will be intimidated to be dropped in a python file.
- Set custom heading fragments (e.g. `{:#csv}`).
- Simplify page title in nav menu.
- Re-order page in nav, placing it before other pages because import is commonly done early when using Mathesar.


## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>


