### PR TITLE
Shared queries - Auth handling for query requests, frontend consumer view, basic API tests

### DIFF
--- a/mathesar/api/db/permissions/query.py
+++ b/mathesar/api/db/permissions/query.py
@@ -1,6 +1,8 @@
 from django.db.models import Q
 from rest_access_policy import AccessPolicy
 
+from mathesar.api.utils import SHARED_LINK_UUID_QUERY_PARAM
+from mathesar.api.permission_utils import QueryAccessInspector
 from mathesar.models.users import Role
 
 
@@ -8,18 +10,25 @@ class QueryAccessPolicy(AccessPolicy):
 
     statements = [
         {
+            'action': [
+                'retrieve',
+                'results',
+            ],
+            'principal': '*',
+            'effect': 'allow',
+            'condition_expression': 'is_atleast_query_viewer'
+        },
+        {
             # Restrictions for the create method is done by the Serializers when creating the query,
             # As the permissions depend on the base_table object and not on the query object.
             'action': [
                 'list',
-                'retrieve',
                 'destroy',
                 'create',
                 'run',
                 'update',
                 'partial_update',
                 'columns',
-                'results',
                 'records',
 
             ],
@@ -43,3 +52,11 @@ class QueryAccessPolicy(AccessPolicy):
             qs = qs.filter(permissible_database_role_filter | permissible_schema_roles_filter)
 
         return qs
+
+    def is_atleast_query_viewer(self, request, view, action):
+        query = view.get_object()
+        return QueryAccessInspector(
+            request.user,
+            query,
+            token=request.query_params.get(SHARED_LINK_UUID_QUERY_PARAM)
+        ).is_atleast_viewer()

--- a/mathesar/api/db/viewsets/queries.py
+++ b/mathesar/api/db/viewsets/queries.py
@@ -87,7 +87,6 @@ class QueryViewSet(
                 "records": paginated_records.data,
                 "output_columns": columns,
                 "column_metadata": column_metadata,
-                "parameters": {k: json.loads(request.GET[k]) for k in request.GET},
             }
         )
 

--- a/mathesar/api/ui/viewsets/shares.py
+++ b/mathesar/api/ui/viewsets/shares.py
@@ -19,7 +19,7 @@ class SharedTableViewSet(AccessViewSetMixin, viewsets.ModelViewSet):
         serializer.save(table_id=self.kwargs['table_pk'])
 
 
-class SharedQueryViewSet(viewsets.ModelViewSet):
+class SharedQueryViewSet(AccessViewSetMixin, viewsets.ModelViewSet):
     pagination_class = DefaultLimitOffsetPagination
     serializer_class = SharedQuerySerializer
     access_policy = SharedQueryAccessPolicy

--- a/mathesar/tests/api/query/conftest.py
+++ b/mathesar/tests/api/query/conftest.py
@@ -12,32 +12,42 @@ def academics_ma_tables(db_table_to_dj_table, academics_db_tables):
 
 
 @pytest.fixture
-def minimal_patents_query(create_patents_table, get_uid):
-    base_table = create_patents_table(table_name=get_uid())
-    initial_columns = [
-        {
-            'id': base_table.get_column_by_name('Center').id,
-            'alias': 'col1',
-        },
-        {
-            'id': base_table.get_column_by_name('Case Number').id,
-            'alias': 'col2',
-        },
-    ]
-    display_names = {
-        'col1': 'Column 1',
-        'col2': 'Column 2',
-        'Checkout Month': 'Month',
-        'Count': 'Number of Checkouts',
-    }
-    display_options = {
-        'col1': dict(a=1),
-        'col2': dict(b=2),
-    }
-    ui_query = UIQuery.objects.create(
-        base_table=base_table,
-        initial_columns=initial_columns,
-        display_options=display_options,
-        display_names=display_names,
-    )
-    return ui_query
+def create_minimal_patents_query(create_patents_table, get_uid, patent_schema):
+    schema_name = patent_schema.name
+
+    def _create(schema_name=schema_name):
+        base_table = create_patents_table(table_name=get_uid(), schema_name=schema_name)
+        initial_columns = [
+            {
+                'id': base_table.get_column_by_name('Center').id,
+                'alias': 'col1',
+            },
+            {
+                'id': base_table.get_column_by_name('Case Number').id,
+                'alias': 'col2',
+            },
+        ]
+        display_names = {
+            'col1': 'Column 1',
+            'col2': 'Column 2',
+            'Checkout Month': 'Month',
+            'Count': 'Number of Checkouts',
+        }
+        display_options = {
+            'col1': dict(a=1),
+            'col2': dict(b=2),
+        }
+        ui_query = UIQuery.objects.create(
+            base_table=base_table,
+            initial_columns=initial_columns,
+            display_options=display_options,
+            display_names=display_names,
+        )
+        return ui_query
+
+    return _create
+
+
+@pytest.fixture
+def minimal_patents_query(create_minimal_patents_query):
+    return create_minimal_patents_query()

--- a/mathesar/tests/api/query/test_query_results.py
+++ b/mathesar/tests/api/query/test_query_results.py
@@ -54,13 +54,5 @@ def test_query_results_minimal(client, minimal_patents_query):
                 'input_alias': None,
             }
         },
-        'parameters': {
-            'order_by': [
-                {'field': 'col1', 'direction': 'asc'},
-                {'field': 'col2', 'direction': 'desc'}
-            ],
-            'limit': 2,
-            'offset': 3,
-        }
     }
     assert actual_response_json == expect_response_json

--- a/mathesar/tests/api/query/test_shared_queries.py
+++ b/mathesar/tests/api/query/test_shared_queries.py
@@ -1,0 +1,156 @@
+import pytest
+
+from mathesar.models.shares import SharedQuery
+
+
+@pytest.fixture
+def shared_test_query(create_minimal_patents_query):
+    query = create_minimal_patents_query()
+    share = SharedQuery.objects.create(
+        query=query,
+        enabled=True,
+    )
+    different_schema_query = create_minimal_patents_query(schema_name="Different Schema")
+    different_schema_share = SharedQuery.objects.create(
+        query=different_schema_query,
+        enabled=True,
+    )
+    yield {
+        'query': query,
+        'share': share,
+        'different_schema_query': different_schema_query,
+        'different_schema_share': different_schema_share,
+    }
+    share.delete()
+
+
+read_client_with_different_roles = [
+    # (client_name, different_schema_status_code)
+    ('superuser_client_factory', 200),
+    ('db_manager_client_factory', 200),
+    ('db_editor_client_factory', 200),
+    ('schema_manager_client_factory', 403),
+    ('schema_viewer_client_factory', 403),
+    ('db_viewer_schema_manager_client_factory', 200)
+]
+
+
+write_client_with_different_roles = [
+    # client_name, is_allowed
+    ('superuser_client_factory', True),
+    ('db_manager_client_factory', True),
+    ('db_editor_client_factory', True),
+    ('schema_manager_client_factory', True),
+    ('schema_viewer_client_factory', False),
+    ('db_viewer_schema_manager_client_factory', True)
+]
+
+
+@pytest.mark.parametrize('client_name,different_schema_status_code', read_client_with_different_roles)
+def test_shared_query_list(
+    shared_test_query,
+    request,
+    client_name,
+    different_schema_status_code,
+):
+    client = request.getfixturevalue(client_name)(shared_test_query["query"].base_table.schema)
+    response = client.get(f'/api/ui/v0/queries/{shared_test_query["query"].id}/shares/')
+    response_data = response.json()
+
+    assert response.status_code == 200
+    assert response_data['count'] == 1
+    assert len(response_data['results']) == 1
+    result = response_data['results'][0]
+    assert result['slug'] == str(shared_test_query['share'].slug)
+    assert result['enabled'] == shared_test_query['share'].enabled
+
+    response = client.get(f'/api/ui/v0/queries/{shared_test_query["different_schema_query"].id}/shares/')
+    assert response.status_code == different_schema_status_code
+    if different_schema_status_code == 200:
+        response_data = response.json()
+        assert len(response_data['results']) == 1
+        result = response_data['results'][0]
+        assert result['slug'] == str(shared_test_query['different_schema_share'].slug)
+        assert result['enabled'] == shared_test_query['different_schema_share'].enabled
+
+
+@pytest.mark.parametrize('client_name,different_schema_status_code', read_client_with_different_roles)
+def test_shared_query_retrieve(
+    shared_test_query,
+    request,
+    client_name,
+    different_schema_status_code,
+):
+    client = request.getfixturevalue(client_name)(shared_test_query["query"].base_table.schema)
+    response = client.get(f'/api/ui/v0/queries/{shared_test_query["query"].id}/shares/{shared_test_query["share"].id}/')
+    response_data = response.json()
+
+    assert response.status_code == 200
+    assert response_data['slug'] == str(shared_test_query['share'].slug)
+    assert response_data['enabled'] == shared_test_query['share'].enabled
+
+    response = client.get(f'/api/ui/v0/queries/{shared_test_query["different_schema_query"].id}/shares/{shared_test_query["different_schema_share"].id}/')
+    assert response.status_code == different_schema_status_code
+    if different_schema_status_code == 200:
+        response_data = response.json()
+        assert response_data['slug'] == str(shared_test_query['different_schema_share'].slug)
+        assert response_data['enabled'] == shared_test_query['different_schema_share'].enabled
+
+
+@pytest.mark.parametrize('client_name,is_allowed', write_client_with_different_roles)
+def test_shared_query_create(
+    minimal_patents_query,
+    request,
+    client_name,
+    is_allowed
+):
+    client = request.getfixturevalue(client_name)(minimal_patents_query.base_table.schema)
+    data = {'enabled': True}
+    response = client.post(f'/api/ui/v0/queries/{minimal_patents_query.id}/shares/', data)
+    response_data = response.json()
+
+    if is_allowed:
+        assert response.status_code == 201
+        assert 'id' in response_data
+        assert response_data['enabled'] is True
+        created_share = SharedQuery.objects.get(id=response_data['id'])
+        assert created_share is not None
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.parametrize('client_name,is_allowed', write_client_with_different_roles)
+def test_shared_query_patch(
+    shared_test_query,
+    request,
+    client_name,
+    is_allowed
+):
+    client = request.getfixturevalue(client_name)(shared_test_query["query"].base_table.schema)
+    data = {'enabled': False}
+    response = client.patch(f'/api/ui/v0/queries/{shared_test_query["query"].id}/shares/{shared_test_query["share"].id}/', data)
+    response_data = response.json()
+
+    if is_allowed:
+        assert response.status_code == 200
+        assert response_data['slug'] == str(shared_test_query['share'].slug)
+        assert response_data['enabled'] is False
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.parametrize('client_name,is_allowed', write_client_with_different_roles)
+def test_shared_query_delete(
+    shared_test_query,
+    request,
+    client_name,
+    is_allowed
+):
+    client = request.getfixturevalue(client_name)(shared_test_query["query"].base_table.schema)
+    response = client.delete(f'/api/ui/v0/queries/{shared_test_query["query"].id}/shares/{shared_test_query["share"].id}/')
+
+    if is_allowed:
+        assert response.status_code == 204
+        assert SharedQuery.objects.filter(id=shared_test_query['share'].id).first() is None
+    else:
+        assert response.status_code == 403

--- a/mathesar/tests/api/test_shared_tables.py
+++ b/mathesar/tests/api/test_shared_tables.py
@@ -1,0 +1,162 @@
+import pytest
+
+from mathesar.models.shares import SharedTable
+
+
+@pytest.fixture
+def shared_test_table(create_patents_table, uid):
+    table_name = f"shared_test_table_{uid}"
+    table = create_patents_table(table_name)
+    share = SharedTable.objects.create(
+        table=table,
+        enabled=True,
+    )
+    different_schema_table = create_patents_table(table_name, schema_name="Different Schema")
+    different_schema_share = SharedTable.objects.create(
+        table=different_schema_table,
+        enabled=True,
+    )
+    yield {
+        'table': table,
+        'share': share,
+        'different_schema_table': different_schema_table,
+        'different_schema_share': different_schema_share,
+    }
+    share.delete()
+    table.delete()
+    different_schema_table.delete()
+
+
+read_client_with_different_roles = [
+    # (client_name, different_schema_status_code)
+    ('superuser_client_factory', 200),
+    ('db_manager_client_factory', 200),
+    ('db_editor_client_factory', 200),
+    ('schema_manager_client_factory', 403),
+    ('schema_viewer_client_factory', 403),
+    ('db_viewer_schema_manager_client_factory', 200)
+]
+
+
+write_client_with_different_roles = [
+    # client_name, is_allowed
+    ('superuser_client_factory', True),
+    ('db_manager_client_factory', True),
+    ('db_editor_client_factory', False),
+    ('schema_manager_client_factory', True),
+    ('schema_viewer_client_factory', False),
+    ('db_viewer_schema_manager_client_factory', True)
+]
+
+
+@pytest.mark.parametrize('client_name,different_schema_status_code', read_client_with_different_roles)
+def test_shared_table_list(
+    shared_test_table,
+    request,
+    client_name,
+    different_schema_status_code,
+):
+    client = request.getfixturevalue(client_name)(shared_test_table["table"].schema)
+    response = client.get(f'/api/ui/v0/tables/{shared_test_table["table"].id}/shares/')
+    response_data = response.json()
+
+    assert response.status_code == 200
+    assert response_data['count'] == 1
+    assert len(response_data['results']) == 1
+    result = response_data['results'][0]
+    assert result['slug'] == str(shared_test_table['share'].slug)
+    assert result['enabled'] == shared_test_table['share'].enabled
+
+    response = client.get(f'/api/ui/v0/tables/{shared_test_table["different_schema_table"].id}/shares/')
+    assert response.status_code == different_schema_status_code
+    if different_schema_status_code == 200:
+        response_data = response.json()
+        assert len(response_data['results']) == 1
+        result = response_data['results'][0]
+        assert result['slug'] == str(shared_test_table['different_schema_share'].slug)
+        assert result['enabled'] == shared_test_table['different_schema_share'].enabled
+
+
+@pytest.mark.parametrize('client_name,different_schema_status_code', read_client_with_different_roles)
+def test_shared_table_retrieve(
+    shared_test_table,
+    request,
+    client_name,
+    different_schema_status_code,
+):
+    client = request.getfixturevalue(client_name)(shared_test_table["table"].schema)
+    response = client.get(f'/api/ui/v0/tables/{shared_test_table["table"].id}/shares/{shared_test_table["share"].id}/')
+    response_data = response.json()
+
+    assert response.status_code == 200
+    assert response_data['slug'] == str(shared_test_table['share'].slug)
+    assert response_data['enabled'] == shared_test_table['share'].enabled
+
+    response = client.get(f'/api/ui/v0/tables/{shared_test_table["different_schema_table"].id}/shares/{shared_test_table["different_schema_share"].id}/')
+    assert response.status_code == different_schema_status_code
+    if different_schema_status_code == 200:
+        response_data = response.json()
+        assert response_data['slug'] == str(shared_test_table['different_schema_share'].slug)
+        assert response_data['enabled'] == shared_test_table['different_schema_share'].enabled
+
+
+@pytest.mark.parametrize('client_name,is_allowed', write_client_with_different_roles)
+def test_shared_table_create(
+    patents_table,
+    request,
+    client_name,
+    is_allowed
+):
+    client = request.getfixturevalue(client_name)(patents_table.schema)
+    data = {'enabled': True}
+    response = client.post(f'/api/ui/v0/tables/{patents_table.id}/shares/', data)
+    response_data = response.json()
+
+    if is_allowed:
+        assert response.status_code == 201
+        assert 'id' in response_data
+        assert response_data['enabled'] is True
+        created_share = SharedTable.objects.get(id=response_data['id'])
+        assert created_share is not None
+    else:
+        assert response.status_code == 403
+
+    # clean up
+    patents_table.delete()
+
+
+@pytest.mark.parametrize('client_name,is_allowed', write_client_with_different_roles)
+def test_shared_table_patch(
+    shared_test_table,
+    request,
+    client_name,
+    is_allowed
+):
+    client = request.getfixturevalue(client_name)(shared_test_table["table"].schema)
+    data = {'enabled': False}
+    response = client.patch(f'/api/ui/v0/tables/{shared_test_table["table"].id}/shares/{shared_test_table["share"].id}/', data)
+    response_data = response.json()
+
+    if is_allowed:
+        assert response.status_code == 200
+        assert response_data['slug'] == str(shared_test_table['share'].slug)
+        assert response_data['enabled'] is False
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.parametrize('client_name,is_allowed', write_client_with_different_roles)
+def test_shared_table_delete(
+    shared_test_table,
+    request,
+    client_name,
+    is_allowed
+):
+    client = request.getfixturevalue(client_name)(shared_test_table["table"].schema)
+    response = client.delete(f'/api/ui/v0/tables/{shared_test_table["table"].id}/shares/{shared_test_table["share"].id}/')
+
+    if is_allowed:
+        assert response.status_code == 204
+        assert SharedTable.objects.filter(id=shared_test_table['share'].id).first() is None
+    else:
+        assert response.status_code == 403

--- a/mathesar/urls.py
+++ b/mathesar/urls.py
@@ -51,6 +51,7 @@ urlpatterns = [
     path('administration/users/<user_id>/', views.admin_home, name='admin_users_edit'),
     path('administration/update/', views.admin_home, name='admin_update'),
     path('shares/tables/<slug>/', views.shared_table, name='shared_table'),
+    path('shares/explorations/<slug>/', views.shared_query, name='shared_query'),
     path('db/', views.home, name='db_home'),
     path('db/<db_name>/', views.schemas, name='schemas'),
     re_path(

--- a/mathesar_ui/src/api/types/queries.ts
+++ b/mathesar_ui/src/api/types/queries.ts
@@ -174,14 +174,17 @@ type QueryResultRecords =
   | PaginatedResponse<QueryResultRecord>
   | { count: 0; results: null };
 
-export interface QueryRunResponse {
+export interface QueryResultsResponse {
+  records: QueryResultRecords;
+  output_columns: QueryColumnAlias[];
+  column_metadata: Record<string, QueryColumnMetaData>;
+}
+
+export interface QueryRunResponse extends QueryResultsResponse {
   query: {
     schema: SchemaEntry['id'];
     base_table: QueryInstance['base_table'];
     initial_columns: QueryInstanceInitialColumn[];
     transformations?: QueryInstanceTransformation[];
   };
-  records: QueryResultRecords;
-  output_columns: QueryColumnAlias[];
-  column_metadata: Record<string, QueryColumnMetaData>;
 }

--- a/mathesar_ui/src/pages/exploration/ExplorationPage.svelte
+++ b/mathesar_ui/src/pages/exploration/ExplorationPage.svelte
@@ -37,6 +37,7 @@
     queryRunner = new QueryRunner({
       query: new QueryModel(_query),
       abstractTypeMap,
+      runMode: 'queryId',
     });
   }
 

--- a/mathesar_ui/src/pages/exploration/ExplorationPage.svelte
+++ b/mathesar_ui/src/pages/exploration/ExplorationPage.svelte
@@ -14,6 +14,7 @@
     QueryRunner,
     WithExplorationInspector,
   } from '@mathesar/systems/data-explorer';
+  import type { ShareConsumer } from '@mathesar/utils/shares';
   import Header from './Header.svelte';
 
   const userProfile = getUserProfileStoreFromContext();
@@ -21,6 +22,7 @@
   export let database: Database;
   export let schema: SchemaEntry;
   export let query: QueryInstance;
+  export let shareConsumer: ShareConsumer | undefined = undefined;
 
   $: canEditMetadata =
     $userProfile?.hasPermission({ database, schema }, 'canEditMetadata') ??
@@ -38,6 +40,7 @@
       query: new QueryModel(_query),
       abstractTypeMap,
       runMode: 'queryId',
+      shareConsumer,
     });
   }
 

--- a/mathesar_ui/src/pages/exploration/ExplorationPage.svelte
+++ b/mathesar_ui/src/pages/exploration/ExplorationPage.svelte
@@ -31,10 +31,13 @@
 
   function createQueryRunner(
     _query: QueryInstance,
-    abstractTypesMap: AbstractTypesMap,
+    abstractTypeMap: AbstractTypesMap,
   ) {
     queryRunner?.destroy();
-    queryRunner = new QueryRunner(new QueryModel(_query), abstractTypesMap);
+    queryRunner = new QueryRunner({
+      query: new QueryModel(_query),
+      abstractTypeMap,
+    });
   }
 
   $: createQueryRunner(query, $currentDbAbstractTypes.data);

--- a/mathesar_ui/src/routes/AnonymousAccessRoutes.svelte
+++ b/mathesar_ui/src/routes/AnonymousAccessRoutes.svelte
@@ -3,10 +3,15 @@
   import { setUserProfileStoreInContext } from '@mathesar/stores/userProfile';
   import { AnonymousViewerUserModel } from '@mathesar/stores/users';
   import SharedTableRoute from '@mathesar/routes/SharedTableRoute.svelte';
+  import SharedExplorationRoute from '@mathesar/routes/SharedExplorationRoute.svelte';
 
   setUserProfileStoreInContext(new AnonymousViewerUserModel());
 </script>
 
 <Route path="/tables/:slug/*" let:meta>
   <SharedTableRoute slug={String(meta.params.slug)} />
+</Route>
+
+<Route path="/explorations/:slug/*" let:meta>
+  <SharedExplorationRoute slug={String(meta.params.slug)} />
 </Route>

--- a/mathesar_ui/src/routes/DataExplorerRoute.svelte
+++ b/mathesar_ui/src/routes/DataExplorerRoute.svelte
@@ -33,24 +33,24 @@
 
   function createQueryManager(queryInstance: UnsavedQueryInstance) {
     queryManager?.destroy();
-    queryManager = new QueryManager(
-      new QueryModel(queryInstance),
-      $currentDbAbstractTypes.data,
-    );
+    queryManager = new QueryManager({
+      query: new QueryModel(queryInstance),
+      abstractTypeMap: $currentDbAbstractTypes.data,
+      onSave: async (instance) => {
+        try {
+          const url = getExplorationEditorPageUrl(
+            database.name,
+            schema.id,
+            instance.id,
+          );
+          router.goto(url, true);
+        } catch (err) {
+          console.error('There was an error when updating the URL', err);
+        }
+      },
+    });
     query = queryManager.query;
     is404 = false;
-    queryManager.on('save', async (instance) => {
-      try {
-        const url = getExplorationEditorPageUrl(
-          database.name,
-          schema.id,
-          instance.id,
-        );
-        router.goto(url, true);
-      } catch (err) {
-        console.error('There was an error when updating the URL', err);
-      }
-    });
   }
 
   function removeQueryManager(): void {

--- a/mathesar_ui/src/routes/ExplorationRoute.svelte
+++ b/mathesar_ui/src/routes/ExplorationRoute.svelte
@@ -23,8 +23,6 @@
   />
 
   <ExplorationPage {database} {schema} {query} />
-{:else if Number.isNaN(queryId)}
-  <ErrorPage>The specified URL is not found.</ErrorPage>
 {:else}
-  <ErrorPage>Table with id {queryId} not found.</ErrorPage>
+  <ErrorPage>The page you're looking for doesn't exist.</ErrorPage>
 {/if}

--- a/mathesar_ui/src/routes/SharedExplorationRoute.svelte
+++ b/mathesar_ui/src/routes/SharedExplorationRoute.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { Route } from 'tinro';
+  import { preloadRouteData } from '@mathesar/utils/preloadData';
+  import ErrorPage from '@mathesar/pages/ErrorPage.svelte';
+  import ExplorationPage from '@mathesar/pages/exploration/ExplorationPage.svelte';
+  import { currentDatabase } from '@mathesar/stores/databases';
+  import { currentSchema } from '@mathesar/stores/schemas';
+  import { queries } from '@mathesar/stores/queries';
+  import { ShareConsumer } from '@mathesar/utils/shares';
+
+  const routeSpecificData = preloadRouteData<{ query_id: number | null }>(
+    'shared_query',
+  );
+
+  export let slug: string;
+
+  $: queryId = routeSpecificData?.query_id ?? undefined;
+  $: query = queryId ? $queries.data.get(queryId) : undefined;
+  $: database = $currentDatabase;
+  $: schema = $currentSchema;
+
+  $: shareConsumer = new ShareConsumer({
+    slug,
+  });
+</script>
+
+<Route path="/">
+  {#if query && database && schema}
+    <ExplorationPage {database} {schema} {query} {shareConsumer} />
+  {:else}
+    <ErrorPage>The page you're looking for doesn't exist.</ErrorPage>
+  {/if}
+</Route>

--- a/mathesar_ui/src/routes/SharedTableRoute.svelte
+++ b/mathesar_ui/src/routes/SharedTableRoute.svelte
@@ -27,10 +27,10 @@
   onMount(() => handleUnmount);
 </script>
 
-{#if table}
-  <Route path="/">
+<Route path="/">
+  {#if table}
     <TablePage {table} {shareConsumer} />
-  </Route>
-{:else}
-  <ErrorPage>The page you're looking for doesn't exist.</ErrorPage>
-{/if}
+  {:else}
+    <ErrorPage>The page you're looking for doesn't exist.</ErrorPage>
+  {/if}
+</Route>

--- a/mathesar_ui/src/stores/queries.ts
+++ b/mathesar_ui/src/stores/queries.ts
@@ -56,6 +56,7 @@ import type {
   QueryResultsResponse,
 } from '@mathesar/api/types/queries';
 import { CancellablePromise } from '@mathesar-component-library';
+import { SHARED_LINK_UUID_QUERY_PARAM } from '@mathesar/utils/shares';
 
 import { currentSchemaId, addCountToSchemaNumExplorations } from './schemas';
 
@@ -281,7 +282,11 @@ export function runQuery(
 
 export function fetchQueryResults(
   queryId: number,
-  params: { limit: number; offset: number } = { limit: 100, offset: 0 },
+  params?: {
+    limit: number;
+    offset: number;
+    [SHARED_LINK_UUID_QUERY_PARAM]?: string;
+  },
 ): CancellablePromise<QueryResultsResponse> {
   const url = addQueryParamsToUrl(
     `/api/db/v0/queries/${queryId}/results/`,

--- a/mathesar_ui/src/stores/queries.ts
+++ b/mathesar_ui/src/stores/queries.ts
@@ -39,6 +39,7 @@ import {
   getAPI,
   postAPI,
   putAPI,
+  addQueryParamsToUrl,
 } from '@mathesar/api/utils/requestUtils';
 import type {
   RequestStatus,
@@ -52,6 +53,7 @@ import type {
   QueryGetResponse,
   QueryRunRequest,
   QueryRunResponse,
+  QueryResultsResponse,
 } from '@mathesar/api/types/queries';
 import { CancellablePromise } from '@mathesar-component-library';
 
@@ -275,6 +277,17 @@ export function runQuery(
   request: QueryRunRequest,
 ): CancellablePromise<QueryRunResponse> {
   return postAPI('/api/db/v0/queries/run/', request);
+}
+
+export function fetchQueryResults(
+  queryId: number,
+  params: { limit: number; offset: number } = { limit: 100, offset: 0 },
+): CancellablePromise<QueryResultsResponse> {
+  const url = addQueryParamsToUrl(
+    `/api/db/v0/queries/${queryId}/results/`,
+    params,
+  );
+  return getAPI(url);
 }
 
 export function deleteQuery(queryId: number): CancellablePromise<void> {

--- a/mathesar_ui/src/systems/data-explorer/QueryManager.ts
+++ b/mathesar_ui/src/systems/data-explorer/QueryManager.ts
@@ -82,7 +82,7 @@ export default class QueryManager extends QueryRunner {
     super({
       query,
       abstractTypeMap,
-      onRun: (response: QueryRunResponse) => {
+      onRunWithObject: (response: QueryRunResponse) => {
         this.checkAndUpdateSummarizationAfterRun(
           new QueryModel(response.query),
         );


### PR DESCRIPTION
Fixes #3034 
Fixes #3036 

*The diff appears large due to the tests added, the actual code is of reasonable size.*
*This is mainly frontend code, the backend changes are minimal.*

**This PR**:
* Bypasses authentication for query requests for valid share uuids
* Adds custom common_data for shared tables required by frontend
* Allows viewing shared queries on the frontend
* Adds basic share crud API tests

**Flows built in this PR:**
* Requests to the following endpoints should succeed with a valid `share-link-uuid`:
   - `/api/db/v0/queries/<query_pk/?shared-link-uuid=<uuid>`
   - `/api/db/v0/queries/<query_pk/results/?shared-link-uuid=<uuid>`
* The following user flows should work for the above endpoints:
   - Unauthenticated requests with valid `shared-link-uuid`
   - Authenticated requests made by users who do not have explicit access the query, but have valid `shared-link-uuid`
   - Authenticated requests made by users who have access to the query, with or without valid `shared-link-uuid`

**Testing instructions:**
* Generate a shared link for a query via API:
  - A post request to `/api/ui/v0/queries/1/shares` with `{ enabled: true }` should share the query and generate a slug. The response will be like follows:
    ```
    {
      "id": 1,
      "slug": "584cfd0p-890j-95ec-9ded-c226d46f9542",
      "enabled": true
    }
    ```
* Visit `http://localhost:8000/shares/explorations/584cfd0p-890j-95ec-9ded-c226d46f9542/` and you should be able to see a readonly view of the query.
* The following cases should be taken into account, when the link is valid:
  - a. The link should work when you're not logged into Mathesar.
  - b. The link should work when the user is logged in but does not have access to the query's schema or DB.
  - c. The link should work when the user is logged in and has access to the table.

**Frontend notes**:
* The FE initially used only the `/run` endpoint for running queries to keep code common between exploration viewing route, and data explorer routes.
* However, permission checks made it clear that the FE had to use the `/results` endpoint for the exploration page, which is also the proper endpoint to use for it. We didn't do this earlier due to a time crunch. This change is implemented in this PR.

**Backend notes**:
* The tests added are only for CRUD operations on /shares endpoints of tables and queries.
* The auth bypass tests for the /tables/* and queries/* endpoints are not implemented in this PR.
* They will be covered in upcoming PRs. 

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the `develop` branch of the repository
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
