### PR TITLE
New linting rule

### DIFF
--- a/db/records/operations/group.py
+++ b/db/records/operations/group.py
@@ -49,9 +49,9 @@ class GroupBy:
             prefix_length=None,
             extract_field=None,
     ):
-        self._columns = tuple(columns) if type(columns) != str else tuple([columns])
+        self._columns = tuple(columns) if type(columns) is not str else tuple([columns])
         self._mode = mode
-        if type(preproc) == str:
+        if type(preproc) is str:
             self._preproc = tuple([preproc])
         elif preproc is not None:
             self._preproc = tuple(preproc)
@@ -134,7 +134,7 @@ class GroupBy:
 
         elif (
                 self.mode == GroupMode.PERCENTILE.value
-                and not type(self.num_groups) == int
+                and not type(self.num_groups) is int
         ):
             raise records_exceptions.BadGroupFormat(
                 f'{GroupMode.PERCENTILE.value} mode requires integer num_groups'
@@ -182,7 +182,7 @@ class GroupBy:
             )
 
         for col in self.columns:
-            if type(col) != str:
+            if type(col) is not str:
                 raise records_exceptions.BadGroupFormat(
                     f"Group column {col} must be a string."
                 )

--- a/db/records/operations/insert.py
+++ b/db/records/operations/insert.py
@@ -159,22 +159,22 @@ def insert_from_select(from_table, target_table, engine, col_mappings=None):
         try:
             result = conn.execute(ins)
         except IntegrityError as e:
-            if type(e.orig) == NotNullViolation:
+            if type(e.orig) is NotNullViolation:
                 raise NotNullError
-            elif type(e.orig) == ForeignKeyViolation:
+            elif type(e.orig) is ForeignKeyViolation:
                 raise ForeignKeyError
-            elif type(e.orig) == UniqueViolation:
+            elif type(e.orig) is UniqueViolation:
                 # ToDo: Try to differentiate between the types of unique violations
                 # Scenario 1: Adding a duplicate value into a column with uniqueness constraint in the target table.
                 # Scenario 2: Adding a non existing value twice in a column with uniqueness constraint in the target table.
                 # Both the scenarios currently result in the same exception being thrown.
                 raise UniqueValueError
-            elif type(e.orig) == ExclusionViolation:
+            elif type(e.orig) is ExclusionViolation:
                 raise ExclusionError
             else:
                 raise e
         except ProgrammingError as e:
-            if type(e.orig) == DatatypeMismatch:
+            if type(e.orig) is DatatypeMismatch:
                 raise TypeMismatchError
             else:
                 raise e

--- a/db/records/operations/update.py
+++ b/db/records/operations/update.py
@@ -13,9 +13,9 @@ def update_record(table, engine, id_value, record_data):
                 table.update().where(primary_key_column == id_value).values(record_data)
             )
         except DataError as e:
-            if type(e.orig) == DatetimeFieldOverflow:
+            if type(e.orig) is DatetimeFieldOverflow:
                 raise InvalidDate
-            elif type(e.orig) == InvalidDatetimeFormat:
+            elif type(e.orig) is InvalidDatetimeFormat:
                 raise InvalidDateFormat
             else:
                 raise e

--- a/db/tests/constraints/utils.py
+++ b/db/tests/constraints/utils.py
@@ -4,14 +4,14 @@ from sqlalchemy import PrimaryKeyConstraint, UniqueConstraint
 def get_first_unique_constraint(table):
     constraint_list = list(table.constraints)
     for item in constraint_list:
-        if type(item) == UniqueConstraint:
+        if type(item) is UniqueConstraint:
             return item
 
 
 def assert_only_primary_key_present(table):
     constraint_list = list(table.constraints)
     assert len(constraint_list) == 1
-    assert type(constraint_list[0]) == PrimaryKeyConstraint
+    assert type(constraint_list[0]) is PrimaryKeyConstraint
 
 
 def assert_primary_key_and_unique_present(table):

--- a/db/tests/records/operations/test_select.py
+++ b/db/tests/records/operations/test_select.py
@@ -53,8 +53,8 @@ def test_get_column_cast_records(engine_with_schema):
     records = get_column_cast_records(engine, table, column_definitions)
     for record in records:
         assert (
-            type(record[COL1 + "_mod"]) == str
-            and type(record[COL2 + "_mod"]) == Decimal
+            type(record[COL1 + "_mod"]) is str
+            and type(record[COL2 + "_mod"]) is Decimal
         )
 
 
@@ -84,8 +84,8 @@ def test_get_column_cast_records_options(engine_with_schema):
     records = get_column_cast_records(engine, table, column_definitions)
     for record in records:
         assert (
-            type(record[COL1 + "_mod"]) == str
-            and type(record[COL2 + "_mod"]) == Decimal
+            type(record[COL1 + "_mod"]) is str
+            and type(record[COL2 + "_mod"]) is Decimal
         )
 
 

--- a/db/tests/types/test_email.py
+++ b/db/tests/types/test_email.py
@@ -101,7 +101,7 @@ def test_create_email_type_domain_checks_broken_emails(engine_with_schema):
                     f"SELECT '{address_incorrect}'::{email.DB_TYPE};"
                 )
             )
-        assert type(e.orig) == CheckViolation
+        assert type(e.orig) is CheckViolation
 
 
 @pytest.mark.parametrize("main_db_function,literal_param,expected_count", [

--- a/db/tests/types/test_uri.py
+++ b/db/tests/types/test_uri.py
@@ -224,7 +224,7 @@ def test_uri_type_domain_rejects_malformed_uris(engine_with_schema, test_str):
     with pytest.raises(IntegrityError) as e:
         with engine.begin() as conn:
             conn.execute(text(f"SELECT '{test_str}'::{uri.DB_TYPE}"))
-        assert type(e.orig) == CheckViolation
+        assert type(e.orig) is CheckViolation
 
 
 @pytest.mark.parametrize("main_db_function,literal_param,expected_count", [

--- a/mathesar/api/db/viewsets/constraints.py
+++ b/mathesar/api/db/viewsets/constraints.py
@@ -35,7 +35,7 @@ class ConstraintViewSet(AccessViewSetMixin, ListModelMixin, RetrieveModelMixin, 
         try:
             constraint.drop()
         except ProgrammingError as e:
-            if type(e.orig) == UndefinedObject:
+            if type(e.orig) is UndefinedObject:
                 raise base_api_exceptions.NotFoundAPIException(e)
             else:
                 raise base_database_api_exceptions.ProgrammingAPIException(e)

--- a/mathesar/api/db/viewsets/tables.py
+++ b/mathesar/api/db/viewsets/tables.py
@@ -155,7 +155,7 @@ class TableViewSet(AccessViewSetMixin, CreateModelMixin, RetrieveModelMixin, Lis
         try:
             preview_records = table.get_preview(columns)
         except (DataError, IntegrityError) as e:
-            if type(e.orig) == InvalidTextRepresentation or type(e.orig) == CheckViolation:
+            if type(e.orig) is InvalidTextRepresentation or type(e.orig) is CheckViolation:
                 raise database_api_exceptions.InvalidTypeCastAPIException(
                     e,
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/mathesar/api/exceptions/mixins.py
+++ b/mathesar/api/exceptions/mixins.py
@@ -24,7 +24,7 @@ class MathesarErrorMessageMixin(FriendlyErrorMessagesMixin):
             # Since our exception is an object instead of a string, the object properties are mistaken to be fields of a serializer,
             # and it gets converted into {'field': [error strings]} by DRF
             # We need to convert it to dictionary of list of object and return it instead of passing it down the line
-            scalar_errors = dict(map(lambda item: (item[0], item[1][0] if type(item[1]) == list else item[1]), errors.items()))
+            scalar_errors = dict(map(lambda item: (item[0], item[1][0] if type(item[1]) is list else item[1]), errors.items()))
             return [scalar_errors]
         for error_type in errors:
             error = errors[error_type]
@@ -35,12 +35,12 @@ class MathesarErrorMessageMixin(FriendlyErrorMessagesMixin):
                     pretty.extend(self.get_non_field_error_entries(errors[error_type]))
             else:
                 field = self.get_serializer_fields(self.initial_data).fields[error_type]
-                if isinstance(field, Serializer) and type(errors[error_type]) == dict:
+                if isinstance(field, Serializer) and type(errors[error_type]) is dict:
                     field.initial_data = self.initial_data[error_type]
                     child_errors = field.build_pretty_errors(errors[error_type])
                     pretty += child_errors
                     continue
-                if isinstance(field, ListSerializer) and type(errors[error_type]) == list:
+                if isinstance(field, ListSerializer) and type(errors[error_type]) is list:
                     pretty_child_errors = []
                     for index, child_error in enumerate(errors[error_type]):
                         child_field = field.child

--- a/mathesar/api/serializers/records.py
+++ b/mathesar/api/serializers/records.py
@@ -35,20 +35,20 @@ class RecordSerializer(MathesarErrorMessageMixin, serializers.BaseSerializer):
                 status_code=status.HTTP_400_BAD_REQUEST
             )
         except IntegrityError as e:
-            if type(e.orig) == NotNullViolation:
+            if type(e.orig) is NotNullViolation:
                 raise database_api_exceptions.NotNullViolationAPIException(
                     e,
                     status_code=status.HTTP_400_BAD_REQUEST,
                     table=table
                 )
-            elif type(e.orig) == UniqueViolation:
+            elif type(e.orig) is UniqueViolation:
                 raise database_api_exceptions.UniqueViolationAPIException(
                     e,
                     message="The requested update violates a uniqueness constraint",
                     table=table,
                     status_code=status.HTTP_400_BAD_REQUEST,
                 )
-            elif type(e.orig) == CheckViolation:
+            elif type(e.orig) is CheckViolation:
                 raise database_api_exceptions.CheckViolationAPIException(
                     e,
                     status_code=status.HTTP_400_BAD_REQUEST
@@ -62,20 +62,20 @@ class RecordSerializer(MathesarErrorMessageMixin, serializers.BaseSerializer):
         try:
             record = table.create_record_or_records(validated_data)
         except IntegrityError as e:
-            if type(e.orig) == NotNullViolation:
+            if type(e.orig) is NotNullViolation:
                 raise database_api_exceptions.NotNullViolationAPIException(
                     e,
                     status_code=status.HTTP_400_BAD_REQUEST,
                     table=table
                 )
-            elif type(e.orig) == UniqueViolation:
+            elif type(e.orig) is UniqueViolation:
                 raise database_api_exceptions.UniqueViolationAPIException(
                     e,
                     message="The requested insert violates a uniqueness constraint",
                     table=table,
                     status_code=status.HTTP_400_BAD_REQUEST,
                 )
-            elif type(e.orig) == CheckViolation:
+            elif type(e.orig) is CheckViolation:
                 raise database_api_exceptions.CheckViolationAPIException(
                     e,
                     status_code=status.HTTP_400_BAD_REQUEST

--- a/mathesar/tests/api/test_constraint_api.py
+++ b/mathesar/tests/api/test_constraint_api.py
@@ -66,14 +66,14 @@ def _verify_foreign_key_constraint(
     assert constraint_data['onupdate'] == onupdate
     assert constraint_data['ondelete'] == ondelete
     assert constraint_data['deferrable'] == deferrable
-    assert 'id' in constraint_data and type(constraint_data['id']) == int
+    assert 'id' in constraint_data and type(constraint_data['id']) is int
 
 
 def _verify_unique_constraint(constraint_data, columns, name):
     assert constraint_data['columns'] == columns
     assert constraint_data['name'] == name
     assert constraint_data['type'] == 'unique'
-    assert 'id' in constraint_data and type(constraint_data['id']) == int
+    assert 'id' in constraint_data and type(constraint_data['id']) is int
 
 
 write_client_with_different_roles = [
@@ -118,7 +118,7 @@ def test_default_constraint_list(create_patents_table, client):
     assert response.status_code == 200
     assert response_data['count'] == 1
     assert constraint_data['columns'] == [constraint_column_id]
-    assert 'id' in constraint_data and type(constraint_data['id']) == int
+    assert 'id' in constraint_data and type(constraint_data['id']) is int
     assert constraint_data['name'] == 'NASA Constraint List 0_pkey'
     assert constraint_data['type'] == 'primary'
 


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3115 

<!-- Concisely describe what the pull request does. -->

This modifies all type comparisons to use `is` or `is not` rather than `==` or `!=`, respectively.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `develop` branch of the repository
- [X] My commit messages follow [best practices][best_practices].
- [X] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
