### PR TITLE
Structures Dockerfile based on operation, and simplifies dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,29 +6,44 @@ ENV NODE_MAJOR 18
 ARG BUILD_PG_MAJOR=15
 ENV PG_MAJOR=$BUILD_PG_MAJOR
 
-# Install dependencies
-RUN apt-get update
-RUN apt-get install -y sudo ca-certificates curl gnupg
-RUN set -eux; \
-	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN set -eux;
 
-# Install PostgreSQL
+#---------- 1. INSTALL SYSTEM DEPENDENCIES -----------------------------------#
+
+RUN mkdir -p /etc/apt/keyrings;
+
+# Add Postgres source
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - ; \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list;
+
+# Add Node.js source
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list;
+
+RUN apt-get update -y;
+
+# Install common dependencies
+RUN apt-get install -y --no-install-recommends sudo ca-certificates curl gnupg gettext nodejs locales;
+
+# Define Locale
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
-RUN set -ex; \
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - ; \
-    echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list; \
-    apt-get update -y; \
-     apt-get install -y --no-install-recommends \
-        postgresql-$PG_MAJOR postgresql-client-$PG_MAJOR postgresql-contrib-$PG_MAJOR \
-    ; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
-    :
+
+# Install Postgres
+RUN apt-get install -y --no-install-recommends \
+    postgresql-$PG_MAJOR postgresql-client-$PG_MAJOR postgresql-contrib-$PG_MAJOR;
+
+RUN apt-get clean; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
+
+
+#---------- 2. CONFIGURE SYSTEM DEPENDENCIES ---------------------------------#
+
+# Postgres
 
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
-
 ENV PGDATA /var/lib/postgresql/mathesar
+
 VOLUME /etc/postgresql/
 VOLUME /var/lib/postgresql/
 
@@ -43,26 +58,17 @@ STOPSIGNAL SIGINT
 
 EXPOSE 5432
 
-# Install dockerize, we still need it when running Postgres using docker-compose
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-# Install Node
-RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update
-RUN apt-get install nodejs -y
+#---------- 3. SETUP MATHESAR ------------------------------------------------#
 
-# Change work directory
 WORKDIR /code/
 
-# Copy all the requirements
 COPY requirements* ./
 RUN pip install --no-cache-dir -r ${PYTHON_REQUIREMENTS} --force-reinstall sqlalchemy-filters
 COPY . .
 
 RUN cd mathesar_ui && npm ci && npm run build
+
 EXPOSE 8000 3000 6006
+
 ENTRYPOINT ["./run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,21 +20,27 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - ; \
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list;
 
-RUN apt-get update -y;
-
 # Install common dependencies
-RUN apt-get install -y --no-install-recommends sudo ca-certificates curl gnupg gettext nodejs locales;
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        sudo \
+        ca-certificates \
+        curl \
+        gnupg \
+        gettext \
+        nodejs \
+        locales \
+    && rm -rf /var/lib/apt/lists/*
 
 # Define Locale
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
 # Install Postgres
-RUN apt-get install -y --no-install-recommends \
-    postgresql-$PG_MAJOR postgresql-client-$PG_MAJOR postgresql-contrib-$PG_MAJOR;
-
-RUN apt-get clean; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*;
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        postgresql-$PG_MAJOR postgresql-client-$PG_MAJOR postgresql-contrib-$PG_MAJOR \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 #---------- 2. CONFIGURE SYSTEM DEPENDENCIES ---------------------------------#

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,6 +22,12 @@ services:
     volumes:
       - dev_postgres_data:/var/lib/postgresql/data
       - ./db/sql:/sql/
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB-mathesar_django} -U $${POSTGRES_USER-mathesar}"]
+      interval: 5s
+      timeout: 1s
+      retries: 30
+      start_period: 5s
   test-service:
     extends:
       file: docker-compose.yml
@@ -52,23 +58,23 @@ services:
       dockerfile: Dockerfile
       args:
         PYTHON_REQUIREMENTS: requirements-dev.txt
-    extends:
-      file: docker-compose.yml
-      service: service
     environment:
       - MODE=${MODE-DEVELOPMENT}
       - DEBUG=${DEBUG-True}
       - DJANGO_ALLOW_ASYNC_UNSAFE=true
-      - DJANGO_SUPERUSER_PASSWORD=password
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE-config.settings.development}
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS-*}
+      - SECRET_KEY=${SECRET_KEY}
       - DJANGO_DATABASE_URL=postgres://mathesar:mathesar@mathesar_dev_db:5432/mathesar_django
       - MATHESAR_DATABASES=(mathesar_tables|postgresql://mathesar:mathesar@mathesar_dev_db:5432/mathesar)
-    entrypoint: dockerize -wait tcp://mathesar_dev_db:5432 -timeout 30s ./dev-run.sh
+      - DJANGO_SUPERUSER_PASSWORD=password
+    entrypoint: ./dev-run.sh
     volumes:
       - .:/code/
       - ui_node_modules:/code/mathesar_ui/node_modules/
     depends_on:
-      - dev-db
+      dev-db:
+        condition: service_healthy
     # On dev, following ports are exposed to other containers, and the host.
     ports:
       - "8000:8000"


### PR DESCRIPTION
Fixes #2973 

**Technical details**
* Dockerfile:
  * Adds structure to our Dockerfile, based on operation performed. Previously:
    * It wasn't clear where to add a new dependency that I wanted installed
  * Removes dockerize.It isn't needed after the changes to the compose file (see next parah)
  * Installs `gettext`, which is required for i18n project
* docker-compose.dev.yml
  * Removes dependency between `dev-service` and `service`, which fixes #2973 
  * Checks healthcheck of db, instead of using dockerize to regularly check if tcp port is open

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `develop` branch of the repository
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
