### PR TITLE
Tests for links & constraints ddl

### DIFF
--- a/db/tests/constraints/operations/test_create.py
+++ b/db/tests/constraints/operations/test_create.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import patch
+import db.constraints.operations.create as con_create
+from db.constraints.base import UniqueConstraint, ForeignKeyConstraint
+
+
+@pytest.mark.parametrize(
+    "constraint_obj", [
+        (UniqueConstraint(
+            name='test_uq_con',
+            table_oid=12345,
+            columns_attnum=[80085, 53301]
+        )),
+        (ForeignKeyConstraint(
+            name='test_fk_con',
+            table_oid=12345,
+            columns_attnum=[80085],
+            referent_table_oid=54321,
+            referent_columns_attnum=[53301],
+            options={'match_type': 'f', 'on_update': 'r', 'on_delete': 'c'}
+        ))]
+)
+def test_add_constraint_db(engine_with_schema, constraint_obj):
+    engine = engine_with_schema
+    with patch.object(con_create, 'execute_msar_func_with_engine') as mock_exec:
+        con_create.add_constraint(
+            engine=engine,
+            constraint_obj=constraint_obj
+        )
+    call_args = mock_exec.call_args_list[0][0]
+    assert call_args[0] == engine
+    assert call_args[1] == "add_constraints"
+    assert call_args[2] == constraint_obj.table_oid
+    assert call_args[3] == constraint_obj.get_constraint_def_json()

--- a/db/tests/constraints/operations/test_drop.py
+++ b/db/tests/constraints/operations/test_drop.py
@@ -1,31 +1,19 @@
-from sqlalchemy import String, Integer, Column, Table, MetaData
-from db.constraints.base import UniqueConstraint
-from db.constraints.operations.create import add_constraint
-from db.constraints.operations.drop import drop_constraint
-from db.tables.operations.select import get_oid_from_table, reflect_table_from_oid
-from db.tests.constraints import utils as test_utils
-from db.metadata import get_empty_metadata
+from unittest.mock import patch
+import db.constraints.operations.drop as con_drop
 
 
-def test_drop_unique_constraint(engine_with_schema):
-    engine, schema = engine_with_schema
-    table_name = "orders_3"
-    unique_column_name = 'product_name'
-    table = Table(
-        table_name,
-        MetaData(bind=engine, schema=schema),
-        Column('order_id', Integer, primary_key=True),
-        Column(unique_column_name, String),
-    )
-    table.create()
-
-    table_oid = get_oid_from_table(table_name, schema, engine)
-    uq_constraint = UniqueConstraint(None, table_oid, [unique_column_name])
-    add_constraint(uq_constraint, engine)
-    altered_table = reflect_table_from_oid(table_oid, engine, metadata=get_empty_metadata())
-    test_utils.assert_primary_key_and_unique_present(altered_table)
-    unique_constraint = test_utils.get_first_unique_constraint(altered_table)
-
-    drop_constraint(table_name, schema, engine, unique_constraint.name)
-    new_altered_table = reflect_table_from_oid(table_oid, engine, metadata=get_empty_metadata())
-    test_utils.assert_only_primary_key_present(new_altered_table)
+def test_drop_constraint_db(engine_with_schema):
+    engine, schema_name = engine_with_schema
+    with patch.object(con_drop, 'execute_msar_func_with_engine') as mock_exec:
+        con_drop.drop_constraint(
+            engine=engine,
+            schema_name=schema_name,
+            table_name='test_table_name',
+            constraint_name='test_constraint_name'
+        )
+    call_args = mock_exec.call_args_list[0][0]
+    assert call_args[0] == engine
+    assert call_args[1] == "drop_constraint"
+    assert call_args[2] == schema_name
+    assert call_args[3] == "test_table_name"
+    assert call_args[4] == "test_constraint_name"

--- a/db/tests/links/operations/test_create.py
+++ b/db/tests/links/operations/test_create.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import patch
+import db.links.operations.create as link_create
+
+
+@pytest.mark.parametrize(
+    "unique_link", [(True), (False), (None)]
+)
+def test_create_foreign_key_link(engine_with_schema, unique_link):
+    engine = engine_with_schema
+    with patch.object(link_create, 'execute_msar_func_with_engine') as mock_exec:
+        link_create.create_foreign_key_link(
+            engine=engine,
+            referent_table_oid=12345,
+            referrer_table_oid=54321,
+            referrer_column_name='actor_id',
+            unique_link=unique_link
+        )
+    call_args = mock_exec.call_args_list[0][0]
+    assert call_args[0] == engine
+    assert call_args[1] == "create_many_to_one_link"
+    assert call_args[2] == 12345
+    assert call_args[3] == 54321
+    assert call_args[4] == "actor_id"
+    assert call_args[5] == unique_link or False

--- a/db/tests/links/operations/test_create.py
+++ b/db/tests/links/operations/test_create.py
@@ -23,3 +23,23 @@ def test_create_foreign_key_link(engine_with_schema, unique_link):
     assert call_args[3] == 54321
     assert call_args[4] == "actor_id"
     assert call_args[5] == unique_link or False
+
+
+@pytest.mark.skip(reason="Python layer function not calling the sql layer function yet.")
+def test_many_to_many_link(engine_with_schema):
+    engine, schema = engine_with_schema
+    referents = {'referent_table': [12345, 54321], 'column_names': ['movie_id', 'actor_id']}
+    with patch.object(link_create, 'execute_msar_func_with_engine') as mock_exec:
+        link_create.create_many_to_many_link(
+            engine=engine,
+            schema=schema,
+            referents=referents,
+            map_table_name='movies_actors'
+        )
+    call_args = mock_exec.call_args_list[0][0]
+    assert call_args[0] == engine
+    assert call_args[1] == "create_many_to_many_link"
+    assert call_args[2] == schema
+    assert call_args[3] == "movies_actors"
+    assert call_args[4] == referents['referent_table']
+    assert call_args[5] == referents['column_names']


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #2737

<!-- Concisely describe what the pull request does. -->

**Technical details**

Improves the SQL layer test suite for links & constraints related ddl operations, also removes now redundant python layer tests for the same.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
