### PR TITLE
Fix `NaN:NaN` error while aggregating duration column

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -262,6 +262,7 @@ LIBRARY_SQL = os.path.join(RESOURCES, "library_without_checkouts.sql")
 LIBRARY_CHECKOUTS_SQL = os.path.join(RESOURCES, "library_add_checkouts.sql")
 FRAUDULENT_PAYMENTS_SQL = os.path.join(RESOURCES, "fraudulent_payments.sql")
 PLAYER_PROFILES_SQL = os.path.join(RESOURCES, "player_profiles.sql")
+MARATHON_ATHLETES_SQL = os.path.join(RESOURCES, "marathon_athletes.sql")
 
 
 @pytest.fixture
@@ -366,4 +367,21 @@ def players_db_table(engine_with_player_profiles):
     engine, schema = engine_with_player_profiles
     metadata = MetaData(bind=engine)
     table = Table("Players", metadata, schema=schema, autoload_with=engine)
+    return table
+
+
+@pytest.fixture
+def engine_with_marathon_athletes(engine_with_schema):
+    engine, schema = engine_with_schema
+    with engine.begin() as conn, open(MARATHON_ATHLETES_SQL) as f:
+        conn.execute(text(f"SET search_path={schema}"))
+        conn.execute(text(f.read()))
+    yield engine, schema
+
+
+@pytest.fixture
+def athletes_db_table(engine_with_marathon_athletes):
+    engine, schema = engine_with_marathon_athletes
+    metadata = MetaData(bind=engine)
+    table = Table("Marathon", metadata, schema=schema, autoload_with=engine)
     return table

--- a/db/tests/resources/marathon_athletes.sql
+++ b/db/tests/resources/marathon_athletes.sql
@@ -48,4 +48,3 @@ INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
 
 INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
 ('Florence Kiplagat', 'Female', 'PT2H17M45S', 'Chicago');
-

--- a/db/tests/resources/marathon_athletes.sql
+++ b/db/tests/resources/marathon_athletes.sql
@@ -1,0 +1,51 @@
+CREATE TABLE "Marathon" (
+  id integer NOT NULL,
+  "athlete" VARCHAR(255),
+  "gender" VARCHAR(255),
+  "finish time" Interval,
+  "city" VARCHAR(255)
+);
+
+CREATE SEQUENCE "Marathon_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE "Marathon_id_seq" OWNED BY "Marathon".id;
+
+ALTER TABLE ONLY "Marathon" 
+  ALTER COLUMN id SET DEFAULT nextval('"Marathon_id_seq"'::regclass);
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Eliud Kipchoge', 'Male', 'PT2H1M39S', 'Berlin');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Brigid Kosgei', 'Female', 'PT2H14M4S', 'Chicago');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Dennis Kimetto', 'Male', 'PT2H2M57S', 'Berlin');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Paula Radcliffe', 'Female', 'PT2H15M25S', 'London');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Haile Gebrselassie', 'Male', 'PT2H3M59S', 'Berlin');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Mary Keitany', 'Female', 'PT2H18M35S', 'London');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Geoffrey Kamworor', 'Male', 'PT2H4M0S', 'Berlin');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Tirunesh Dibaba', 'Female', 'PT2H17M56S', 'London');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Wilson Kipsang', 'Male', 'PT2H3M23S', 'Berlin');
+
+INSERT INTO "Marathon" ("athlete", "gender", "finish time", "city") VALUES
+('Florence Kiplagat', 'Female', 'PT2H17M45S', 'Chicago');
+

--- a/db/types/custom/datetime.py
+++ b/db/types/custom/datetime.py
@@ -3,9 +3,11 @@ from sqlalchemy.dialects.postgresql import DATE as SA_DATE
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.dialects.postgresql import TIME as SA_TIME
 from sqlalchemy.dialects.postgresql import TIMESTAMP as SA_TIMESTAMP
+from sqlalchemy.dialects.postgresql import TEXT as SA_TEXT
 from sqlalchemy.types import TypeDecorator
 
 from db.types.exceptions import InvalidTypeParameters
+from db.types.custom.underlying_type import HasUnderlyingType
 
 
 class DATE(TypeDecorator):
@@ -186,9 +188,10 @@ class TIMESTAMP_WITH_TIME_ZONE(TypeDecorator):
         )
 
 
-class Interval(TypeDecorator):
+class Interval(TypeDecorator, HasUnderlyingType):
     impl = INTERVAL
     cache_ok = True
+    underlying_type = SA_TEXT
 
     def __init__(self, *arg, **kwarg):
         TypeDecorator.__init__(self, *arg, **kwarg)

--- a/mathesar/tests/api/conftest.py
+++ b/mathesar/tests/api/conftest.py
@@ -310,6 +310,12 @@ def players_ma_table(db_table_to_dj_table, players_db_table):
 
 
 @pytest.fixture
+def athletes_ma_table(db_table_to_dj_table, athletes_db_table):
+    reset_reflection()
+    return db_table_to_dj_table(athletes_db_table)
+
+
+@pytest.fixture
 def table_with_unknown_types(create_schema, get_uid, engine):
     prefix = "unknown_types"
     schema_name = f"schema_{prefix}_{get_uid()}"

--- a/mathesar/tests/api/query/test_aggregation_functions.py
+++ b/mathesar/tests/api/query/test_aggregation_functions.py
@@ -1048,7 +1048,6 @@ def test_list_aggregation_intrval(athletes_ma_table, get_uid, client):
     assert sorted(actual_records, key=lambda x: x['city']) == expect_records
 
 
-
 def test_list_aggregation_mathesar_json_array(players_ma_table, get_uid, client):
     _ = players_ma_table
     players = {


### PR DESCRIPTION
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #2963 

<!-- Concisely describe what the pull request does. -->

**Technical details**

This PR:
- Downcast `Interval` to `string`. (which eventually fixes the `NaN:NaN` part).
- Adds some tests for the same.

<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

**Screenshots**
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
<img width="960" alt="image" src="https://github.com/centerofci/mathesar/assets/64671908/a06efa49-c763-48fb-b6e4-c7b517ab5d9f">


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
