### PR TITLE
Disable SQL tests broken by upstream bug

### DIFF
--- a/db/sql/test_0_msar.sql
+++ b/db/sql/test_0_msar.sql
@@ -303,7 +303,6 @@ BEGIN
 END;
 $f$ LANGUAGE plpgsql;
 
-
 CREATE OR REPLACE FUNCTION test_add_columns_interval_precision() RETURNS SETOF TEXT AS $f$
 DECLARE
   col_create_arr jsonb := '[{"type": {"name": "interval", "options": {"precision": 6}}}]';
@@ -314,38 +313,39 @@ END;
 $f$ LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION test_add_columns_interval_fields() RETURNS SETOF TEXT AS $f$
-DECLARE
-  col_create_arr jsonb := '[{"type": {"name": "interval", "options": {"fields": "year"}}}]';
-BEGIN
-  PERFORM msar.add_columns('add_col_testable'::regclass::oid, col_create_arr);
-  RETURN NEXT col_type_is('add_col_testable', 'Column 4', 'interval year');
-END;
-$f$ LANGUAGE plpgsql;
-
-
-CREATE OR REPLACE FUNCTION test_add_columns_interval_fields_prec() RETURNS SETOF TEXT AS $f$
-DECLARE
-  col_create_arr jsonb := $j$
-    [{"type": {"name": "interval", "options": {"fields": "second", "precision": 3}}}]
-  $j$;
-BEGIN
-  PERFORM msar.add_columns('add_col_testable'::regclass::oid, col_create_arr);
-  RETURN NEXT col_type_is('add_col_testable', 'Column 4', 'interval second(3)');
-END;
-$f$ LANGUAGE plpgsql;
-
-
-CREATE OR REPLACE FUNCTION test_add_columns_timestamp_prec() RETURNS SETOF TEXT AS $f$
-DECLARE
-  col_create_arr jsonb := $j$
-    [{"type": {"name": "timestamp", "options": {"precision": 3}}}]
-  $j$;
-BEGIN
-  PERFORM msar.add_columns('add_col_testable'::regclass::oid, col_create_arr);
-  RETURN NEXT col_type_is('add_col_testable', 'Column 4', 'timestamp(3) without time zone');
-END;
-$f$ LANGUAGE plpgsql;
+-- upstream pgTAP bug: https://github.com/theory/pgtap/issues/315
+-- CREATE OR REPLACE FUNCTION test_add_columns_interval_fields() RETURNS SETOF TEXT AS $f$
+-- DECLARE
+--   col_create_arr jsonb := '[{"type": {"name": "interval", "options": {"fields": "year"}}}]';
+-- BEGIN
+--   PERFORM msar.add_columns('add_col_testable'::regclass::oid, col_create_arr);
+--   RETURN NEXT col_type_is('add_col_testable', 'Column 4', 'interval year');
+-- END;
+-- $f$ LANGUAGE plpgsql;
+--
+--
+-- CREATE OR REPLACE FUNCTION test_add_columns_interval_fields_prec() RETURNS SETOF TEXT AS $f$
+-- DECLARE
+--   col_create_arr jsonb := $j$
+--     [{"type": {"name": "interval", "options": {"fields": "second", "precision": 3}}}]
+--   $j$;
+-- BEGIN
+--   PERFORM msar.add_columns('add_col_testable'::regclass::oid, col_create_arr);
+--   RETURN NEXT col_type_is('add_col_testable', 'Column 4', 'interval second(3)');
+-- END;
+-- $f$ LANGUAGE plpgsql;
+--
+--
+-- CREATE OR REPLACE FUNCTION test_add_columns_timestamp_prec() RETURNS SETOF TEXT AS $f$
+-- DECLARE
+--   col_create_arr jsonb := $j$
+--     [{"type": {"name": "timestamp", "options": {"precision": 3}}}]
+--   $j$;
+-- BEGIN
+--   PERFORM msar.add_columns('add_col_testable'::regclass::oid, col_create_arr);
+--   RETURN NEXT col_type_is('add_col_testable', 'Column 4', 'timestamp(3) without time zone');
+-- END;
+-- $f$ LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION test_add_columns_timestamp_raw_default() RETURNS SETOF TEXT AS $f$
@@ -527,14 +527,15 @@ END;
 $f$ LANGUAGE plpgsql;
 
 
-CREATE OR REPLACE FUNCTION test_copy_column_interval_notation() RETURNS SETOF TEXT AS $f$
-BEGIN
-  PERFORM msar.copy_column(
-    'copy_coltest'::regclass::oid, 7::smallint, null, false, false
-  );
-  RETURN NEXT col_type_is('copy_coltest', 'col6 1', 'interval second(3)');
-END;
-$f$ LANGUAGE plpgsql;
+-- upstream pgTAP bug: https://github.com/theory/pgtap/issues/315
+-- CREATE OR REPLACE FUNCTION test_copy_column_interval_notation() RETURNS SETOF TEXT AS $f$
+-- BEGIN
+--   PERFORM msar.copy_column(
+--     'copy_coltest'::regclass::oid, 7::smallint, null, false, false
+--   );
+--   RETURN NEXT col_type_is('copy_coltest', 'col6 1', 'interval second(3)');
+-- END;
+-- $f$ LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION test_copy_column_space_name() RETURNS SETOF TEXT AS $f$


### PR DESCRIPTION
pgTAP 1.3.0 introduced a bug that affects our tests, but not the actual functionality of our SQL logic:
https://github.com/theory/pgtap/issues/315

This PR should be reverted once that bug is sorted. I'll also jump in on the issue in the upstream repo.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
