### PR TITLE
Add tests for third party table with long identifiers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -54,7 +54,7 @@ def create_db(request, SES_engine_cache):
     A factory for Postgres mathesar-installed databases. A fixture made of this method tears down
     created dbs when leaving scope.
 
-    This method is used to create two fixtures with different scopes, that's why it's not a fixture
+    This method is used to create fixtures with different scopes, that's why it's not a fixture
     itself.
     """
     engine_cache = SES_engine_cache

--- a/mathesar/tests/api/test_column_api.py
+++ b/mathesar/tests/api/test_column_api.py
@@ -9,9 +9,6 @@ from db.types.base import PostgresType, MathesarCustomType
 
 from mathesar.api.exceptions.error_codes import ErrorCodes
 from mathesar.tests.api.test_table_api import check_columns_response
-from mathesar.api.exceptions.database_exceptions import (
-    exceptions as database_api_exceptions
-)
 
 
 def test_column_list(column_test_table, client):
@@ -171,22 +168,6 @@ def test_column_create(table_fixture, client, request):
     assert actual_new_col["name"] == name
     assert actual_new_col["type"] == db_type.id
     assert actual_new_col["default"] is None
-
-
-def test_column_create_with_long_column_name(column_test_table, client):
-    very_long_string = ''.join(map(str, range(50)))
-    name = 'very_long_identifier_' + very_long_string
-    db_type = PostgresType.NUMERIC
-    data = {
-        "name": name,
-        "type": db_type.id,
-    }
-    response = client.post(
-        f"/api/db/v0/tables/{column_test_table.id}/columns/",
-        data=data,
-    )
-    assert response.status_code == 400
-    assert response.json()[0]['code'] == database_api_exceptions.IdentifierTooLong.error_code
 
 
 @pytest.mark.parametrize('client_name, expected_status_code', write_client_with_different_roles)

--- a/mathesar/tests/api/test_long_identifiers.py
+++ b/mathesar/tests/api/test_long_identifiers.py
@@ -1,0 +1,206 @@
+import pytest
+
+from sqlalchemy.sql import text
+
+from django.core.files.base import File
+
+from db.types.base import PostgresType
+from db.identifiers import truncate_if_necessary, POSTGRES_IDENTIFIER_SIZE_LIMIT
+
+from mathesar.api.exceptions.database_exceptions import (
+    exceptions as database_api_exceptions
+)
+from mathesar.models.base import DataFile
+
+from mathesar.tests.api.test_table_api import check_create_table_response, get_expected_name
+
+
+def _get_string_of_length(n):
+    def return_a_character(_):
+        return 'x'
+    return ''.join(map(return_a_character, range(n)))
+
+
+@pytest.fixture
+def long_column_data_file():
+    data_filepath = 'mathesar/tests/data/long_column_names.csv'
+    with open(data_filepath, "rb") as csv_file:
+        data_file = DataFile.objects.create(
+            file=File(csv_file),
+            created_from='file',
+            base_name='longdatafiled',
+            type='csv'
+        )
+    return data_file
+
+
+@pytest.fixture
+def dj_model_of_preexisting_db(worker_id, FUN_create_dj_db, FUN_engine_cache):
+    db_name = f"preexisting_db_{worker_id}"
+    db_model = FUN_create_dj_db(db_name)
+    engine = FUN_engine_cache(db_name)
+    max_length_identifier = _get_string_of_length(
+        POSTGRES_IDENTIFIER_SIZE_LIMIT
+    )
+    with engine.connect() as con:
+        statement = text(f"""
+            CREATE TABLE public.persons (
+                {max_length_identifier} INT PRIMARY KEY
+            );
+        """)
+        con.execute(statement)
+        con.commit()
+    return db_model
+
+
+def test_long_identifier_in_prexisting_db(dj_model_of_preexisting_db, client):
+    """
+    Checks that the table and column endpoints work for a third-party db with
+    an identifier that has maximum length supported by Postgres.
+    """
+    response = client.get("/api/db/v0/tables/")
+    json = response.json()
+    assert response.status_code == 200
+    assert json['count'] == 1
+    table_json = json['results'][0]
+    assert table_json['name'] == 'persons'
+    table_id = table_json['id']
+    response = client.get(
+        f"/api/db/v0/tables/{table_id}/columns/",
+    )
+    json = response.json()
+    assert response.status_code == 200
+    column_json = json['results'][0]
+    assert len(column_json['name']) == POSTGRES_IDENTIFIER_SIZE_LIMIT
+
+
+def test_column_create_with_long_column_name(column_test_table, client):
+    very_long_string = ''.join(map(str, range(50)))
+    name = 'very_long_identifier_' + very_long_string
+    db_type = PostgresType.NUMERIC
+    data = {
+        "name": name,
+        "type": db_type.id,
+    }
+    response = client.post(
+        f"/api/db/v0/tables/{column_test_table.id}/columns/",
+        data=data,
+    )
+    assert response.status_code == 400
+    assert response.json()[0]['code'] == database_api_exceptions.IdentifierTooLong.error_code
+
+
+@pytest.mark.parametrize(
+    'before_truncation, after_truncation',
+    [
+        [
+            "bbbbbbbbbbbbbb",
+            "bbbbbbbbbbbbbb",
+        ],
+        [
+            "cccccccccccccccccccccc",
+            "cccccccccccccccccccccc",
+        ],
+        [
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ],
+        [
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "fffffffffffffffffffffffffffffffffffffff-7e43d30e"
+        ],
+        [
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-d0ccef3c",
+        ],
+        [
+            "ggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
+            "ggggggggggggggggggggggggggggggggggggggg-2910cecf",
+        ],
+    ]
+)
+def test_truncate_if_necessary(before_truncation, after_truncation):
+    assert truncate_if_necessary(before_truncation) == after_truncation
+
+
+def test_create_table_long_name_data_file(client, long_column_data_file, create_schema, uid):
+    table_name = 'My Long column name datafile'
+    # response, response_table, table = _create_table(
+    # )
+    expt_name = get_expected_name(table_name, data_file=long_column_data_file)
+    first_row = (
+        1, 'NATION', '8.6', '4.5', '8.5', '4.3', '8.3', '4.6', '78.6', '2.22',
+        '0.88', '0.66', '1.53', '3.75', '3.26', '0.45', '0.07', '53.9', '52.3',
+        '0.8', '0.38487', '3.15796', '2.3', '33247', '14.842144', '6.172333',
+        '47.158545', '1.698662', '2.345577', '7.882694', '0.145406', '3.395302',
+        '92.085375', '14.447634', '78.873848', '1.738571', '16.161024',
+        '19.436701', '8.145643', '94.937079', '74.115131', '75.601680',
+        '22.073834', '11.791045', '1.585233',
+        '1.016932', '2023-02-01'
+    )
+    column_names = [
+        "State or Nation",
+        "Cycle 1 Total Number of Health Deficiencies",
+        "Cycle 1 Total Number of Fire Safety Deficiencies",
+        "Cycle 2 Total Number of Health Deficiencies",
+        "Cycle 2 Total Number of Fire Safety Deficiencies",
+        "Cycle 3 Total Number of Health Deficiencies",
+        "Cycle 3 Total Number of Fire Safety Deficiencies",
+        "Average Number of Residents per Day",
+        "Reported Nurse Aide Staffing Hours per Resident per Day",
+        "Reported LPN Staffing Hours per Resident per Day",
+        "Reported RN Staffing Hours per Resident per Day",
+        "Reported Licensed Staffing Hours per Resident per Day",
+        "Reported Total Nurse Staffing Hours per Resident per Day",
+        "Total number of nurse staff hours per resident per day on the weekend",
+        "Registered Nurse hours per resident per day on the weekend",
+        "Reported Physical Therapist Staffing Hours per Resident Per Day",
+        "Total nursing staff turnover",
+        "Registered Nurse turnover",
+        "Number of administrators who have left the nursing home",
+        "Case-Mix RN Staffing Hours per Resident per Day",
+        "Case-Mix Total Nurse Staffing Hours per Resident per Day",
+        "Number of Fines",
+        "Fine Amount in Dollars",
+        "Percentage of long stay residents whose need for help with daily activities has increased",
+        "Percentage of long stay residents who lose too much weight",
+        "Percentage of low risk long stay residents who lose control of their bowels or bladder",
+        "Percentage of long stay residents with a catheter inserted and left in their bladder",
+        "Percentage of long stay residents with a urinary tract infection",
+        "Percentage of long stay residents who have depressive symptoms",
+        "Percentage of long stay residents who were physically restrained",
+        "Percentage of long stay residents experiencing one or more falls with major injury",
+        "Percentage of long stay residents assessed and appropriately given the pneumococcal vaccine",
+        "Percentage of long stay residents who received an antipsychotic medication",
+        "Percentage of short stay residents assessed and appropriately given the pneumococcal vaccine",
+        "Percentage of short stay residents who newly received an antipsychotic medication",
+        "Percentage of long stay residents whose ability to move independently worsened",
+        "Percentage of long stay residents who received an antianxiety or hypnotic medication",
+        "Percentage of high risk long stay residents with pressure ulcers",
+        "Percentage of long stay residents assessed and appropriately given the seasonal influenza vaccine",
+        "Percentage of short stay residents who made improvements in function",
+        "Percentage of short stay residents who were assessed and appropriately given the seasonal influenza vaccine",
+        "Percentage of short stay residents who were rehospitalized after a nursing home admission",
+        "Percentage of short stay residents who had an outpatient emergency department visit",
+        "Number of hospitalizations per 1000 long-stay resident days",
+        "Number of outpatient emergency department visits per 1000 long-stay resident days",
+        "Processing Date"
+    ]
+    # Make sure at least some column names require truncation;
+    # 63 is the hard Postgres limit; we're also experiencing problems with ids
+    # as short as 58 characters, but I'll leave this at 63 so that it doesn't
+    # have to be updated once that's fixed.
+    assert any(
+        len(column_name) >= 63
+        for column_name
+        in column_names
+    )
+    processed_column_names = [truncate_if_necessary(col) for col in column_names]
+    schema = create_schema(uid)
+    table = check_create_table_response(
+        client, table_name, expt_name, long_column_data_file, schema, first_row,
+        processed_column_names, import_target_table=None
+    )
+    # This just makes sure we can get records. This was a bug with long column names.
+    response = client.get(f'/api/db/v0/tables/{table.id}/records/')
+    assert response.status_code == 200

--- a/mathesar/tests/api/test_long_identifiers.py
+++ b/mathesar/tests/api/test_long_identifiers.py
@@ -71,6 +71,16 @@ def test_long_identifier_in_prexisting_db(dj_model_of_preexisting_db, client):
     json = response.json()
     assert response.status_code == 200
     column_json = json['results'][0]
+    column_id = column_json['id']
+    assert len(column_json['name']) == POSTGRES_IDENTIFIER_SIZE_LIMIT
+    db_type = PostgresType.BOOLEAN
+    data = {"type": db_type.id}
+    response = client.patch(
+        f"/api/db/v0/tables/{table_id}/columns/{column_id}/", data=data
+    )
+    assert response.status_code == 200
+    json = response.json()
+    column_json = json
     assert len(column_json['name']) == POSTGRES_IDENTIFIER_SIZE_LIMIT
 
 

--- a/mathesar/tests/api/test_table_api.py
+++ b/mathesar/tests/api/test_table_api.py
@@ -6,7 +6,6 @@ from django.core.files.base import File, ContentFile
 from sqlalchemy import text
 
 from db.columns.operations.select import get_column_attnum_from_name, get_column_attnum_from_names_as_map
-from db.identifiers import truncate_if_necessary
 from db.types.base import PostgresType, MathesarCustomType
 from db.metadata import get_empty_metadata
 from mathesar.models.users import DatabaseRole, SchemaRole
@@ -15,20 +14,6 @@ from mathesar.models.query import UIQuery
 from mathesar.state import reset_reflection
 from mathesar.api.exceptions.error_codes import ErrorCodes
 from mathesar.models.base import Column, Table, DataFile
-
-
-# DUPLICATE: We need a better testing organization schema. Now is not the time to fix.
-@pytest.fixture
-def long_column_data_file():
-    data_filepath = 'mathesar/tests/data/long_column_names.csv'
-    with open(data_filepath, "rb") as csv_file:
-        data_file = DataFile.objects.create(
-            file=File(csv_file),
-            created_from='file',
-            base_name='longdatafiled',
-            type='csv'
-        )
-    return data_file
 
 
 @pytest.fixture
@@ -168,7 +153,7 @@ def _create_table(client, data_files, table_name, schema, import_target_table, d
     return response, response_table, table
 
 
-def _get_expected_name(table_name, data_file=None):
+def get_expected_name(table_name, data_file=None):
     if not table_name and data_file:
         return data_file.base_name
     elif not table_name and data_file is None:
@@ -593,7 +578,7 @@ def test_table_previews_missing_columns(client, type_inference_table):
 
 @pytest.mark.parametrize('table_name', ['Test Table Create From Datafile', ''])
 def test_table_create_from_datafile(client, data_file, schema, table_name):
-    expt_name = _get_expected_name(table_name, data_file=data_file)
+    expt_name = get_expected_name(table_name, data_file=data_file)
     first_row = (1, 'NASA Kennedy Space Center', 'Application', 'KSC-12871', '0',
                  '13/033,085', 'Polyimide Wire Insulation Repair System', None)
     column_names = ['Center', 'Status', 'Case Number', 'Patent Number',
@@ -607,7 +592,7 @@ def test_table_create_from_datafile(client, data_file, schema, table_name):
 @pytest.mark.parametrize('table_name', ['Test Table Create From Datafile', ''])
 def test_table_create_from_datafile_with_import_target(client, data_file, schema, table_name):
     _, _, import_target_table = _create_table(client, None, 'target_table', schema, import_target_table=None)
-    expt_name = _get_expected_name(table_name, data_file=data_file)
+    expt_name = get_expected_name(table_name, data_file=data_file)
     first_row = (1, 'NASA Kennedy Space Center', 'Application', 'KSC-12871', '0',
                  '13/033,085', 'Polyimide Wire Insulation Repair System', None)
     column_names = ['Center', 'Status', 'Case Number', 'Patent Number',
@@ -620,7 +605,7 @@ def test_table_create_from_datafile_with_import_target(client, data_file, schema
 
 @pytest.mark.parametrize('table_name', ['Test Table Create From Paste', ''])
 def test_table_create_from_paste(client, schema, paste_data_file, table_name):
-    expt_name = _get_expected_name(table_name)
+    expt_name = get_expected_name(table_name)
     first_row = (1, 'NASA Kennedy Space Center', 'Application', 'KSC-12871', '0',
                  '13/033,085', 'Polyimide Wire Insulation Repair System', None)
     column_names = ['Center', 'Status', 'Case Number', 'Patent Number',
@@ -633,7 +618,7 @@ def test_table_create_from_paste(client, schema, paste_data_file, table_name):
 
 @pytest.mark.parametrize('table_name', ['Test Table Create From URL', ''])
 def test_table_create_from_url(client, schema, url_data_file, table_name):
-    expt_name = _get_expected_name(table_name, data_file=url_data_file)
+    expt_name = get_expected_name(table_name, data_file=url_data_file)
     first_row = (1, 'NASA Kennedy Space Center', 'Application', 'KSC-12871', '0',
                  '13/033,085', 'Polyimide Wire Insulation Repair System', None)
     column_names = ['center', 'status', 'case_number', 'patent_number',
@@ -648,7 +633,7 @@ def test_table_create_from_url(client, schema, url_data_file, table_name):
 @pytest.mark.parametrize('table_name', ['test_table_no_file', ''])
 def test_table_create_without_datafile(client, schema, data_files, table_name):
     num_tables = Table.objects.count()
-    expt_name = _get_expected_name(table_name)
+    expt_name = get_expected_name(table_name)
 
     expect_comment = 'test comment for table create'
     response, response_table, table = _create_table(
@@ -1804,123 +1789,9 @@ def test_table_ui_dependency(client, create_patents_table, get_uid):
     assert response_data == expected_response
 
 
-@pytest.mark.parametrize(
-    'before_truncation, after_truncation',
-    [
-        [
-            "bbbbbbbbbbbbbb",
-            "bbbbbbbbbbbbbb",
-        ],
-        [
-            "cccccccccccccccccccccc",
-            "cccccccccccccccccccccc",
-        ],
-        [
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        ],
-        [
-            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            "fffffffffffffffffffffffffffffffffffffff-7e43d30e"
-        ],
-        [
-            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-d0ccef3c",
-        ],
-        [
-            "ggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
-            "ggggggggggggggggggggggggggggggggggggggg-2910cecf",
-        ],
-    ]
-)
-def test_truncate_if_necessary(before_truncation, after_truncation):
-    assert truncate_if_necessary(before_truncation) == after_truncation
-
-
-def test_create_table_long_name_data_file(client, long_column_data_file, schema):
-    table_name = 'My Long column name datafile'
-    # response, response_table, table = _create_table(
-    # )
-    expt_name = _get_expected_name(table_name, data_file=long_column_data_file)
-    first_row = (
-        1, 'NATION', '8.6', '4.5', '8.5', '4.3', '8.3', '4.6', '78.6', '2.22',
-        '0.88', '0.66', '1.53', '3.75', '3.26', '0.45', '0.07', '53.9', '52.3',
-        '0.8', '0.38487', '3.15796', '2.3', '33247', '14.842144', '6.172333',
-        '47.158545', '1.698662', '2.345577', '7.882694', '0.145406', '3.395302',
-        '92.085375', '14.447634', '78.873848', '1.738571', '16.161024',
-        '19.436701', '8.145643', '94.937079', '74.115131', '75.601680',
-        '22.073834', '11.791045', '1.585233',
-        '1.016932', '2023-02-01'
-    )
-    column_names = [
-        "State or Nation",
-        "Cycle 1 Total Number of Health Deficiencies",
-        "Cycle 1 Total Number of Fire Safety Deficiencies",
-        "Cycle 2 Total Number of Health Deficiencies",
-        "Cycle 2 Total Number of Fire Safety Deficiencies",
-        "Cycle 3 Total Number of Health Deficiencies",
-        "Cycle 3 Total Number of Fire Safety Deficiencies",
-        "Average Number of Residents per Day",
-        "Reported Nurse Aide Staffing Hours per Resident per Day",
-        "Reported LPN Staffing Hours per Resident per Day",
-        "Reported RN Staffing Hours per Resident per Day",
-        "Reported Licensed Staffing Hours per Resident per Day",
-        "Reported Total Nurse Staffing Hours per Resident per Day",
-        "Total number of nurse staff hours per resident per day on the weekend",
-        "Registered Nurse hours per resident per day on the weekend",
-        "Reported Physical Therapist Staffing Hours per Resident Per Day",
-        "Total nursing staff turnover",
-        "Registered Nurse turnover",
-        "Number of administrators who have left the nursing home",
-        "Case-Mix RN Staffing Hours per Resident per Day",
-        "Case-Mix Total Nurse Staffing Hours per Resident per Day",
-        "Number of Fines",
-        "Fine Amount in Dollars",
-        "Percentage of long stay residents whose need for help with daily activities has increased",
-        "Percentage of long stay residents who lose too much weight",
-        "Percentage of low risk long stay residents who lose control of their bowels or bladder",
-        "Percentage of long stay residents with a catheter inserted and left in their bladder",
-        "Percentage of long stay residents with a urinary tract infection",
-        "Percentage of long stay residents who have depressive symptoms",
-        "Percentage of long stay residents who were physically restrained",
-        "Percentage of long stay residents experiencing one or more falls with major injury",
-        "Percentage of long stay residents assessed and appropriately given the pneumococcal vaccine",
-        "Percentage of long stay residents who received an antipsychotic medication",
-        "Percentage of short stay residents assessed and appropriately given the pneumococcal vaccine",
-        "Percentage of short stay residents who newly received an antipsychotic medication",
-        "Percentage of long stay residents whose ability to move independently worsened",
-        "Percentage of long stay residents who received an antianxiety or hypnotic medication",
-        "Percentage of high risk long stay residents with pressure ulcers",
-        "Percentage of long stay residents assessed and appropriately given the seasonal influenza vaccine",
-        "Percentage of short stay residents who made improvements in function",
-        "Percentage of short stay residents who were assessed and appropriately given the seasonal influenza vaccine",
-        "Percentage of short stay residents who were rehospitalized after a nursing home admission",
-        "Percentage of short stay residents who had an outpatient emergency department visit",
-        "Number of hospitalizations per 1000 long-stay resident days",
-        "Number of outpatient emergency department visits per 1000 long-stay resident days",
-        "Processing Date"
-    ]
-    # Make sure at least some column names require truncation;
-    # 63 is the hard Postgres limit; we're also experiencing problems with ids
-    # as short as 58 characters, but I'll leave this at 63 so that it doesn't
-    # have to be updated once that's fixed.
-    assert any(
-        len(column_name) >= 63
-        for column_name
-        in column_names
-    )
-    processed_column_names = [truncate_if_necessary(col) for col in column_names]
-    table = check_create_table_response(
-        client, table_name, expt_name, long_column_data_file, schema, first_row,
-        processed_column_names, import_target_table=None
-    )
-    # This just makes sure we can get records. This was a bug with long column names.
-    client.get(f'/api/db/v0/tables/{table.id}/records/')
-
-
 def test_create_table_and_normalize_json_data_file(client, missing_keys_json_data_file, schema):
     table_name = 'Missing keys'
-    expt_name = _get_expected_name(table_name, data_file=missing_keys_json_data_file)
+    expt_name = get_expected_name(table_name, data_file=missing_keys_json_data_file)
     first_row = (1, 'Matt', 'Murdock', 'Male', '["Stick", "Foggy"]', '{"street": "210", "city": "NY"}', None)
     column_names = [
         "first_name", "last_name", "gender", "friends", "address", "email"


### PR DESCRIPTION
I had promised way back when to extend our checks for whether long identifiers are supported. What was unchecked specifically is whether we support reflecting and manipulating a table/column with a maximally-long identifier. Finally found the time to do it.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
