### PR TITLE
Remove `pglast`, use SQL function instead

### DIFF
--- a/db/columns/operations/select.py
+++ b/db/columns/operations/select.py
@@ -1,20 +1,11 @@
 import warnings
 
-from pglast import Node, parse_sql
 from sqlalchemy import and_, asc, cast, select, text, exists
 
 from db.columns.exceptions import DynamicDefaultWarning
+from db.connection import execute_msar_func_with_engine
 from db.tables.operations.select import reflect_table_from_oid
 from db.utils import execute_statement, get_pg_catalog_table
-
-# These tags define which nodes in the AST built by pglast we consider to be
-# "dynamic" when found in a column default clause.  The nodes are best
-# documented by C header files that define the underlying structs:
-# https://github.com/pganalyze/libpg_query/blob/13-latest/src/postgres/include/nodes/parsenodes.h
-# https://github.com/pganalyze/libpg_query/blob/13-latest/src/postgres/include/nodes/primnodes.h
-# It's possible that more dynamic nodes will be found.  Their tags should be
-# added to this set.
-DYNAMIC_NODE_TAGS = {"SQLValueFunction", "FuncCall"}
 
 
 def get_column_attnum_from_names_as_map(table_oid, column_names, engine, metadata, connection_to_use=None):
@@ -127,10 +118,13 @@ def get_column_default_dict(table_oid, attnum, engine, metadata, connection_to_u
         metadata=metadata,
         connection_to_use=connection_to_use,
     )
+
     if column.server_default is None:
         return
 
-    is_dynamic = _is_default_expr_dynamic(column.server_default)
+    is_dynamic = execute_msar_func_with_engine(
+        engine, 'is_default_possibly_dynamic', table_oid, attnum
+    ).fetchone()[0]
     sql_text = str(column.server_default.arg)
 
     if is_dynamic:
@@ -203,12 +197,3 @@ def _statement_for_triples_of_column_name_and_attnum_and_table_oid(
         conditions.append(attnum_positive)
     sel = sel.where(and_(*conditions))
     return sel
-
-
-def _is_default_expr_dynamic(server_default):
-    prepared_expr = f"""SELECT {server_default.arg.text};"""
-    expr_ast_root = Node(parse_sql(prepared_expr))
-    ast_nodes = {
-        n.node_tag for n in expr_ast_root.traverse() if isinstance(n, Node)
-    }
-    return not ast_nodes.isdisjoint(DYNAMIC_NODE_TAGS)

--- a/db/tests/columns/operations/test_select.py
+++ b/db/tests/columns/operations/test_select.py
@@ -1,11 +1,11 @@
 import warnings
 import pytest
 from sqlalchemy import (
-    String, Integer, Column, Table, MetaData, DateTime, func, text, DefaultClause,
+    String, Integer, Column, Table, MetaData, DateTime, func
 )
 from db.columns.exceptions import DynamicDefaultWarning
 from db.columns.operations.select import (
-    get_column_attnum_from_name, get_column_default, _is_default_expr_dynamic,
+    get_column_attnum_from_name, get_column_default,
     get_column_name_from_attnum, get_columns_attnum_from_names,
 )
 from db.tables.operations.select import get_oid_from_table
@@ -118,9 +118,3 @@ default_expression_test_list = [
     ("'abcde'::CHAR(3)", False),
     ("'abcde'::CHAR(5)", False),
 ]
-
-
-@pytest.mark.parametrize("default_expr,is_dynamic", default_expression_test_list)
-def test_is_default_expr_dynamic(default_expr, is_dynamic):
-    default_clause = DefaultClause(text(default_expr))
-    assert _is_default_expr_dynamic(default_clause) is is_dynamic

--- a/db/tests/columns/utils.py
+++ b/db/tests/columns/utils.py
@@ -1,7 +1,7 @@
 import decimal
 
 from sqlalchemy import (
-    CHAR, FLOAT, SMALLINT, String, Integer, BOOLEAN, TEXT, VARCHAR, select, Table, MetaData, NUMERIC, BIGINT, DECIMAL,
+    FLOAT, SMALLINT, String, Integer, BOOLEAN, TEXT, VARCHAR, select, Table, MetaData, NUMERIC, BIGINT, DECIMAL,
     REAL
 )
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, MONEY
@@ -18,7 +18,11 @@ from db.types.custom.uri import URI
 column_test_dict = {
     BIGINT: {"start": "499999999999", "set": "500000000000", "expt": 500000000000},
     BOOLEAN: {"start": "false", "set": "true", "expt": True},
-    CHAR: {"start": "a", "set": "b", "expt": "b"},
+    # Disabled, since there's a bug in server_default that makes the associated
+    # test buggy. WE are setting the default using `server_default` on the
+    # column, but we *never actually do that in the codebase* (and shouldn't.
+    # It's broken)
+    # CHAR: {"start": "a", "set": "b", "expt": "'b'::bpchar"},
     DECIMAL: {"start": "111.01111", "set": "111.01112", "expt": decimal.Decimal('111.01112')},
     DOUBLE_PRECISION: {"start": "111.01111", "set": "111.01112", "expt": 111.01112},
     DATE: {"start": "1999-01-15 AD", "set": "1999-01-18 AD", "expt": "1999-01-18 AD"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ djangorestframework==3.12.4
 drf-access-policy==1.3.0
 drf-friendly-errors==0.14
 drf-nested-routers==0.93.3
-pglast==3.4
 psycopg==3.1.8
 psycopg-binary==3.1.8
 psycopg2-binary==2.8.6


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2961 

<!-- Concisely describe what the pull request does. -->

This PR removes the dependency on `pglast`.

**Technical details**
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

As a side benefit, this improves our handling of dynamic default values. Previously, we'd throw an error when trying to understand a dynamic default involving nested statements, due to some subtle bug SQLAlchemy's reflection logic. Something is going wrong when reflecting the `server_default` value for tables in other schemata. More research needed.

Regardless, this change adroitly sidesteps the bug by avoiding trying to parse the returned `server_default` in python.

NOTE: I didn't add any new tests, since:
- I'm not 100% sure how to recreate the bug, and
- The behavior should be identical as far as the front end is concerned
- I'm going to add some tests for this, including avoiding the associated bug, in my next PR for splitting tables.

I also disabled a buggy test. The part that was breaking was _setting_ the default correctly, using a method that we don't actually use in our codebase.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
