### PR TITLE
Add pldebugger to dev db

### DIFF
--- a/Dockerfile.devdb
+++ b/Dockerfile.devdb
@@ -1,4 +1,4 @@
 FROM postgres:13
 
 RUN apt update
-RUN apt install -y postgresql-13-pgtap && rm -rf /var/lib/apt/lists/*
+RUN apt install -y postgresql-13-pgtap postgresql-13-pldebugger && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
   # It is used to run automated test cases to verify if the app works as intended
   dev-db:
     container_name: mathesar_dev_db
+    command: ["postgres", "-c", "shared_preload_libraries=plugin_debugger"]
     build:
       context: .
       dockerfile: Dockerfile.devdb


### PR DESCRIPTION
Indirectly part of my work on dynamic defaults.

Adds a debugger to our dev Postgres db. Helps to work with our `plpgsql` code that @mathemancer has been steadily introducing as part of the removing sqlalchemy project.

My current prefered way to use it is via [pgadmin4's debugger](https://www.pgadmin.org/docs/pgadmin4/development/debugger.html). Before using, debugger's extension must be created via `CREATE EXTENSION pldbgapi;`.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
